### PR TITLE
SNOW-452342 fix breaking change introduced in sqlalchemy 1.4

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -19,6 +19,7 @@ from sqlalchemy.engine import default, reflection
 from sqlalchemy.schema import Table
 from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import quoted_name
+from sqlalchemy.sql.sqltypes import String
 from sqlalchemy.types import (
     BIGINT,
     BINARY,
@@ -102,7 +103,7 @@ class SnowflakeDialect(default.DefaultDialect):
     #  unicode strings
     supports_unicode_statements = True
     supports_unicode_binds = True
-    returns_unicode_strings = True
+    returns_unicode_strings = String.RETURNS_UNICODE
     description_encoding = None
 
     # No lastrowid support. See SNOW-11155

--- a/test/test_orm.py
+++ b/test/test_orm.py
@@ -4,8 +4,9 @@
 # Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
 #
 
+import enum
 import pytest
-from sqlalchemy import Column, ForeignKey, Integer, Sequence, String
+from sqlalchemy import Column, ForeignKey, Integer, Sequence, String, Enum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, relationship
 
@@ -16,12 +17,17 @@ def test_basic_orm(engine_testaccount):
     """
     Base = declarative_base()
 
+    class UserStatus(enum.Enum):
+        ACTIVE = "active",
+        INACTIVE = "inactive"
+
     class User(Base):
         __tablename__ = 'user'
 
         id = Column(Integer, Sequence('user_id_seq'), primary_key=True)
         name = Column(String)
         fullname = Column(String)
+        status = Column(Enum(UserStatus), default=UserStatus.ACTIVE)
 
         def __repr__(self):
             return "<User(%r, %r)>" % (self.name, self.fullname)


### PR DESCRIPTION
sqlalchemy 1.4 introduced a breaking change in the definition of returns_unicode_strings.
this change influences parsing Enum's encoded as string in snowflake. ﻿
