### PR TITLE
Fix typo in README Connection Parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ You can optionally specify the initial database and schema for the Snowflake ses
 
     .. code-block:: python
 
-        'snowflake://<user_login_name>:<password>@<account_name>/<database_name>/<schema_name>?warehouse=<warehouse_name>?role=<role_name>'
+        'snowflake://<user_login_name>:<password>@<account_name>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>'
 
 .. note::
 


### PR DESCRIPTION
I tried to connect to snowflake using flask-sqlalchemy (that uses alembic) db setup, and the connection string that worked for me was the one corrected here. I think seeing how connection parameters are usually defined in URLs, this felt more like a typo in the official docs.