### PR TITLE
SNOW-629067 connector executemany handle escaping double percents when no params

### DIFF
--- a/tests/sqlalchemy_test_suite/test_suite.py
+++ b/tests/sqlalchemy_test_suite/test_suite.py
@@ -11,7 +11,6 @@ from sqlalchemy.testing.suite import HasSequenceTest as _HasSequenceTest
 from sqlalchemy.testing.suite import InsertBehaviorTest as _InsertBehaviorTest
 from sqlalchemy.testing.suite import LikeFunctionsTest as _LikeFunctionsTest
 from sqlalchemy.testing.suite import LongNameBlowoutTest as _LongNameBlowoutTest
-from sqlalchemy.testing.suite import PercentSchemaNamesTest as _PercentSchemaNamesTest
 from sqlalchemy.testing.suite import SimpleUpdateDeleteTest as _SimpleUpdateDeleteTest
 from sqlalchemy.testing.suite import *  # noqa
 
@@ -68,18 +67,7 @@ class InsertBehaviorTest(_InsertBehaviorTest):
         pass
 
 
-# 3. Need fix in connector
-
-
-class PercentSchemaNamesTest(_PercentSchemaNamesTest):
-    @pytest.mark.xfail
-    # TODO: connector cursor "executemany" needs to handle double percentage like
-    #  "execute" using self._dbapi_connection._interpolate_empty_sequences
-    def test_executemany_roundtrip(self, connection):
-        super().test_executemany_roundtrip(connection)
-
-
-# 4. Patched Tests
+# 2. Patched Tests
 
 
 class HasSequenceTest(_HasSequenceTest):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-629067

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

In pre execute:
- add a check whether double percents is used; whether the statement is compiled; whether the statement is an insertion 
- check whether it's a insert batch, insert batch needs to be handled with care because of the connector implementation
