### PR TITLE
Fix #47

### DIFF
--- a/base.py
+++ b/base.py
@@ -158,6 +158,17 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
         """
         return tuple([self.quote(i) for i in ids if i is not None])
 
+    def quote_schema(self, schema, force=None):
+        """
+        Split schema by a dot and merge with required quotes
+        """
+        idents = schema.split('.')
+        return self._denormalize_quote_join(*idents)
+
+    def _denormalize_quote_join(self, *idents):
+        return '.'.join(
+            self._quote_free_identifiers(*idents))
+
 
 class SnowflakeCompiler(compiler.SQLCompiler):
     def visit_sequence(self, sequence):

--- a/test/test_orm.py
+++ b/test/test_orm.py
@@ -201,13 +201,17 @@ def test_orm_query(engine_testaccount):
 def test_schema_including_db(engine_testaccount, db_parameters):
     Base = declarative_base()
 
+    namespace = '{0}.{1}'.format(
+        db_parameters['database'], db_parameters['schema'])
+
     class User(Base):
         __tablename__ = 'users'
         __table_args__ = {
-            'schema': '{0}.{1}'.format(
-                db_parameters['database'], db_parameters['schema'])}
+            'schema': namespace
+        }
 
-        id = Column(Integer, Sequence('user_id_seq'), primary_key=True)
+        id = Column(Integer, Sequence('user_id_orm_seq', schema=namespace),
+                    primary_key=True)
         name = Column(String)
         fullname = Column(String)
 

--- a/test/test_orm.py
+++ b/test/test_orm.py
@@ -229,3 +229,4 @@ def test_schema_including_db(engine_testaccount, db_parameters):
         session.commit()
     finally:
         Base.metadata.drop_all(engine_testaccount)
+

--- a/test/test_unit_core.py
+++ b/test/test_unit_core.py
@@ -77,3 +77,17 @@ def test_create_connect_args():
     for idx, ts in enumerate(test_data):
         _, opts = sfdialect.create_connect_args(ts[0])
         assert opts == ts[1], "Failed: {0}: {1}".format(idx, ts[0])
+
+
+def test_denormalize_quote_join():
+    sfdialect = base.SnowflakeDialect()
+
+    test_data = [
+        (['abc', 'cde'], 'abc.cde'),
+        (['abc.cde', 'def'], 'abc.cde.def'),
+        (['"Abc".cde', 'def'], '"Abc".cde.def'),
+        (['"Abc".cde', '"dEf"'], '"Abc".cde."dEf"'),
+
+    ]
+    for idx, ts in enumerate(test_data):
+        assert sfdialect._denormalize_quote_join(*ts[0]) == ts[1]


### PR DESCRIPTION
Split schema name into db and schema if dot separated, and add quotes to each if required, then reconstruct a full namespace.

Fixed #47 