### PR TITLE
Single quotes for the COLLATE statement

### DIFF
--- a/base.py
+++ b/base.py
@@ -436,6 +436,14 @@ class SnowflakeTypeCompiler(compiler.GenericTypeCompiler):
     def visit_TIMESTAMP(self, type_, **kw):
         return "TIMESTAMP"
 
+    def _render_string_type(self, type_, name):
+
+        text = name
+        if type_.length:
+            text += "(%d)" % type_.length
+        if type_.collation:
+            text += ' COLLATE \'%s\'' % type_.collation
+        return text
 
 construct_arguments = [
     (Table, {


### PR DESCRIPTION
As we can see in the [snowflake docs](https://docs.snowflake.com/en/sql-reference/functions/collate.html#syntaxl) the COLLATE statement requires single quotes for the collation specification.
In case of running CREATE TABLE script with double quotes in the Snowflake Console it returns the result like `SQL compilation error: syntax error line 3 at position 24 unexpected '"SQL_Latin1_General_CP1_CI_AS"'.`

After this PR `sqlalchemy.schema.CreateTable(some_table).compile` with `dialect=snowflake.sqlalchemy.snowdialect.dialect()` will return i.e. `name NCHAR(10) COLLATE 'SQL_Latin1_General_CP1_CI_AS'` instead of `name NCHAR(10) COLLATE "SQL_Latin1_General_CP1_CI_AS"`

This PR just overriding [_render_string_type](https://github.com/sqlalchemy/sqlalchemy/blob/67a2afbed5e820e2919f699d4f7d852288ffe2d8/lib/sqlalchemy/sql/compiler.py#L4254) method from SQLAlchemy GenericTypeCompiler class for Snowflake SQLAlchemy dialect.

Tested with Python 3.8.2

