### PR TITLE
Add extra line on account name in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,8 +101,10 @@ Where:
 
 - :code:`<user_login_name>` is the login name for your Snowflake user.
 - :code:`<password>` is the password for your Snowflake user.
-- :code:`<account_name>` is the name of your Snowflake account (region included if applicable, more info `Python
-<https://docs.snowflake.com/en/user-guide/connecting.html#your-snowflake-account-name>`_.).
+- :code:`<account_name>` is the name of your Snowflake account 
+
+Include the region in the `<account_name>` if applicable, more info `here
+<https://docs.snowflake.com/en/user-guide/connecting.html#your-snowflake-account-name>`_.
 
 You can optionally specify the initial database and schema for the Snowflake session by including them at the end of the connection string, separated by :code:`/`. You can also specify the initial warehouse and role for the session as a parameter string at the end of the connection string:
 

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Where:
 
 - :code:`<user_login_name>` is the login name for your Snowflake user.
 - :code:`<password>` is the password for your Snowflake user.
-- :code:`<account_name>` is the name of your Snowflake account 
+- :code:`<account_name>` is the name of your Snowflake account.
 
 Include the region in the `<account_name>` if applicable, more info `here
 <https://docs.snowflake.com/en/user-guide/connecting.html#your-snowflake-account-name>`_.

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,8 @@ Where:
 
 - :code:`<user_login_name>` is the login name for your Snowflake user.
 - :code:`<password>` is the password for your Snowflake user.
-- :code:`<account_name>` is the name of your Snowflake account.
+- :code:`<account_name>` is the name of your Snowflake account (region included if applicable, more info `Python
+<https://docs.snowflake.com/en/user-guide/connecting.html#your-snowflake-account-name>`_.).
 
 You can optionally specify the initial database and schema for the Snowflake session by including them at the end of the connection string, separated by :code:`/`. You can also specify the initial warehouse and role for the session as a parameter string at the end of the connection string:
 


### PR DESCRIPTION
Hiya!

I added an extra line in the readme that references the snowflake account name docs. It threw me off for a small amount of time because I didn't know the region had to be added and it was not mentioned in the documentation of this project. So this PR adds that.

Feel free to merge or decline! 😄 