### PR TITLE
Adds ExternalStage

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@
 from . import base
 from . import snowdialect
 from .custom_commands import (
-    MergeInto, CSVFormatter, JSONFormatter, PARQUETFormatter, CopyIntoStorage, AWSBucket, AzureContainer
+    MergeInto, CSVFormatter, JSONFormatter, PARQUETFormatter, CopyIntoStorage, AWSBucket, AzureContainer, ExternalStage
 )
 from .util import _url as URL
 from .version import VERSION
@@ -96,4 +96,5 @@ __all__ = (
     'CopyIntoStorage',
     'AWSBucket',
     'AzureContainer'
+    'ExternalStage',
 )

--- a/base.py
+++ b/base.py
@@ -224,6 +224,9 @@ class SnowflakeCompiler(compiler.SQLCompiler):
                                                         value))
                                                     for name, value in options_list])) if formatter.options else "")
 
+    def visit_external_stage(self, stage, **kw):
+        return "@{}{}{}".format(stage.namespace, stage.name, stage.path)
+
     def visit_aws_bucket(self, aws_bucket, **kw):
         credentials_list = list(aws_bucket.credentials_used.items())
         if kw.get('deterministic', False):

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -289,6 +289,19 @@ class PARQUETFormatter(CopyFormatter):
         return self
 
 
+class ExternalStage(ClauseElement):
+    """External Stage descriptor"""
+    __visit_name__ = "external_stage"
+
+    def __init__(self, name, path='', namespace=''):
+        self.name = name
+        self.path = '/{}'.format(path) if path and not path.startswith('/') else path
+        self.namespace = '{}.' if namespace and not namespace.endswith('.') else namespace
+
+    def __repr__(self):
+        return "@{}{}{}".format(self.namespace, self.name, self.path)
+
+
 class AWSBucket(ClauseElement):
     """AWS S3 bucket descriptor"""
     __visit_name__ = 'aws_bucket'

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -293,10 +293,18 @@ class ExternalStage(ClauseElement):
     """External Stage descriptor"""
     __visit_name__ = "external_stage"
 
-    def __init__(self, name, path='', namespace=''):
+    @staticmethod
+    def prepare_namespace(namespace):
+        return "{}.".format(namespace) if not namespace.endswith(".") else namespace
+
+    @staticmethod
+    def prepare_path(path):
+        return "/{}".format(path) if not namespace.startswith("/") else path
+
+    def __init__(self, name, path=None, namespace=None):
         self.name = name
-        self.path = '/{}'.format(path) if path and not path.startswith('/') else path
-        self.namespace = '{}.' if namespace and not namespace.endswith('.') else namespace
+        self.path = self.prepare_path(path) if path else ""
+        self.namespace = self.prepare_namespace(namespace) if namespace else ""
 
     def __repr__(self):
         return "@{}{}{}".format(self.namespace, self.name, self.path)

--- a/custom_commands.py
+++ b/custom_commands.py
@@ -299,7 +299,7 @@ class ExternalStage(ClauseElement):
 
     @staticmethod
     def prepare_path(path):
-        return "/{}".format(path) if not namespace.startswith("/") else path
+        return "/{}".format(path) if not path.startswith("/") else path
 
     def __init__(self, name, path=None, namespace=None):
         self.name = name

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -17,6 +17,19 @@ from sqlalchemy import Column, Integer, MetaData, Sequence, String, Table
 from sqlalchemy.sql import select
 
 
+def test_external_stage():
+    assert ExternalStage.prepare_namespace("something") == "something."
+    assert ExternalStage.prepare_path("prefix") == "/prefix"
+
+    # All arguments are handled
+    assert (
+        str(ExternalStage(name="name", path="prefix/path", namespace="namespace") == "@namespace.name/prefix/path"
+    )
+
+    # defaults don't ruin things
+    assert str(ExternalStage(name="name", path=None, namespace=None)) == "@name"
+
+
 def test_copy_into_location(engine_testaccount, sql_compiler):
     meta = MetaData()
     conn = engine_testaccount.connect()


### PR DESCRIPTION
I'm trying to use the very helpful `CopyIntoStorage` custom command to copy results into an S3 bucket using an IAM role (can confirm the the assume role policy from snowflake to our account is correctly setup on this role).

Something as simple as:

```python
from snowflake.sqlalchemy import AWSBucket, CopyIntoStorage, CSVFormatter

bucket = AWSBucket.from_uri("s3://bucket").credentials(aws_role="arn:.....role/role_name")
copy_into = CopyIntoStorage(from_=statement, into=bucket, formatter=CSVFormatter())
with engine.connect() as connection:
    connection.execute(copy_into)
```

Cannot work because [the docs](https://docs.snowflake.net/manuals/sql-reference/sql/copy-into-location.html#additional-cloud-provider-parameters) state this nugget:

> Using an IAM role for credentials requires a named external stage. Accessing an S3 bucket URL directly in a COPY statement is not supported.

Therefore, I've added an `ExternalStage` class that compiles to `@[namespace.]stage_name[/path]`

This, locally (more on that later) works just fine for me:

```python
formatter = CSVFormatter().compression('gzip').field_delimiter('|')
stage = ExternalStage(name="stage_name", path="prefix/file")
copy_into = CopyIntoStorage(from_=s, into=stage, formatter=formatter)
with engine.connect() as connection:
    connection.execute(copy_into)
```

I have added a few statements to test in `tests/test_copy.py` but the parameters provided in `tests/README.rst` don't work and I just get a ton of connection failures. Is this supposed to happen?
