### PR TITLE
default compiler impl for get_from_hint_text

### DIFF
--- a/base.py
+++ b/base.py
@@ -280,6 +280,9 @@ class SnowflakeCompiler(compiler.SQLCompiler):
                                  fromhints=from_hints, **kw)
             for t in extra_froms)
 
+    def get_from_hint_text(self, table, text):
+        return text
+
 
 class SnowflakeExecutionContext(default.DefaultExecutionContext):
     def fire_sequence(self, seq, type_):


### PR DESCRIPTION
This is the same as the mssql and mysql compilers in sqlalchemy
[mssql-impl](https://github.com/sqlalchemy/sqlalchemy/blob/cf6f342150791ace82c6a099e8ea2923138bd61e/lib/sqlalchemy/dialects/mssql/base.py#L1749-L1750)
[mysql-impl](https://github.com/sqlalchemy/sqlalchemy/blob/cf6f342150791ace82c6a099e8ea2923138bd61e/lib/sqlalchemy/dialects/mysql/base.py#L1596-L1597)

This lets you use features like timetravel in Snowflake-Alchemy with:
```
>>> from sqlalchemy.engine import url
>>> from sqlalchemy import table, column, select
>>> t = table('my_table', column('q'))
>>> stmt = select([t]).with_hint(t, "BEFORE(TIMESTAMP => to_timestamp(1618254539))")
>>> sf_dialect = url.URL("snowflake").get_dialect()()
>>> print(stmt.compile(dialect=sf_dialect))
SELECT my_table.q 
FROM my_table BEFORE(TIMESTAMP => to_timestamp(1618254539))
```
