### PR TITLE
Include SAMPLE in the set of reserved words.

### DIFF
--- a/base.py
+++ b/base.py
@@ -54,6 +54,7 @@ RESERVED_WORDS = frozenset([
     "REVOKE",
     "ROW",
     "ROWS",
+    "SAMPLE",
     "SELECT",
     "SET",
     "START",


### PR DESCRIPTION
As listed in https://docs.snowflake.net/manuals/sql-reference/reserved-keywords.html `SAMPLE` is a reserved keyword and should be quoted, if used as an identifier. It is not that far fetched that people may use the word as the name of a table, such as [here](https://stackoverflow.com/questions/55349047/how-to-fix-snowflake-database-write-error-snowflake-connector-errors-programmin).