### PR TITLE
map `DATETIME` to `TIMESTAMP(0)`

### DIFF
--- a/base.py
+++ b/base.py
@@ -225,6 +225,13 @@ class SnowflakeTypeCompiler(compiler.GenericTypeCompiler):
     def visit_OBJECT(selfself, type, **kw):
         return "OBJECT"
 
+    def visit_DATETIME(selfself, type, **kw):
+        c = kw['type_expression']
+        if c is not None and c.type.timezone:
+            return "TIMESTAMP_TZ(0)"
+        else:
+            return "TIMESTAMP_NTZ(0)"
+
 
 class SnowflakeDialect(default.DefaultDialect):
     name = 'snowflake'


### PR DESCRIPTION
`DATETIME` isn't supported by snowflake:
```
create table nick (
  test DATETIME
)
```
results in
```
SQL compilation error: Unsupported data type 'TOK_DATETIME'.
```

So map `DATETIME` to `TIMESTAMP_TZ(0)` or `TIMESTAMP_NTZ(0)` (whether the `DateTime` column specifies `timestamp=True` or `timestam=False`)