### PR TITLE
Add ability to set ORDER / NOORDER sequence on columns with IDENTITY

### DIFF
--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -966,13 +966,14 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
         )
 
     def visit_identity_column(self, identity, **kw):
-        text = " IDENTITY"
+        text = "IDENTITY"
         if identity.start is not None or identity.increment is not None:
             start = 1 if identity.start is None else identity.start
             increment = 1 if identity.increment is None else identity.increment
             text += f"({start},{increment})"
-        order = "ORDER" if identity.order else "NOORDER"
-        text += f" {order}"
+        if identity.order is not None:
+            order = "ORDER" if identity.order else "NOORDER"
+            text += f" {order}"
         return text
 
     def get_identity_options(self, identity_options):

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -971,6 +971,8 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
             start = 1 if identity.start is None else identity.start
             increment = 1 if identity.increment is None else identity.increment
             text += f"({start},{increment})"
+        order = "ORDER" if identity.order else "NOORDER"
+        text += f" {order}"
         return text
 
     def get_identity_options(self, identity_options):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #436 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   [CREATE TABLE DDL](https://docs.snowflake.com/en/sql-reference/sql/create-table#optional-parameters) supports optional `ORDER | NOORDER` value for `AUTOINCREMENT | IDENTITY` sequences on a column. Before this change, using a column with a sequence like `Column(NUMBER, Identity(start=1, increment=1, order=True)` would default to session parameter [NOORDER_SEQUENCE_AS_DEFAULT](https://docs.snowflake.com/en/sql-reference/parameters#label-noorder-sequence-as-default) `TRUE` by default which would always set `NOORDER` instead of what is being set in the column definition.

   For us, this lead to discrepancies between ORM defined models and the Snowflake state seen by Alembic.
