### PR TITLE
SNOW-638966: SQLAlchemy jobs are not uploading test results to Tests table in snowhouse

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,16 +37,16 @@ setenv =
 commands = pytest \
            {env:SNOWFLAKE_PYTEST_OPTS:} \
            --cov "snowflake.sqlalchemy" \
-           --junitxml {toxworkdir}/junit.{envname}.xml \
+           --junitxml {toxworkdir}/junit_{envname}.xml \
            {posargs:tests}
            pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
            --cov "snowflake.sqlalchemy" --cov-append \
-           --junitxml {toxworkdir}/junit.{envname}.xml \
+           --junitxml {toxworkdir}/junit_{envname}.xml \
            {posargs:tests/sqlalchemy_test_suite}
            pytest \
            {env:SNOWFLAKE_PYTEST_OPTS:} \
            --cov "snowflake.sqlalchemy" --cov-append \
-           --junitxml {toxworkdir}/junit.{envname}.xml \
+           --junitxml {toxworkdir}/junit_{envname}.xml \
            --run_v20_sqlalchemy \
            {posargs:tests}
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-638966

update junit file name so that the test data could be collected.

the previous naming pattern `junit.{envname}.xml`, the `.` between `junit` and `{envname}` leading the infra unable to match the report and upload to s3, which further makes the test data could not be collected by snowhouse.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
