### PR TITLE
Update snowdialect.py

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,10 @@ Source code is also available at:
 
 # Release Notes
 
+- v1.4.5(Unreleased)
+
+  - Improved performance of looking up columns in tables.
+
 - v1.4.4(Nov 16, 2022)
 
   - Fixed a bug that percent signs in a non-compiled statement should not be interpolated with emtpy sequence when executed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = snowflake-sqlalchemy
-version = 1.4.4
+version = 1.4.5
 description = Snowflake SQLAlchemy Dialect
 long_description = file: DESCRIPTION.md
 long_description_content_type = text/markdown

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -320,8 +320,8 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_primary_keys(self, connection, schema, table_name, **kw):
-        fully_qualified_path = self._denormalize_quote_join(schema, table_name)
         if table_name.upper() in RESERVED_WORDS:
+            fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(
                     f"SHOW /* sqlalchemy:_get_table_primary_keys */PRIMARY KEYS IN TABLE {fully_qualified_path}"
@@ -389,8 +389,8 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_unique_constraints(self, connection, schema, table_name, **kw):
-        fully_qualified_path = self._denormalize_quote_join(schema, table_name)
         if table_name.upper() in RESERVED_WORDS:
+            fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(
                     f"SHOW /* sqlalchemy:_get_table_unique_constraints */ UNIQUE KEYS IN TABLE {fully_qualified_path}"
@@ -471,9 +471,9 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_foreign_keys(self, connection, schema, table_name, **kw):
-        fully_qualified_path = self._denormalize_quote_join(schema, table_name)
         _, current_schema = self._current_database_schema(connection, **kw)
         if table_name.upper() in RESERVED_WORDS:
+            fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(
                     f"SHOW /* sqlalchemy:_get_table_foreign_keys */ IMPORTED KEYS IN TABLE {fully_qualified_path}"

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -319,10 +319,10 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_primary_keys(self, connection, schema, table_name, **kw):
-        # fully_qualified_path = self._denormalize_quote_join(schema, table_name)
+        fully_qualified_path = self._denormalize_quote_join(schema, table_name)
         result = connection.execute(
             text(
-                f"SHOW /* sqlalchemy:_get_table_primary_keys */PRIMARY KEYS IN TABLE {schema}.{table_name}"
+                f"SHOW /* sqlalchemy:_get_table_primary_keys */PRIMARY KEYS IN TABLE {fully_qualified_path}"
             )
         )
         ans = {}

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -367,8 +367,7 @@ class SnowflakeDialect(default.DefaultDialect):
         )
         if table_name is not None:
             return self._get_table_primary_keys(
-                connection, self.denormalize_name(full_schema_name),
-                table_name, **kw
+                connection, self.denormalize_name(full_schema_name), table_name, **kw
             ).get(table_name, {"constrained_columns": [], "name": None})
         else:
             return self._get_schema_primary_keys(
@@ -439,8 +438,7 @@ class SnowflakeDialect(default.DefaultDialect):
         )
         if table_name is not None:
             return self._get_table_unique_constraints(
-                connection, self.denormalize_name(full_schema_name),
-                table_name, **kw
+                connection, self.denormalize_name(full_schema_name), table_name, **kw
             ).get(table_name, [])
         else:
             return self._get_schema_unique_constraints(
@@ -469,7 +467,7 @@ class SnowflakeDialect(default.DefaultDialect):
                     "referred_schema": (
                         referred_schema
                         if referred_schema
-                           not in (self.default_schema_name, current_schema)
+                        not in (self.default_schema_name, current_schema)
                         else None
                     ),
                     "referred_table": self.normalize_name(
@@ -585,8 +583,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
         if table_name is not None:
             foreign_key_map = self._get_table_foreign_keys(
-                connection, self.denormalize_name(full_schema_name),
-                table_name, **kw
+                connection, self.denormalize_name(full_schema_name), table_name, **kw
             )
         else:
             foreign_key_map = self._get_schema_foreign_keys(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -319,19 +319,12 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_primary_keys(self, connection, schema, table_name, **kw):
-        if table_name in SnowflakeIdentifierPreparer.reserved_words:
-            fully_qualified_path = self._denormalize_quote_join(schema, table_name)
-            result = connection.execute(
-                text(
-                    f"SHOW /* sqlalchemy:_get_table_primary_keys */ PRIMARY KEYS IN TABLE {fully_qualified_path}"
-                )
+        fully_qualified_path = self._denormalize_quote_join(schema, self.denormalize_name(table_name))
+        result = connection.execute(
+            text(
+                f"SHOW /* sqlalchemy:_get_table_primary_keys */ PRIMARY KEYS IN TABLE {fully_qualified_path}"
             )
-        else:
-            result = connection.execute(
-                text(
-                    f"SHOW /* sqlalchemy:_get_table_primary_keys */ PRIMARY KEYS IN TABLE {schema}.{table_name}"
-                )
-            )
+        )
         ans = {}
         for row in result:
             table_name = self.normalize_name(row._mapping["table_name"])
@@ -388,19 +381,12 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_unique_constraints(self, connection, schema, table_name, **kw):
-        if table_name in SnowflakeIdentifierPreparer.reserved_words:
-            fully_qualified_path = self._denormalize_quote_join(schema, table_name)
-            result = connection.execute(
-                text(
-                    f"SHOW /* sqlalchemy:_get_table_unique_constraints */ UNIQUE KEYS IN TABLE {fully_qualified_path}"
-                )
+        fully_qualified_path = self._denormalize_quote_join(schema, table_name)
+        result = connection.execute(
+            text(
+                f"SHOW /* sqlalchemy:_get_table_unique_constraints */ UNIQUE KEYS IN TABLE {fully_qualified_path}"
             )
-        else:
-            result = connection.execute(
-                text(
-                    f"SHOW /* sqlalchemy:_get_table_unique_constraints */ UNIQUE KEYS IN TABLE {schema}.{table_name}"
-                )
-            )
+        )
         unique_constraints = {}
         for row in result:
             name = self.normalize_name(row._mapping["constraint_name"])
@@ -471,19 +457,12 @@ class SnowflakeDialect(default.DefaultDialect):
     @reflection.cache
     def _get_table_foreign_keys(self, connection, schema, table_name, **kw):
         _, current_schema = self._current_database_schema(connection, **kw)
-        if table_name in SnowflakeIdentifierPreparer.reserved_words:
-            fully_qualified_path = self._denormalize_quote_join(schema, table_name)
-            result = connection.execute(
-                text(
-                    f"SHOW /* sqlalchemy:_get_table_foreign_keys */ IMPORTED KEYS IN TABLE {fully_qualified_path}"
-                )
+        fully_qualified_path = self._denormalize_quote_join(schema, self.denormalize_name(table_name))
+        result = connection.execute(
+            text(
+                f"SHOW /* sqlalchemy:_get_table_foreign_keys */ IMPORTED KEYS IN TABLE {fully_qualified_path}"
             )
-        else:
-            result = connection.execute(
-                text(
-                    f"SHOW /* sqlalchemy:_get_table_foreign_keys */ IMPORTED KEYS IN TABLE {schema}.{table_name}"
-                )
-            )
+        )
         foreign_key_map = {}
         for row in result:
             name = self.normalize_name(row._mapping["fk_name"])

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -365,9 +365,13 @@ class SnowflakeDialect(default.DefaultDialect):
         full_schema_name = self._denormalize_quote_join(
             current_database, schema if schema else current_schema
         )
+
         if table_name is not None:
             return self._get_table_primary_keys(
-                connection, self.denormalize_name(full_schema_name), table_name, **kw
+                connection,
+                self.denormalize_name(full_schema_name),
+                self.denormalize_name(table_name),
+                **kw,
             ).get(table_name, {"constrained_columns": [], "name": None})
         else:
             return self._get_schema_primary_keys(
@@ -438,7 +442,10 @@ class SnowflakeDialect(default.DefaultDialect):
         )
         if table_name is not None:
             return self._get_table_unique_constraints(
-                connection, self.denormalize_name(full_schema_name), table_name, **kw
+                connection,
+                self.denormalize_name(full_schema_name),
+                self.denormalize_name(table_name),
+                **kw,
             ).get(table_name, [])
         else:
             return self._get_schema_unique_constraints(
@@ -583,7 +590,10 @@ class SnowflakeDialect(default.DefaultDialect):
 
         if table_name is not None:
             foreign_key_map = self._get_table_foreign_keys(
-                connection, self.denormalize_name(full_schema_name), table_name, **kw
+                connection,
+                self.denormalize_name(full_schema_name),
+                self.denormalize_name(table_name),
+                **kw,
             )
         else:
             foreign_key_map = self._get_schema_foreign_keys(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -319,7 +319,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_primary_keys(self, connection, schema, table_name, **kw):
-        #fully_qualified_path = self._denormalize_quote_join(schema, table_name)
+        # fully_qualified_path = self._denormalize_quote_join(schema, table_name)
         result = connection.execute(
             text(
                 f"SHOW /* sqlalchemy:_get_table_primary_keys */PRIMARY KEYS IN TABLE {schema}.{table_name}"

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -630,9 +630,13 @@ class SnowflakeDialect(default.DefaultDialect):
                    ic.identity_increment
               FROM information_schema.columns ic
              WHERE ic.table_schema=:table_schema
+             AND   ic.table_name=:table_name
              ORDER BY ic.ordinal_position"""
                 ),
-                {"table_schema": self.denormalize_name(schema)},
+                {
+                    "table_schema": self.denormalize_name(schema),
+                    "table_name": self.denormalize_name(table_name),
+                },
             )
         except sa_exc.ProgrammingError as pe:
             if pe.orig.errno == 90030:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -319,7 +319,9 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_primary_keys(self, connection, schema, table_name, **kw):
-        fully_qualified_path = self._denormalize_quote_join(schema, self.denormalize_name(table_name))
+        fully_qualified_path = self._denormalize_quote_join(
+            schema, self.denormalize_name(table_name)
+        )
         result = connection.execute(
             text(
                 f"SHOW /* sqlalchemy:_get_table_primary_keys */ PRIMARY KEYS IN TABLE {fully_qualified_path}"
@@ -457,7 +459,9 @@ class SnowflakeDialect(default.DefaultDialect):
     @reflection.cache
     def _get_table_foreign_keys(self, connection, schema, table_name, **kw):
         _, current_schema = self._current_database_schema(connection, **kw)
-        fully_qualified_path = self._denormalize_quote_join(schema, self.denormalize_name(table_name))
+        fully_qualified_path = self._denormalize_quote_join(
+            schema, self.denormalize_name(table_name)
+        )
         result = connection.execute(
             text(
                 f"SHOW /* sqlalchemy:_get_table_foreign_keys */ IMPORTED KEYS IN TABLE {fully_qualified_path}"

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -323,13 +323,13 @@ class SnowflakeDialect(default.DefaultDialect):
             fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(
-                    f"SHOW /* sqlalchemy:_get_table_primary_keys */PRIMARY KEYS IN TABLE {fully_qualified_path}"
+                    f"SHOW /* sqlalchemy:_get_table_primary_keys */ PRIMARY KEYS IN TABLE {fully_qualified_path}"
                 )
             )
         else:
             result = connection.execute(
                 text(
-                    f"SHOW /* sqlalchemy:_get_table_primary_keys */PRIMARY KEYS IN TABLE {schema}.{table_name}"
+                    f"SHOW /* sqlalchemy:_get_table_primary_keys */ PRIMARY KEYS IN TABLE {schema}.{table_name}"
                 )
             )
         ans = {}
@@ -460,7 +460,7 @@ class SnowflakeDialect(default.DefaultDialect):
             return self._get_table_unique_constraints(
                 connection,
                 self.denormalize_name(full_schema_name),
-                self.normalize_name(table_name),
+                self.denormalize_name(table_name),
                 **kw,
             ).get(table_name, [])
         else:
@@ -616,7 +616,7 @@ class SnowflakeDialect(default.DefaultDialect):
             foreign_key_map = self._get_table_foreign_keys(
                 connection,
                 self.denormalize_name(full_schema_name),
-                self.normalize_name(table_name),
+                self.denormalize_name(table_name),
                 **kw,
             )
         else:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -46,7 +46,7 @@ from .base import (
     SnowflakeExecutionContext,
     SnowflakeIdentifierPreparer,
     SnowflakeTypeCompiler,
-    RESERVED_WORDS
+    RESERVED_WORDS,
 )
 from .custom_types import (
     _CUSTOM_DECIMAL,

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -370,7 +370,7 @@ class SnowflakeDialect(default.DefaultDialect):
             return self._get_table_primary_keys(
                 connection,
                 self.denormalize_name(full_schema_name),
-                self.denormalize_name(table_name),
+                self.normalize_name(table_name),
                 **kw,
             ).get(table_name, {"constrained_columns": [], "name": None})
         else:
@@ -444,7 +444,7 @@ class SnowflakeDialect(default.DefaultDialect):
             return self._get_table_unique_constraints(
                 connection,
                 self.denormalize_name(full_schema_name),
-                self.denormalize_name(table_name),
+                self.normalize_name(table_name),
                 **kw,
             ).get(table_name, [])
         else:
@@ -592,7 +592,7 @@ class SnowflakeDialect(default.DefaultDialect):
             foreign_key_map = self._get_table_foreign_keys(
                 connection,
                 self.denormalize_name(full_schema_name),
-                self.denormalize_name(table_name),
+                self.normalize_name(table_name),
                 **kw,
             )
         else:
@@ -800,7 +800,9 @@ class SnowflakeDialect(default.DefaultDialect):
             _, schema = self._current_database_schema(connection, **kw)
 
         if table_name is not None:
-            return self._get_table_columns(connection, table_name, schema, **kw)
+            return self._get_table_columns(
+                connection, self.normalize_name(table_name), schema, **kw
+            )
         else:
             schema_columns = self._get_schema_columns(connection, schema, **kw)
         if schema_columns is None:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -46,7 +46,6 @@ from .base import (
     SnowflakeExecutionContext,
     SnowflakeIdentifierPreparer,
     SnowflakeTypeCompiler,
-    RESERVED_WORDS,
 )
 from .custom_types import (
     _CUSTOM_DECIMAL,
@@ -320,7 +319,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_primary_keys(self, connection, schema, table_name, **kw):
-        if table_name.upper() in RESERVED_WORDS:
+        if table_name in SnowflakeIdentifierPreparer.reserved_words:
             fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(
@@ -389,7 +388,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
     @reflection.cache
     def _get_table_unique_constraints(self, connection, schema, table_name, **kw):
-        if table_name.upper() in RESERVED_WORDS:
+        if table_name in SnowflakeIdentifierPreparer.reserved_words:
             fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(
@@ -472,7 +471,7 @@ class SnowflakeDialect(default.DefaultDialect):
     @reflection.cache
     def _get_table_foreign_keys(self, connection, schema, table_name, **kw):
         _, current_schema = self._current_database_schema(connection, **kw)
-        if table_name.upper() in RESERVED_WORDS:
+        if table_name in SnowflakeIdentifierPreparer.reserved_words:
             fully_qualified_path = self._denormalize_quote_join(schema, table_name)
             result = connection.execute(
                 text(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -602,6 +602,108 @@ class SnowflakeDialect(default.DefaultDialect):
         return foreign_key_map.get(table_name, [])
 
     @reflection.cache
+    def _get_schema_columns_v2(self, connection, schema, table_name, **kw):
+        """Get all columns in the schema, if we hit 'Information schema query returned too much data' problem return
+        None, as it is cacheable and is an unexpected return type for this function"""
+        ans = {}
+        current_database, _ = self._current_database_schema(connection, **kw)
+        full_schema_name = self._denormalize_quote_join(current_database, schema)
+        try:
+            schema_primary_keys = self._get_table_primary_keys(
+                connection, full_schema_name, table_name, **kw
+            )
+            result = connection.execute(
+                text(
+                    """
+            SELECT /* sqlalchemy:_get_schema_columns_v2 */
+                   ic.table_name,
+                   ic.column_name,
+                   ic.data_type,
+                   ic.character_maximum_length,
+                   ic.numeric_precision,
+                   ic.numeric_scale,
+                   ic.is_nullable,
+                   ic.column_default,
+                   ic.is_identity,
+                   ic.comment,
+                   ic.identity_start,
+                   ic.identity_increment
+              FROM information_schema.columns ic
+             WHERE ic.table_schema=:table_schema
+             ORDER BY ic.ordinal_position"""
+                ),
+                {"table_schema": self.denormalize_name(schema)},
+            )
+        except sa_exc.ProgrammingError as pe:
+            if pe.orig.errno == 90030:
+                # This means that there are too many tables in the schema, we need to go more granular
+                return None  # None triggers _get_table_columns while staying cacheable
+            raise
+        for (
+            table_name,
+            column_name,
+            coltype,
+            character_maximum_length,
+            numeric_precision,
+            numeric_scale,
+            is_nullable,
+            column_default,
+            is_identity,
+            comment,
+            identity_start,
+            identity_increment,
+        ) in result:
+            table_name = self.normalize_name(table_name)
+            column_name = self.normalize_name(column_name)
+            if table_name not in ans:
+                ans[table_name] = list()
+            if column_name.startswith("sys_clustering_column"):
+                continue  # ignoring clustering column
+            col_type = self.ischema_names.get(coltype, None)
+            col_type_kw = {}
+            if col_type is None:
+                sa_util.warn(
+                    f"Did not recognize type '{coltype}' of column '{column_name}'"
+                )
+                col_type = sqltypes.NULLTYPE
+            else:
+                if issubclass(col_type, FLOAT):
+                    col_type_kw["precision"] = numeric_precision
+                    col_type_kw["decimal_return_scale"] = numeric_scale
+                elif issubclass(col_type, sqltypes.Numeric):
+                    col_type_kw["precision"] = numeric_precision
+                    col_type_kw["scale"] = numeric_scale
+                elif issubclass(col_type, (sqltypes.String, sqltypes.BINARY)):
+                    col_type_kw["length"] = character_maximum_length
+
+            type_instance = col_type(**col_type_kw)
+
+            current_table_pks = schema_primary_keys.get(table_name)
+
+            ans[table_name].append(
+                {
+                    "name": column_name,
+                    "type": type_instance,
+                    "nullable": is_nullable == "YES",
+                    "default": column_default,
+                    "autoincrement": is_identity == "YES",
+                    "comment": comment,
+                    "primary_key": (
+                        column_name
+                        in schema_primary_keys[table_name]["constrained_columns"]
+                    )
+                    if current_table_pks
+                    else False,
+                }
+            )
+            if is_identity == "YES":
+                ans[table_name][-1]["identity"] = {
+                    "start": identity_start,
+                    "increment": identity_increment,
+                }
+        return ans
+
+    @reflection.cache
     def _get_schema_columns(self, connection, schema, **kw):
         """Get all columns in the schema, if we hit 'Information schema query returned too much data' problem return
         None, as it is cacheable and is an unexpected return type for this function"""
@@ -710,7 +812,7 @@ class SnowflakeDialect(default.DefaultDialect):
         current_database, _ = self._current_database_schema(connection, **kw)
         full_schema_name = self._denormalize_quote_join(current_database, schema)
         schema_primary_keys = self._get_table_primary_keys(
-            connection, full_schema_name, table_name, **kw
+            connection, full_schema_name, self.normalize_name(table_name), **kw
         )
         result = connection.execute(
             text(
@@ -800,8 +902,8 @@ class SnowflakeDialect(default.DefaultDialect):
             _, schema = self._current_database_schema(connection, **kw)
 
         if table_name is not None:
-            return self._get_table_columns(
-                connection, self.normalize_name(table_name), schema, **kw
+            schema_columns = self._get_schema_columns_v2(
+                connection, schema, table_name, **kw
             )
         else:
             schema_columns = self._get_schema_columns(connection, schema, **kw)


### PR DESCRIPTION
Optimizations for table-specific metadata lookups

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   ref: SNOW-689531

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Refine table-specific metadata lookups to target specific tables instead of searching the entire schema for:
    - get_columns()
    - get_foreign_keys()
    - get_pk_contraints()
    - get_unique_constraints()
    
   Please write a short description of how your code change solves the related issue.

Allow SHOW metadata lookups for table-level operations to be table-specific.