### PR TITLE
SNOW-538310: Error when using create_engine() and password containing % character

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ You can optionally specify the initial database and schema for the Snowflake ses
 #### Escaping Special Characters such as `%, @` signs in Passwords
 
 As pointed out in [SQLAlchemy](https://docs.sqlalchemy.org/en/14/core/engines.html#escaping-special-characters-such-as-signs-in-passwords), URLs
-containing special characters need to be URL encoded to be parsed correctly. This includes the `%, @` signs.
+containing special characters need to be URL encoded to be parsed correctly. This includes the `%, @` signs. Unescaped password containing special
+characters could lead to authentication failure.
 
 The encoding for the password can be generated using `urllib.parse`:
 ```python

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -14,6 +14,11 @@ def _url(**db_parameters):
     """
     Composes a SQLAlchemy connect string from the given database connection
     parameters.
+
+    Password containing special characters (e.g., '@', '%') need to be encoded to be parsed correctly.
+    Unescaped password containing special characters might lead to authentication failure.
+    Please follow the instructions to encode the password:
+    https://github.com/snowflakedb/snowflake-sqlalchemy#escaping-special-characters-such-as---signs-in-passwords
     """
     specified_parameters = []
     if "account" not in db_parameters:

--- a/tests/test_unit_url.py
+++ b/tests/test_unit_url.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
+import urllib.parse
 
 from snowflake.sqlalchemy import URL
 
@@ -23,6 +24,16 @@ def test_url():
             password="1-pass 2-pass 3-: 4-@ 5-/ 6-pass",
         )
         == "snowflake://admin:1-pass 2-pass 3-%3A 4-%40 5-%2F 6-pass@testaccount/"
+    )
+
+    quoted_password = urllib.parse.quote("kx@% jj5/g")
+    assert (
+        URL(
+            account="testaccount",
+            user="admin",
+            password=quoted_password,
+        )
+        == "snowflake://admin:kx%40%25%20jj5%2Fg@testaccount/"
     )
 
     assert (


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-538310

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

SQLAlchemy requires the db password to be escaped if it's containing special characters. Adding instruction in our readme/doc.