### PR TITLE
SNOW-679045: _rfc_1738_quote is no longer available in sqlalchemy 1.4.42

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,4 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear == 20.11.1
+          - importlib_metadata == 4.13.0

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at:
 
 - v1.4.3(Unreleased)
   - Fixed a bug that `SnowflakeDialect.normalize_name` and `SnowflakeDialect.denormalize_name` could not handle empty string.
+  - Fixed a compatibility issue to vendor function `sqlalchemy.engine.url._rfc_1738_quote` as it is removed from SQLAlchemy v1.4.42.
 
 - v1.4.2(Sep 19, 2022)
 

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -4,8 +4,8 @@
 
 from urllib.parse import quote_plus
 
+import re
 from sqlalchemy import exc
-from sqlalchemy.engine.url import _rfc_1738_quote
 
 from snowflake.connector.compat import IS_STR
 
@@ -21,6 +21,10 @@ def _url(**db_parameters):
     https://github.com/snowflakedb/snowflake-sqlalchemy#escaping-special-characters-such-as---signs-in-passwords
     """
     specified_parameters = []
+
+    def _rfc_1738_quote(text):
+        return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
+
     if "account" not in db_parameters:
         raise exc.ArgumentError("account parameter must be specified.")
 

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
+import re
 from urllib.parse import quote_plus
 
-import re
 from sqlalchemy import exc
 
 from snowflake.connector.compat import IS_STR

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -10,6 +10,10 @@ from sqlalchemy import exc
 from snowflake.connector.compat import IS_STR
 
 
+def _rfc_1738_quote(text):
+    return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
+
+
 def _url(**db_parameters):
     """
     Composes a SQLAlchemy connect string from the given database connection
@@ -21,10 +25,6 @@ def _url(**db_parameters):
     https://github.com/snowflakedb/snowflake-sqlalchemy#escaping-special-characters-such-as---signs-in-passwords
     """
     specified_parameters = []
-
-    def _rfc_1738_quote(text):
-        return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
-
     if "account" not in db_parameters:
         raise exc.ArgumentError("account parameter must be specified.")
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #350 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Removes the import of a private function that was removed in the release of SQLAlchemy 1.4.42 and adds this directly to the codebase.
