### PR TITLE
Fix fallback to NullType when dialect type not found

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -380,8 +380,7 @@ class SnowflakeDialect(default.DefaultDialect):
                                 (sqltypes.String, sqltypes.BINARY)):
                     col_type_kw['length'] = character_maximum_length
 
-            type_instance = col_type(**col_type_kw)
-
+            type_instance = col_type if isinstance(col_type, sqltypes.NullType) else col_type(**col_type_kw)
             current_table_pks = schema_primary_keys.get(table_name)
 
             ans[table_name].append({


### PR DESCRIPTION
GEOGRAPHY custom type is not supported yet. Decided to fix issue similarly how sqlalchemy/postgresql dialect fixes it using sqlalchemy generic type called NULLTYPE. For more information [see here](https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/dialects/postgresql/base.py#L3753)

Root cause: `sqltypes.NULLTYPE` is already an instance of sqltypes.NullType, however when type is not supported logic does not account for that and tries to initalize already initialized instance.

**Related Issue**: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/194