### PR TITLE
Add get_schema_names

### DIFF
--- a/base.py
+++ b/base.py
@@ -654,6 +654,13 @@ SELECT /* sqlalchemy:get_columns */
 
         return ret
 
+    def get_schema_names(self, connection, **kw):
+        """
+        Gets all schema names.
+        """
+        cursor = connection.execute("SHOW /* sqlalchemy:get_schema_names */ SCHEMAS ")
+
+        return [self.normalize_name(row[1]) for row in cursor]
 
 dialect = SnowflakeDialect
 


### PR DESCRIPTION
This PR adds an implementation for the [`get_schema_names`](http://docs.sqlalchemy.org/en/latest/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_schema_names) method.

Without this implementation, `get_schema_names` returns an empty list. This causes issues in derived applications such as [Superset](https://github.com/apache/incubator-superset).