### PR TITLE
CopyInto successfully compiles statement for storage to table

### DIFF
--- a/base.py
+++ b/base.py
@@ -179,7 +179,8 @@ class SnowflakeCompiler(compiler.SQLCompiler):
 
     def visit_copy_into(self, copy_into, **kw):
         formatter = copy_into.formatter._compiler_dispatch(self, **kw)
-        into = copy_into.into._compiler_dispatch(self, **kw)
+        into = (copy_into.into if isinstance(copy_into.into, Table)
+                else copy_into.into._compiler_dispatch(self, **kw))
         from_ = None
         if isinstance(copy_into.from_, Table):
             from_ = copy_into.from_

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -953,6 +953,13 @@ def test_copy_into_location(engine_testaccount, sql_compiler):
     assert (sql_compiler(copy_stmt_3) == "COPY INTO 'azure://snowflake.blob.core.windows.net/snowpile/backup' "
                                          "FROM python_tests_foods FILE_FORMAT=(TYPE=parquet SNAPPY_COMPRESSION=true) "
                                          "CREDENTIALS=(AZURE_SAS_TOKEN='token')")
+    copy_stmt_4 = CopyIntoStorage(from_=AWSBucket.from_uri('s3://backup').encryption_aws_sse_kms(
+                                        '1234abcd-12ab-34cd-56ef-1234567890ab'),
+                                  into=food_items,
+                                  formatter=CSVFormatter().record_delimiter('|').escape(None).null_if(['null', 'Null']))
+    assert (sql_compiler(copy_stmt_4) == "COPY INTO python_tests_foods FROM 's3://backup' FILE_FORMAT=(TYPE=csv "
+                                         "ESCAPE=None NULL_IF=('null', 'Null') RECORD_DELIMITER='|') ENCRYPTION="
+                                         "(KMS_KEY_ID='1234abcd-12ab-34cd-56ef-1234567890ab' TYPE='AWS_SSE_KMS')")
     # NOTE Other than expect known compiled text, submit it to RegressionTests environment and expect them to fail, but
     # because of the right reasons
     try:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -966,7 +966,7 @@ def test_copy_into_location(engine_testaccount, sql_compiler):
         acceptable_exc_reasons = {'Failure using stage area',
                                   'AWS_ROLE credentials are not allowed for this account.',
                                   'AWS_ROLE credentials are invalid'}
-        for stmnt in (copy_stmt_1, copy_stmt_2, copy_stmt_3):
+        for stmnt in (copy_stmt_1, copy_stmt_2, copy_stmt_3, copy_stmt_4):
             with pytest.raises(Exception) as exc:
                 conn.execute(stmnt)
             if not any(map(lambda reason: reason in str(exc) or reason in str(exc.value), acceptable_exc_reasons)):


### PR DESCRIPTION
This PR should address the [issue I had with CopyInto](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/97) for compiling statements where we `COPY INTO` a table *from* storage. The changes can be summarized as follows:
- Changed some of the setup logic in `visit_copy_into` in the `SnowflakeCompiler` so we can leave from_ alone if it is a table, call _compiler_dispatch if it is an AWSBucket or an AzureContainer, or format _compiler_dispatch into ‘({})’ if the argument is some other type (such as a SQLAlchemy select)
    - This logical change could potentially be abstracted out into a helper method to be reused wherever a similar check is done
- Added a case to the `test_copy_into_location` test for the case of having from_ as an AWSBucket and into_ as a table
