### PR TITLE
SNOW-271500 Update dialect to wrap raw SQL for SQLA 1.4

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -228,6 +228,8 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _current_database_schema(self, connection, **kw):
+        # "branches" a connection if one exists, otherwise creates one
+        # branched connections use the same underlying DBAPI but maintain separate references
         with connection.connect() as sqla_con:
             dbapi_con = sqla_con.connection
             return (

--- a/snowdialect.py
+++ b/snowdialect.py
@@ -228,10 +228,11 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _current_database_schema(self, connection, **kw):
-        con = connection.connection
-        return (
-            self.normalize_name(con.database),
-            self.normalize_name(con.schema))
+        with connection.connect() as sqla_con:
+            dbapi_con = sqla_con.connection
+            return (
+                self.normalize_name(dbapi_con.database),
+                self.normalize_name(dbapi_con.schema))
 
     def _get_default_schema_name(self, connection):
         # NOTE: no cache object is passed here


### PR DESCRIPTION
SQLAlchemy 1.4.0b1 throw `sqlalchemy.exc.ObjectNotExecutableError` any time `connection.execute` is called using an `AsyncConnection` on raw string SQL. This wraps the raw string SQL objects in `sqlalchemy.text` and updates the bind parameter syntax correspondingly to avoid this issue.