### PR TITLE
SNOW-396922 bump minimum sqlalchemy dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     use_2to3=False,
 
     install_requires=[
-        'sqlalchemy<2.0.0',
+        'sqlalchemy<2.0.0,>=1.4.0',
         'snowflake-connector-python<3.0.0',
     ],
     namespace_packages=[


### PR DESCRIPTION
With the release of `snowflake-sqlalchemy==1.2.5` the package now depends on `sqlalchemy>=1.4.0`. Since install_requires have not been updated to reflect this, the new 1.2.5 release will break all Snowflake customers' tasks pinning `sqlalchemy<1.4`. To highlight, this will likely break some of your customer tasks (it sure did for us) at runtime or (hopefully) during testing since pip install will not complain during installation.

This PR fixes `setup.py` to have the proper `install_requires`, but ideally, this PR should not be approved. It is not a good practice to force your customers to upgrade sqlalchemy due to a patch version change of your package. This is a pretty major break of backward compatibility, a potential break of production tasks, and an unexpected force-upgrade on your customers. 