### PR TITLE
SNOW-522232 fix: set `supports_statement_cache=False` in dialect class

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -91,6 +91,9 @@ class SnowflakeDialect(default.DefaultDialect):
     max_identifier_length = 65535
     cte_follows_insert = True
 
+    # TODO: support SQL caching, for more info see: https://docs.sqlalchemy.org/en/14/core/connections.html#caching-for-third-party-dialects
+    supports_statement_cache = False
+
     encoding = UTF8
     default_paramstyle = 'pyformat'
     colspecs = colspecs


### PR DESCRIPTION
When `supports_statement_cache` is unset in a sqlalchemy dialect, sqlalchemy emits a warning on first usage. Setting this attribute to `False` prevents this warning. See: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/265#issuecomment-1064446533.