### PR TITLE
SNOW-24699: added VARIANT, OBJECT and ARRAY datatype support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,11 +4,11 @@
 # Copyright (c) 2012-2016 Snowflake Computing Inc. All right reserved.
 #
 
+from .base import (VARIANT, ARRAY, OBJECT)
+from .util import _url as URL
 from .version import VERSION
 from ..connector.compat import (TO_UNICODE)
 
 SNOWFLAKE_CONNECTOR_VERSION = '.'.join(TO_UNICODE(v) for v in VERSION[0:3])
 
 __version__ = SNOWFLAKE_CONNECTOR_VERSION
-
-from .util import _url as URL

--- a/test/test_semi_structured_datatypes.py
+++ b/test/test_semi_structured_datatypes.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2012-2016 Snowflake Computing Inc. All right reserved.
+#
+
+import json
+import logging
+
+import pytest
+
+for logger_name in ['snowflake.connector', 'botocore']:
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.DEBUG)
+    ch = logging.FileHandler('/tmp/python_connector.log')
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(logging.Formatter(
+        '%(asctime)s - %(threadName)s %(filename)s:%(lineno)d - %(funcName)s() - %(levelname)s - %(message)s'))
+    logger.addHandler(ch)
+
+from parameters import (CONNECTION_PARAMETERS)
+
+from sqlalchemy import inspect
+from sqlalchemy import (Table, Column, Integer, MetaData)
+from sqlalchemy.sql import select
+from snowflake.sqlalchemy import VARIANT, ARRAY, OBJECT
+
+try:
+    from parameters import (CONNECTION_PARAMETERS2)
+except:
+    CONNECTION_PARAMETERS2 = CONNECTION_PARAMETERS
+
+
+def test_create_table_semi_structured_datatypes(engine_testaccount):
+    """
+    Create table including semi-structured data types
+    """
+    metadata = MetaData()
+    table_name = "test_variant0"
+    test_variant = Table(
+        table_name,
+        metadata,
+        Column('id', Integer, primary_key=True),
+        Column('va', VARIANT),
+        Column('ob', OBJECT),
+        Column('ar', ARRAY))
+    metadata.create_all(engine_testaccount)
+    try:
+        assert test_variant is not None
+    finally:
+        test_variant.drop(engine_testaccount)
+
+
+@pytest.mark.skip("""
+Semi-structured data cannot be inserted by INSERT VALUES. Instead,
+INSERT SELECT must be used. The fix should be either 1) SQLAlchemy dialect
+transforms INSERT statement or 2) Snwoflake DB supports INSERT VALUES for
+semi-structured data types. No ETA for this fix.
+""")
+def test_insert_semi_structured_datatypes(engine_testaccount):
+    metadata = MetaData()
+    table_name = "test_variant1"
+    test_variant = Table(
+        table_name,
+        metadata,
+        Column('id', Integer, primary_key=True),
+        Column('va', VARIANT),
+        Column('ob', OBJECT),
+        Column('ar', ARRAY))
+    metadata.create_all(engine_testaccount)
+    try:
+        ins = test_variant.insert().values(
+            id=1,
+            va='{"vk1":100, "vk2":200, "vk3":300}')
+        results = engine_testaccount.execute(ins)
+        results.close()
+    finally:
+        test_variant.drop(engine_testaccount)
+
+
+def test_inspect_semi_structured_datatypes(engine_testaccount):
+    """
+    Inspects semi-structured data type columns
+    """
+    table_name = "test_variant2"
+    metadata = MetaData()
+    test_variant = Table(
+        table_name,
+        metadata,
+        Column('id', Integer, primary_key=True),
+        Column('va', VARIANT),
+        Column('ar', ARRAY))
+    metadata.create_all(engine_testaccount)
+    try:
+        engine_testaccount.execute("""
+INSERT INTO {0}(id, va, ar)
+SELECT 1,
+       PARSE_JSON('{{"vk1":100, "vk2":200, "vk3":300}}'),
+       PARSE_JSON('[
+{{"k":1, "v":"str1"}},
+{{"k":2, "v":"str2"}},
+{{"k":3, "v":"str3"}}]'
+)""".format(table_name))
+        inspecter = inspect(engine_testaccount)
+        columns = inspecter.get_columns(table_name)
+        assert isinstance(columns[1]['type'], VARIANT)
+        assert isinstance(columns[2]['type'], ARRAY)
+
+        conn = engine_testaccount.connect()
+        s = select([test_variant])
+        results = conn.execute(s)
+        rows = results.fetchone()
+        results.close()
+        assert rows[0] == 1
+        data = json.loads(rows[1])
+        assert data['vk1'] == 100
+        assert data['vk3'] == 300
+        assert data is not None
+        data = json.loads(rows[2])
+        assert data[1]['k'] == 2
+    finally:
+        test_variant.drop(engine_testaccount)


### PR DESCRIPTION
Added `VARIANT`, `OBJECT` and `ARRAY` datatype support.
Limitations:
* No Python native datatype conversion is included, but all of the semi-structured datatypes are treated as `str`. The applications must convert it to `json` if needed.
* No DML support either due to lack of standard INSERT syntax support, i.e., INSERT VALUES(). Instead, the applications have to construct a SQL using INSERT SELECT form.

See the test cases for details.