### PR TITLE
Move azure blobs to extras_require from setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ The Snowflake SQLAlchemy package can be installed from the public PyPI repositor
 
 :code:`pip` automatically installs all required modules, including the Snowflake Connector for Python.
 
+Azure plugins can be installed using :code:`pip`:
+
+    .. code-block:: bash
+
+        pip install --upgrade snowflake-sqlalchemy[azure]
+
 Verifying Your Installation
 ================================================================================
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,13 @@ setup(
         'sqlalchemy<2.0.0',
         'snowflake-connector-python<2.0.0',
     ],
+    extras_require= dict(
+        azure=[
+        'azure-common<=1.1.20',
+        'azure=storage-blob<=1.5.0',
+        'azure-storage-common<=1.4.0',
+        ]
+    ),
     namespace_packages=[
         'snowflake'
     ],


### PR DESCRIPTION
I'm not using Azure in my environment so this should allow users to install the necessary libraries if they do require it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/snowflakedb/snowflake-sqlalchemy/95)
<!-- Reviewable:end -->
