### PR TITLE
Single Quotes for COLLATE statements (New PR)

### DIFF
--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -583,6 +583,15 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
 
 
 class SnowflakeTypeCompiler(compiler.GenericTypeCompiler):
+    def _render_string_type(self, type_, name):
+
+        text = name
+        if type_.length:
+            text += f"({type_.length})" 
+        if type_.collation:
+            text += f"COLLATE '{type_.collation}'" 
+        return text
+    
     def visit_BYTEINT(self, type_, **kw):
         return "BYTEINT"
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

    This solves the issue described in #186, unfortunately, there was no issue referenced there.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

The initial problem description can be viewed [here](https://github.com/snowflakedb/snowflake-sqlalchemy/pull/186).
TL;DR:
When creating tables with columns that have collation in sqlalchemy
```py
table = sqlalchemy.Table("table1", Column("char_column", String(collation="en")))
```
the resulting SQL statements use double quotes
```sql
CREATE TABLE table1 (char_column VARCHAR COLLATE "en")
```
which is allowed in other database engines but does not work in snowflake.

This PR fixes that issue by overwriting the rendering in the SQLAlchemy statement Compiler for text columns and adding at least one new test.