### PR TITLE
Update get_columns to perform its own information schema query specific to a table

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -402,7 +402,6 @@ class SnowflakeDialect(default.DefaultDialect):
             connection, full_schema_name, **kw
         )
 
-        columns = []
         table_name = self.denormalize_name(table_name)
         current_table_pks = schema_primary_keys.get(table_name)
 

--- a/snowdialect.py
+++ b/snowdialect.py
@@ -391,12 +391,16 @@ class SnowflakeDialect(default.DefaultDialect):
         Gets all column info given the table info
         """
         schema = schema or self.default_schema_name
-        current_database, current_schema = self._current_database_schema(connection, **kw)
+        current_database, current_schema = self._current_database_schema(
+            connection, **kw
+        )
         if not schema:
             schema = current_schema
 
         full_schema_name = self._denormalize_quote_join(current_database, schema)
-        schema_primary_keys = self._get_schema_primary_keys(connection, full_schema_name, **kw)
+        schema_primary_keys = self._get_schema_primary_keys(
+            connection, full_schema_name, **kw
+        )
 
         columns = []
         table_name = self.denormalize_name(table_name)
@@ -419,21 +423,27 @@ class SnowflakeDialect(default.DefaultDialect):
                 AND ic.table_name=%(table_name)s
         """
 
-        print('Trying to run this SQL', SQL_COLS)
-
-        result = connection.execute(SQL_COLS, {"table_schema": self.denormalize_name(schema), "table_name": self.denormalize_name(table_name)})
+        result = connection.execute(
+            SQL_COLS,
+            {
+                "table_schema": self.denormalize_name(schema),
+                "table_name": self.denormalize_name(table_name),
+            },
+        )
 
         columns = []
 
-        for (column_name,
-             coltype,
-             character_maximum_length,
-             numeric_precision,
-             numeric_scale,
-             is_nullable,
-             column_default,
-             is_identity,
-             comment) in result:
+        for (
+            column_name,
+            coltype,
+            character_maximum_length,
+            numeric_precision,
+            numeric_scale,
+            is_nullable,
+            column_default,
+            is_identity,
+            comment,
+        ) in result:
 
             column_name = self.normalize_name(column_name)
             if column_name.startswith('sys_clustering_column'):
@@ -445,7 +455,9 @@ class SnowflakeDialect(default.DefaultDialect):
             if col_type is None:
                 sa_util.warn(
                     "Did not recognize type '{}' of column '{}'".format(
-                        coltype, column_name))
+                        coltype, column_name
+                    )
+                )
                 col_type = sqltypes.NULLTYPE
 
             else:
@@ -455,8 +467,7 @@ class SnowflakeDialect(default.DefaultDialect):
                 elif issubclass(col_type, sqltypes.Numeric):
                     col_type_kw['precision'] = numeric_precision
                     col_type_kw['scale'] = numeric_scale
-                elif issubclass(col_type,
-                                (sqltypes.String, sqltypes.BINARY)):
+                elif issubclass(col_type, (sqltypes.String, sqltypes.BINARY)):
                     col_type_kw['length'] = character_maximum_length
 
             type_instance = col_type(**col_type_kw)
@@ -469,7 +480,12 @@ class SnowflakeDialect(default.DefaultDialect):
                     'default': column_default,
                     'autoincrement': is_identity == 'YES',
                     'comment': comment,
-                    'primary_key': (column_name in schema_primary_keys[table_name]['constrained_columns']) if current_table_pks else False,
+                    'primary_key': (
+                        column_name
+                        in schema_primary_keys[table_name]['constrained_columns']
+                    )
+                    if current_table_pks
+                    else False,
                 }
             )
 


### PR DESCRIPTION
The current implementation of the dialect's method `get_columns` reuses `_get_schema_columns` which runs a query for all columns against the current schema. This sometimes leads to errors, especially in schemas that have a large number of tables. I am currently observing intermittent errors  in my organization's schema containing over 700 tables.

The actual error is reported on snowflake's knowledge base:

https://community.snowflake.com/s/article/error-information-schema-query-returned-too-much-data-please-repeat-query-with-more-selective-predicates-when-querying-information-schema-view

A specific instance of this error appears as such:
```
snowflake.connector.errors.ProgrammingError: 090030 (22000): 0190d231-0117-469e-0000-18c980bbfd9a: Information schema query returned too much data.  Please repeat query with more selective predicates.
```

The solution implemented here is to enable this method to perform its own query specific to a single table instead of against all possible tables in the schema to retrieve column information while following all the same steps as the original `_get_schema_columns` so that column and type information is extracted correctly.

This issue was discovered when attempting to reflect the tables in this schema using techniques and approaches described here: https://docs.sqlalchemy.org/en/13/core/reflection.html#reflecting-database-objects

Direction/ Help Wanted:
* I'm not sure what the decorator @reflection.cache does. If this is important to decorate on functions that actually run information schema queries, I can add it to this fn as it now executes its own query.