### PR TITLE
Add `driver` property to SnowflakeDialect

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -71,6 +71,7 @@ ischema_names = {
 
 class SnowflakeDialect(default.DefaultDialect):
     name = 'snowflake'
+    driver = 'snowflake'
     max_identifier_length = 65535
     cte_follows_insert = True
 


### PR DESCRIPTION
This PR fixes #139. 

SQLAlchemy [defined `Dialects`](https://docs.sqlalchemy.org/en/13/core/internals.html#sqlalchemy.engine.interfaces.Dialect) with a `driver` property. I wasn't sure what to name it. Since this is the official (and likely only implementation) for snowflake connections, I went with `snowflake`, but it could also be `default` or something. I'd be happy to change it if desired.