### PR TITLE
Add six to install_requires.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     sqlalchemy<2.0.0,>=1.4.0
 ; Keep in sync with extras dependency
     snowflake-connector-python<3.0.0
+    six>=1.4.0
 include_package_data = True
 package_dir =
     =src


### PR DESCRIPTION
`install_requires` in setup.py should include dependency to `six` library because snowdialect.py in this library uses `six`.

I added `six>=1.4.0` to `install_requires` in setup.py because snowdialect.py uses `six.moves.urllib_parse.unquote_plus`, which was introduced in `six` 1.4.0.

[snowflake-connector-python](https://github.com/snowflakedb/snowflake-connector-python), which is one of the dependent libraries, `v2.7.7` or older depends on `six` library indirectly, but `v2.7.8` does not.
As a result, this issue occurs after snowflake-connector-python `v2.7.8` was released recently because `six` is not installed automatically when a user runs `pip install snowflake-sqlalchemy`.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   It seems that any issue has not been submitted yet.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [x] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add `"six>=1.4.0"` to `install_requires` in setup.py.
