### PR TITLE
Set foreign key referred schema to None when needed

### DIFF
--- a/snowdialect.py
+++ b/snowdialect.py
@@ -312,7 +312,7 @@ class SnowflakeDialect(default.DefaultDialect):
                     # referred schema should be None in context where it doesn't need to be specified
                     # https://docs.sqlalchemy.org/en/14/core/reflection.html#reflection-schema-qualified-interaction
                     'referred_schema': (referred_schema
-                                        if referred_schema not in [self.default_schema_name, current_schema]
+                                        if referred_schema not in (self.default_schema_name, current_schema)
                                         else None),
                     'referred_table': self.normalize_name(row['pk_table_name']),
                     'referred_columns': [self.normalize_name(row['pk_column_name'])],

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -449,6 +449,8 @@ def test_get_foreign_keys(engine_testaccount):
         foreign_keys = inspector.get_foreign_keys('addresses')
         assert foreign_keys[0]['name'] == fk_name
         assert foreign_keys[0]['constrained_columns'] == ['user_id']
+        assert foreign_keys[0]['referred_table'] == 'users'
+        assert foreign_keys[0]['referred_schema'] == None
     finally:
         addresses.drop(engine_testaccount)
         users.drop(engine_testaccount)


### PR DESCRIPTION
SQLAlchemy expects foreign key reflection to set schemas which do not need specifying in the current database context (i.e. default schema or current schema) to be set to None. Without this, alembic migration keep re-creating foreign keys as it considers a referred table with a schema and without a schema two separate tables.

See [SQLAlchemy docs on reflection](https://docs.sqlalchemy.org/en/14/core/reflection.html#reflection-schema-qualified-interaction) for what is the expected behaviour of dialects.