### PR TITLE
Correctly handle spaces in connection string passwords

### DIFF
--- a/test/test_unit_url.py
+++ b/test/test_unit_url.py
@@ -16,6 +16,9 @@ def test_url():
                password='test') == "snowflake://admin:test@testaccount/"
 
     assert URL(account='testaccount', user='admin',
+               password='test test') == "snowflake://admin:test%20test@testaccount/"
+
+    assert URL(account='testaccount', user='admin',
                password='test', database='testdb') == \
            "snowflake://admin:test@testaccount/testdb"
 

--- a/test/test_unit_url.py
+++ b/test/test_unit_url.py
@@ -16,6 +16,10 @@ def test_url():
                password='test') == "snowflake://admin:test@testaccount/"
 
     assert URL(account='testaccount', user='admin',
+               password='1-pass 2-pass 3-: 4-@ 5-/ 6-pass') == \
+           "snowflake://admin:1-pass 2-pass 3-%3A 4-%40 5-%2F 6-pass@testaccount/"
+
+    assert URL(account='testaccount', user='admin',
                password='test', database='testdb') == \
            "snowflake://admin:test@testaccount/testdb"
 

--- a/test/test_unit_url.py
+++ b/test/test_unit_url.py
@@ -16,9 +16,6 @@ def test_url():
                password='test') == "snowflake://admin:test@testaccount/"
 
     assert URL(account='testaccount', user='admin',
-               password='test test') == "snowflake://admin:test%20test@testaccount/"
-
-    assert URL(account='testaccount', user='admin',
                password='test', database='testdb') == \
            "snowflake://admin:test@testaccount/testdb"
 

--- a/util.py
+++ b/util.py
@@ -9,9 +9,9 @@ from sqlalchemy import exc
 from snowflake.connector.compat import (PY2, IS_STR)
 
 if PY2:
-    from urllib import quote
+    from urllib import quote_plus
 else:
-    from urllib.parse import quote
+    from urllib.parse import quote_plus
 
 
 def _url(**db_parameters):
@@ -26,7 +26,7 @@ def _url(**db_parameters):
     if 'host' in db_parameters:
         ret = 'snowflake://{user}:{password}@{host}:{port}/'.format(
             user=db_parameters.get('user', ''),
-            password=quote(db_parameters.get('password', ''), safe=''),
+            password=quote_plus(db_parameters.get('password', '')),
             host=db_parameters['host'],
             port=db_parameters['port'] if 'port' in db_parameters else 443,
         )
@@ -35,23 +35,23 @@ def _url(**db_parameters):
         ret = 'snowflake://{user}:{password}@{account}/'.format(
             account=db_parameters['account'],
             user=db_parameters.get('user', ''),
-            password=quote(db_parameters.get('password', ''), safe=''),
+            password=quote_plus(db_parameters.get('password', '')),
         )
         specified_parameters += ['user', 'password', 'account']
     else:
         ret = 'snowflake://{user}:{password}@{account}.{region}/'.format(
             account=db_parameters['account'],
             user=db_parameters.get('user', ''),
-            password=quote(db_parameters.get('password', ''), safe=''),
+            password=quote_plus(db_parameters.get('password', '')),
             region=db_parameters['region'],
         )
         specified_parameters += ['user', 'password', 'account', 'region']
 
     if 'database' in db_parameters:
-        ret += quote(db_parameters['database'], safe='')
+        ret += quote_plus(db_parameters['database'])
         specified_parameters += ['database']
         if 'schema' in db_parameters:
-            ret += '/' + quote(db_parameters['schema'], safe='')
+            ret += '/' + quote_plus(db_parameters['schema'])
             specified_parameters += ['schema']
     elif 'schema' in db_parameters:
         raise exc.ArgumentError("schema cannot be specified without database")
@@ -63,7 +63,7 @@ def _url(**db_parameters):
     for p in sorted(db_parameters.keys()):
         v = db_parameters[p]
         if p not in specified_parameters:
-            encoded_value = quote(v, safe='') if IS_STR(v) else str(v)
+            encoded_value = quote_plus(v) if IS_STR(v) else str(v)
             ret += sep(is_first_parameter) + p + '=' + encoded_value
             is_first_parameter = False
     return ret

--- a/util.py
+++ b/util.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
 #
 
+import re
+
 from sqlalchemy import exc
 
 from snowflake.connector.compat import (PY2, IS_STR)
@@ -26,7 +28,7 @@ def _url(**db_parameters):
     if 'host' in db_parameters:
         ret = 'snowflake://{user}:{password}@{host}:{port}/'.format(
             user=db_parameters.get('user', ''),
-            password=quote_plus(db_parameters.get('password', '')),
+            password=_rfc_1738_quote(db_parameters.get('password', '')),
             host=db_parameters['host'],
             port=db_parameters['port'] if 'port' in db_parameters else 443,
         )
@@ -35,14 +37,14 @@ def _url(**db_parameters):
         ret = 'snowflake://{user}:{password}@{account}/'.format(
             account=db_parameters['account'],
             user=db_parameters.get('user', ''),
-            password=quote_plus(db_parameters.get('password', '')),
+            password=_rfc_1738_quote(db_parameters.get('password', '')),
         )
         specified_parameters += ['user', 'password', 'account']
     else:
         ret = 'snowflake://{user}:{password}@{account}.{region}/'.format(
             account=db_parameters['account'],
             user=db_parameters.get('user', ''),
-            password=quote_plus(db_parameters.get('password', '')),
+            password=_rfc_1738_quote(db_parameters.get('password', '')),
             region=db_parameters['region'],
         )
         specified_parameters += ['user', 'password', 'account', 'region']
@@ -67,3 +69,7 @@ def _url(**db_parameters):
             ret += sep(is_first_parameter) + p + '=' + encoded_value
             is_first_parameter = False
     return ret
+
+
+def _rfc_1738_quote(text):
+    return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)

--- a/util.py
+++ b/util.py
@@ -9,9 +9,9 @@ from sqlalchemy import exc
 from snowflake.connector.compat import (PY2, IS_STR)
 
 if PY2:
-    from urllib import quote_plus
+    from urllib import quote
 else:
-    from urllib.parse import quote_plus
+    from urllib.parse import quote
 
 
 def _url(**db_parameters):
@@ -26,7 +26,7 @@ def _url(**db_parameters):
     if 'host' in db_parameters:
         ret = 'snowflake://{user}:{password}@{host}:{port}/'.format(
             user=db_parameters.get('user', ''),
-            password=quote_plus(db_parameters.get('password', '')),
+            password=quote(db_parameters.get('password', ''), safe=''),
             host=db_parameters['host'],
             port=db_parameters['port'] if 'port' in db_parameters else 443,
         )
@@ -35,23 +35,23 @@ def _url(**db_parameters):
         ret = 'snowflake://{user}:{password}@{account}/'.format(
             account=db_parameters['account'],
             user=db_parameters.get('user', ''),
-            password=quote_plus(db_parameters.get('password', '')),
+            password=quote(db_parameters.get('password', ''), safe=''),
         )
         specified_parameters += ['user', 'password', 'account']
     else:
         ret = 'snowflake://{user}:{password}@{account}.{region}/'.format(
             account=db_parameters['account'],
             user=db_parameters.get('user', ''),
-            password=quote_plus(db_parameters.get('password', '')),
+            password=quote(db_parameters.get('password', ''), safe=''),
             region=db_parameters['region'],
         )
         specified_parameters += ['user', 'password', 'account', 'region']
 
     if 'database' in db_parameters:
-        ret += quote_plus(db_parameters['database'])
+        ret += quote(db_parameters['database'], safe='')
         specified_parameters += ['database']
         if 'schema' in db_parameters:
-            ret += '/' + quote_plus(db_parameters['schema'])
+            ret += '/' + quote(db_parameters['schema'], safe='')
             specified_parameters += ['schema']
     elif 'schema' in db_parameters:
         raise exc.ArgumentError("schema cannot be specified without database")
@@ -63,7 +63,7 @@ def _url(**db_parameters):
     for p in sorted(db_parameters.keys()):
         v = db_parameters[p]
         if p not in specified_parameters:
-            encoded_value = quote_plus(v) if IS_STR(v) else str(v)
+            encoded_value = quote(v, safe='') if IS_STR(v) else str(v)
             ret += sep(is_first_parameter) + p + '=' + encoded_value
             is_first_parameter = False
     return ret


### PR DESCRIPTION
`snowflake.sqlalchemy.URL` currently calls `quote_plus` to `quote` passwords for the connection string, but this approach incorrectly handles spaces in passwords. Calling `quote` instead properly percent-encodes spaces.