### PR TITLE
Accept empty password and let Python Connector validate it

### DIFF
--- a/test/test_unit_url.py
+++ b/test/test_unit_url.py
@@ -39,3 +39,18 @@ def test_url():
                password='test') == (
                'snowflake://admin:test@testaccount.eu-central-1'
                '.snowflakecomputing.com:443/?account=testaccount')
+
+    # empty password should be acceptable in URL utility. The validation will
+    # happen in Python connector anyway.
+    assert URL(host='testaccount.eu-central-1.snowflakecomputing.com',
+               user='admin', account='testaccount') == (
+               'snowflake://admin:@testaccount.eu-central-1'
+               '.snowflakecomputing.com:443/?account=testaccount')
+
+    # authenticator=externalbrowser doesn't require a password.
+    assert URL(host='testaccount.eu-central-1.snowflakecomputing.com',
+               user='admin', account='testaccount',
+               authenticator='externalbrowser') == (
+               'snowflake://admin:@testaccount.eu-central-1'
+               '.snowflakecomputing.com:443/?account=testaccount'
+               '&authenticator=externalbrowser')

--- a/util.py
+++ b/util.py
@@ -26,7 +26,7 @@ def _url(**db_parameters):
     if 'host' in db_parameters:
         ret = 'snowflake://{user}:{password}@{host}:{port}/'.format(
             user=db_parameters['user'],
-            password=quote_plus(db_parameters['password']),
+            password=quote_plus(db_parameters.get('password', '')),
             host=db_parameters['host'],
             port=db_parameters['port'] if 'port' in db_parameters else 443,
         )
@@ -35,7 +35,7 @@ def _url(**db_parameters):
         ret = 'snowflake://{user}:{password}@{account}/'.format(
             account=db_parameters['account'],
             user=db_parameters['user'],
-            password=db_parameters['password'],
+            password=db_parameters.get('password', ''),
         )
         specified_parameters += ['user', 'password', 'account']
     if 'database' in db_parameters:


### PR DESCRIPTION
This change defers password empty check to Python Connector so that `externalbrowser` authenticator can be used through SQLAlchemy.