### PR TITLE
Compile the 'on' clause of a merge into statement

### DIFF
--- a/base.py
+++ b/base.py
@@ -149,8 +149,9 @@ class SnowflakeCompiler(compiler.SQLCompiler):
                 ".nextval")
 
     def visit_merge_into(self, merge_into, **kw):
+        on_clause = self.process(merge_into.on, **kw)
         clauses = " ".join(clause._compiler_dispatch(self, **kw) for clause in merge_into.clauses)
-        return "MERGE INTO %s USING %s ON %s" % (merge_into.target, merge_into.source, merge_into.on) + (
+        return "MERGE INTO %s USING %s ON %s" % (merge_into.target, merge_into.source, on_clause) + (
             " " + clauses if clauses else ""
         )
 


### PR DESCRIPTION
I had a use case where my on clause made use of `sqlalchemy.func` and thus had a bind param in it, and without getting the compiler to process the `on` clause before compiling it, it would have a dangling bind param that was never filled.

This fixes my use case. I was not able to run tests because I got a tox error on my mac, so I'm leaving it up to CI (sorry), but all my other Snowflake SQLA code works great with this fix.