### PR TITLE
SNOW-706024: Fix failing github build and test

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,7 +78,9 @@ jobs:
     - name: Upgrade setuptools, pip and wheel
       run: python -m pip install -U setuptools pip wheel
     - name: Install tox
-      run: python -m pip install --pre tox
+      run: python -m pip install tox==4.0.0rc2
+    - name: List installed packages
+      run: python -m pip freeze
     - name: Run tests
       run: python -m tox -e "py${PYTHON_VERSION/\./}" --skip-missing-interpreters false
       env:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.7'
       - name: Display Python version
         run: python -c "import sys; import os; print(\"\n\".join(os.environ[\"PATH\"].split(os.pathsep))); print(sys.version); print(sys.executable);"
       - name: Upgrade setuptools, pip and wheel
@@ -58,7 +58,7 @@ jobs:
          download_name: macosx_x86_64
        - image_name: windows-2019
          download_name: win_amd64
-      python-version: ["3.8"]
+      python-version: ["3.7"]
       cloud-provider: [aws, azure, gcp]
    steps:
     - uses: actions/checkout@v2
@@ -79,6 +79,8 @@ jobs:
       run: python -m pip install -U setuptools pip wheel
     - name: Install tox
       run: python -m pip install --pre tox
+    - name: List installed packages
+      run: python -m pip freeze
     - name: Run tests
       run: python -m tox -e "py${PYTHON_VERSION/\./}" --skip-missing-interpreters false
       env:
@@ -108,7 +110,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.7'
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Upgrade setuptools and pip

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Display Python version
         run: python -c "import sys; import os; print(\"\n\".join(os.environ[\"PATH\"].split(os.pathsep))); print(sys.version); print(sys.executable);"
       - name: Upgrade setuptools, pip and wheel
@@ -58,7 +58,7 @@ jobs:
          download_name: macosx_x86_64
        - image_name: windows-2019
          download_name: win_amd64
-      python-version: ["3.7"]
+      python-version: ["3.8"]
       cloud-provider: [aws, azure, gcp]
    steps:
     - uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Upgrade setuptools and pip

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -79,8 +79,6 @@ jobs:
       run: python -m pip install -U setuptools pip wheel
     - name: Install tox
       run: python -m pip install --pre tox
-    - name: List installed packages
-      run: python -m pip freeze
     - name: Run tests
       run: python -m tox -e "py${PYTHON_VERSION/\./}" --skip-missing-interpreters false
       env:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Upgrade setuptools, pip and wheel
       run: python -m pip install -U setuptools pip wheel
     - name: Install tox
-      run: python -m pip install tox==4.0.0rc2
+      run: python -m pip install tox==4.0.0rc1
     - name: List installed packages
       run: python -m pip freeze
     - name: Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ skip_missing_interpreters = true
 package = external
 description = run the tests with pytest under {basepython}
 extras =
-    development
     pandas
+    development
 external_wheels =
     py37-ci: dist/*.whl
     py38-ci: dist/*.whl

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,12 @@ extras =
     development
 external_wheels =
     py37-ci: dist/*.whl
-    py38-c3: dist/*.whl
+    py38-ci: dist/*.whl
     py39-ci: dist/.whl
     py310-ci: dist/.whl
-deps = pip snowflake-connector-python[pandas]<3.0.0
+deps =
+    pip
+    snowflake-connector-python[pandas]<3.0.0
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,11 @@ skip_missing_interpreters = true
 package = external
 description = run the tests with pytest under {basepython}
 extras =
-    development
     pandas
+    development
 external_wheels =
     py37-ci: dist/*.whl
-    py38-c3i: dist/*.whl
+    py38-c3: dist/*.whl
     py39-ci: dist/.whl
     py310-ci: dist/.whl
 deps = pip snowflake-connector-python[pandas]<3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,16 +9,14 @@ skip_missing_interpreters = true
 package = external
 description = run the tests with pytest under {basepython}
 extras =
-    pandas
     development
+    pandas
 external_wheels =
     py37-ci: dist/*.whl
     py38-ci: dist/*.whl
     py39-ci: dist/.whl
     py310-ci: dist/.whl
-deps =
-    pip
-    snowflake-connector-python[pandas]<3.0.0
+deps = pip
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,14 @@ skip_missing_interpreters = true
 package = external
 description = run the tests with pytest under {basepython}
 extras =
-    pandas
     development
+    pandas
 external_wheels =
     py37-ci: dist/*.whl
-    py38-ci: dist/*.whl
+    py38-c3i: dist/*.whl
     py39-ci: dist/.whl
     py310-ci: dist/.whl
-deps = pip
+deps = pip snowflake-connector-python[pandas]<3.0.0
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-706024

starting from tox 4.0.0rc2 (included), the `extras` in the `tox.ini` is not working correctly, which in our cases, `snowpark-connector-pyhon[pandas]<3.0.0` is not installed.

pin tox to 4.0.0rc1 first

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
