### PR TITLE
Allow get_table_comment to fetch view comments too

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -607,14 +607,14 @@ class SnowflakeDialect(default.DefaultDialect):
         """
         try:
             comment = self._get_table_comment()
-            if comment is None:
+            if comment is None or comment == "":
                 # the "table" being reflected is actually a view
                 comment = self._get_view_comment()
         except (KeyError, TypeError):
             # Also, we should not throw an error here just because we could not
             # fetch the *comment* field
             comment = None
-        return {'text': comment}
+        return {'text': comment if comment else None}
 
 
 @sa_vnt.listens_for(Table, 'before_create')

--- a/snowdialect.py
+++ b/snowdialect.py
@@ -607,7 +607,7 @@ class SnowflakeDialect(default.DefaultDialect):
         """
         try:
             comment = self._get_table_comment()
-            if comment is None or comment == "":
+            if comment is None:
                 # the "table" being reflected is actually a view
                 comment = self._get_view_comment()
         except (KeyError, TypeError):

--- a/snowdialect.py
+++ b/snowdialect.py
@@ -576,7 +576,7 @@ class SnowflakeDialect(default.DefaultDialect):
         """
         Returns comment of table in a dictionary as described by SQLAlchemy spec.
         """
-        sql_command = "SHOW /* sqlalchemy:get_table_comment */ " \
+        sql_command = "SHOW /* sqlalchemy:_get_table_comment */ " \
                       "TABLES LIKE '{0}'{1}".format(
                                         table_name,
                                         (' IN SCHEMA {0}'.format(self.normalize_name(schema))) if schema else ''
@@ -589,7 +589,7 @@ class SnowflakeDialect(default.DefaultDialect):
         """
         Returns comment of view in a dictionary as described by SQLAlchemy spec.
         """
-        sql_command = "SHOW /* sqlalchemy:get_view_comment */ " \
+        sql_command = "SHOW /* sqlalchemy:_get_view_comment */ " \
             "VIEWS LIKE '{0}'{1}".format(
                 table_name,
                 (' IN SCHEMA {0}'.format(self.normalize_name(schema))) if schema else ''
@@ -601,10 +601,10 @@ class SnowflakeDialect(default.DefaultDialect):
     def get_table_comment(self, connection, table_name, schema=None, **kw):
         """
         Returns comment associated with a table (or view) in a dictionary as
-        SQLAlchemy expects.
+        SQLAlchemy expects. Note that since SQLAlchemy may not (in fact,
+        typically does not) know if this is a table or a view, we have to
+        handle both cases here.
         """
-        # NOTE: Since SQLAlchemy may not (in fact, typically does not) know if
-        # this is a table or a view, we have to handle both cases here.
         try:
             comment = self._get_table_comment()
             if comment is None:

--- a/snowdialect.py
+++ b/snowdialect.py
@@ -596,8 +596,8 @@ class SnowflakeDialect(default.DefaultDialect):
 
         # Also, we should not throw an error here just because we could not
         # fetch the *comment* field
-        comment = ans.get('comment', None) if ans else None
-        return {'text': comment if comment else None}
+        comment = ans['comment'] if (ans and ans['comment']) else None
+        return {'text': comment}
 
 
 @sa_vnt.listens_for(Table, 'before_create')

--- a/snowdialect.py
+++ b/snowdialect.py
@@ -582,8 +582,7 @@ class SnowflakeDialect(default.DefaultDialect):
                                         (' IN SCHEMA {0}'.format(self.normalize_name(schema))) if schema else ''
                                     )
         cursor = connection.execute(sql_command)
-        result = cursor.fetchone()
-        return result['comment']
+        return cursor.fetchone()
 
     def _get_view_comment(self, connection, table_name, schema=None, **kw):
         """
@@ -595,8 +594,7 @@ class SnowflakeDialect(default.DefaultDialect):
                 (' IN SCHEMA {0}'.format(self.normalize_name(schema))) if schema else ''
             )
         cursor = connection.execute(sql_command)
-        result = cursor.fetchone()
-        return result['comment']
+        return cursor.fetchone()
 
     def get_table_comment(self, connection, table_name, schema=None, **kw):
         """
@@ -605,16 +603,12 @@ class SnowflakeDialect(default.DefaultDialect):
         typically does not) know if this is a table or a view, we have to
         handle both cases here.
         """
-        try:
-            comment = self._get_table_comment()
-            if comment is None:
-                # the "table" being reflected is actually a view
-                comment = self._get_view_comment()
-        except (KeyError, TypeError):
-            # Also, we should not throw an error here just because we could not
-            # fetch the *comment* field
-            comment = None
-        return {'text': comment if comment else None}
+        result = self._get_table_comment()
+        if result is None:
+            # the "table" being reflected is actually a view
+            result = self._get_view_comment()
+
+        return {'text': result['comment'] if result and result['comment'] else None}
 
 
 @sa_vnt.listens_for(Table, 'before_create')

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -546,10 +546,10 @@ SELECT * FROM {1} WHERE id > 10""".format(
                sql.strip()
         assert inspector.get_view_names() == [test_view_name]
     finally:
-        engine_testaccount.execute(
-            "DROP TABLE IF EXISTS {0}".format(test_table_name))
-        engine_testaccount.execute(
-            "DROP VIEW IF EXISTS {0}".format(test_view_name))
+        engine_testaccount.execute(text(
+            "DROP TABLE IF EXISTS {0}".format(test_table_name)))
+        engine_testaccount.execute(text(
+            "DROP VIEW IF EXISTS {0}".format(test_view_name)))
 
 
 def test_view_comment_reading(engine_testaccount, db_parameters):
@@ -581,10 +581,10 @@ SELECT * FROM {1} WHERE id > 10""".format(
         # but the code to get table comments should work for views too
         assert inspector.get_table_comment(test_view_name) == {'text': comment_text}
     finally:
-        engine_testaccount.execute(
-            "DROP TABLE IF EXISTS {0}".format(test_table_name))
-        engine_testaccount.execute(
-            "DROP VIEW IF EXISTS {0}".format(test_view_name))
+        engine_testaccount.execute(text(
+            "DROP TABLE IF EXISTS {0}".format(test_table_name)))
+        engine_testaccount.execute(text(
+            "DROP VIEW IF EXISTS {0}".format(test_view_name)))
 
 
 


### PR DESCRIPTION
Since SQLAlchemy recommends that views be reflected in the same ways as tables (see https://docs.sqlalchemy.org/en/13/core/reflection.html#reflecting-views), allow the `get_table_comment` method to return metadata for views too.