### PR TITLE
SNOW-1056848-missing-test-action-output: remove TOX_PARALLEL_NO_SPINNER

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -86,7 +86,6 @@ jobs:
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}
         PYTEST_ADDOPTS: -vvv --color=yes --tb=short
-        TOX_PARALLEL_NO_SPINNER: 1
     - name: Combine coverages
       run: python -m tox -e coverage --skip-missing-interpreters false
       shell: bash


### PR DESCRIPTION
SNOW-1056848-missing-test-action-output: remove TOX_PARALLEL_NO_SPINNER env variable

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes # SNOW-1056848

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [x] I am updating workflow actions

3. Please describe how your code solves the related issue.

   `TOX_PARALLEL_NO_SPINNER` variable removed to [restore](https://github.com/tox-dev/tox/issues/3193) action output 
