### PR TITLE
SNOW-652674: normalize name and denormalize name should handle empty string

### DIFF
--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -252,6 +252,8 @@ class SnowflakeDialect(default.DefaultDialect):
     def normalize_name(self, name):
         if name is None:
             return None
+        if name == "":
+            return ""
         if name.upper() == name and not self.identifier_preparer._requires_quotes(
             name.lower()
         ):
@@ -264,6 +266,8 @@ class SnowflakeDialect(default.DefaultDialect):
     def denormalize_name(self, name):
         if name is None:
             return None
+        if name == "":
+            return ""
         elif name.lower() == name and not self.identifier_preparer._requires_quotes(
             name.lower()
         ):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1725,20 +1725,20 @@ def test_normalize_and_denormalize_empty_string_column_name(engine_testaccount):
         table_name = random_string(5)
         conn.exec_driver_sql(
             f"""
-create or replace temp table {table_name}
-(empid int, dept text, jan int, feb int);
+CREATE OR REPLACE TEMP TABLE {table_name}
+(EMPID INT, DEPT TEXT, JAN INT, FEB INT)
 """
         )
         conn.exec_driver_sql(
             f"""
-insert into {table_name} values
-    (1, 'electronics', 100, 200),
-    (2, 'clothes', 100, 300)
+INSERT INTO {table_name} VALUES
+    (1, 'ELECTRONICS', 100, 200),
+    (2, 'CLOTHES', 100, 300)
 """
         )
         results = conn.exec_driver_sql(
             f"""
-select * from {table_name} unpivot(sales for "" in (jan, feb))  order by empid;"""
+SELECT * FROM {table_name} UNPIVOT(SALES FOR "" IN (JAN, FEB))  ORDER BY EMPID;"""
         ).fetchall()  # normalize_name will be called
         assert results == [
             (1, "electronics", "JAN", 100),
@@ -1749,8 +1749,8 @@ select * from {table_name} unpivot(sales for "" in (jan, feb))  order by empid;"
 
         conn.exec_driver_sql(
             f"""
-create or replace temp table {table_name}
-(col int, "" int);
+CREATE OR REPLACE TEMP TABLE {table_name}
+(COL INT, "" INT)
 """
         )
         inspector = inspect(conn)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1741,10 +1741,10 @@ INSERT INTO {table_name} VALUES
 SELECT * FROM {table_name} UNPIVOT(SALES FOR "" IN (JAN, FEB))  ORDER BY EMPID;"""
         ).fetchall()  # normalize_name will be called
         assert results == [
-            (1, "electronics", "JAN", 100),
-            (1, "electronics", "FEB", 200),
-            (2, "clothes", "JAN", 100),
-            (2, "clothes", "FEB", 300),
+            (1, "ELECTRONICS", "JAN", 100),
+            (1, "ELECTRONICS", "FEB", 200),
+            (2, "CLOTHES", "JAN", 100),
+            (2, "CLOTHES", "FEB", 300),
         ]
 
         conn.exec_driver_sql(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-652674

trying to fix issue: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/340, and based on discussion in https://github.com/sqlalchemy/sqlalchemy/discussions/8444.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

column name could be an empty string, and to fix it, we should check if string is empty and return empty string accordingly when normalizing/denormalizing names.