### PR TITLE
maxfilesize method on CopyInto checks for int type

### DIFF
--- a/base.py
+++ b/base.py
@@ -191,8 +191,9 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         options_list = list(copy_into.copy_options.items())
         if kw.get('deterministic', False):
             options_list.sort(key=operator.itemgetter(0))
-        options = (' ' + ' '.join(["{} = {}".format(n, v._compiler_dispatch(self, **kw)) for n, v in
-                                   options_list])) if copy_into.copy_options else ''
+        options = (' ' + ' '.join(["{} = {}".format(
+            n, v._compiler_dispatch(self, **kw) if getattr(v, 'compiler_dispatch', False) else str(v)
+        ) for n, v in options_list])) if copy_into.copy_options else ''
         if credentials:
             options += " {}".format(credentials)
         if encryption:

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -116,9 +116,9 @@ class CopyInto(UpdateBase):
         self.copy_options.update({'SINGLE': translate_bool(single_file)})
 
     def maxfilesize(self, max_size):
-        if not isinstance(max_size, bool):
-            raise TypeError("Parameter max_size should  be a boolean value")
-        self.copy_options.update({'MAX_FILE_SIZE': translate_bool(max_size)})
+        if not isinstance(max_size, int):
+            raise TypeError("Parameter max_size should be an integer value")
+        self.copy_options.update({'MAX_FILE_SIZE': max_size})
 
 
 class CopyFormatter(ClauseElement):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -953,6 +953,11 @@ def test_copy_into_location(engine_testaccount, sql_compiler):
     assert (sql_compiler(copy_stmt_3) == "COPY INTO 'azure://snowflake.blob.core.windows.net/snowpile/backup' "
                                          "FROM python_tests_foods FILE_FORMAT=(TYPE=parquet SNAPPY_COMPRESSION=true) "
                                          "CREDENTIALS=(AZURE_SAS_TOKEN='token')")
+    copy_stmt_3.maxfilesize(50000000)
+    assert (sql_compiler(copy_stmt_3) == "COPY INTO 'azure://snowflake.blob.core.windows.net/snowpile/backup' "
+                                         "FROM python_tests_foods FILE_FORMAT=(TYPE=parquet SNAPPY_COMPRESSION=true) "
+                                         "MAX_FILE_SIZE = 50000000 "
+                                         "CREDENTIALS=(AZURE_SAS_TOKEN='token')")
     # NOTE Other than expect known compiled text, submit it to RegressionTests environment and expect them to fail, but
     # because of the right reasons
     try:


### PR DESCRIPTION
This PR should address the [issue I encountered](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/99) with MAX_FILE_SIZE. The changes can be summed up as follows:

- `maxfilesize` will check for `int` type and raise the type error with an appropriate message if the provided arg is not an int
- in `visit_copy_into`, for the `copy_options`, `_compiler_dispatch` is only called if the value has the method as an attribute; otherwise, str is called.
  - the pattern for this was taken from the method `visit_copy_formatter` below `visit_copy_into`, for consistency, though a helper method to perform this logic could be a useful pattern as well

- updates to the test `test_copy_into_location` to ensure that the MAX_FILE_SIZE can be set properly via `maxfilesize` and that the statement will compile correctly.