### PR TITLE
accepting query_tag as session_parameters in connection arguments

### DIFF
--- a/src/snowflake/sqlalchemy/_constants.py
+++ b/src/snowflake/sqlalchemy/_constants.py
@@ -10,3 +10,6 @@ PARAM_INTERNAL_APPLICATION_VERSION = "internal_application_version"
 
 APPLICATION_NAME = "SnowflakeSQLAlchemy"
 SNOWFLAKE_SQLALCHEMY_VERSION = VERSION
+
+PARAM_QUERY_TAG = "query_tag"
+PARAM_SESSION_PARAMETERS = "session_parameters"

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -63,7 +63,7 @@ from .custom_types import (
     _CUSTOM_Float,
     _CUSTOM_Time,
 )
-from .util import _update_connection_application_name, parse_url_boolean
+from .util import _update_connection_application_name, parse_url_boolean, _update_connection_session_parameters
 
 colspecs = {
     Date: _CUSTOM_Date,
@@ -110,7 +110,7 @@ ischema_names = {
     "GEOMETRY": GEOMETRY,
 }
 
-_ENABLE_SQLALCHEMY_AS_APPLICATION_NAME = True
+_CUSTOMIZE_APPLICATION_NAME_AND_SESSION_PARAMETERS = True
 
 
 class SnowflakeDialect(default.DefaultDialect):
@@ -888,18 +888,10 @@ class SnowflakeDialect(default.DefaultDialect):
         }
 
     def connect(self, *cargs, **cparams):
-        return (
-            super().connect(
-                *cargs,
-                **(
-                    _update_connection_application_name(**cparams)
-                    if _ENABLE_SQLALCHEMY_AS_APPLICATION_NAME
-                    else cparams
-                ),
-            )
-            if _ENABLE_SQLALCHEMY_AS_APPLICATION_NAME
-            else super().connect(*cargs, **cparams)
-        )
+        if _CUSTOMIZE_APPLICATION_NAME_AND_SESSION_PARAMETERS:
+            cparams = _update_connection_application_name(**cparams)
+            cparams = _update_connection_session_parameters(**cparams)
+        return super().connect(*cargs, **cparams)
 
 
 @sa_vnt.listens_for(Table, "before_create")

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -26,6 +26,8 @@ from ._constants import (
     PARAM_INTERNAL_APPLICATION_NAME,
     PARAM_INTERNAL_APPLICATION_VERSION,
     SNOWFLAKE_SQLALCHEMY_VERSION,
+    PARAM_QUERY_TAG,
+    PARAM_SESSION_PARAMETERS,
 )
 
 
@@ -112,6 +114,14 @@ def _update_connection_application_name(**conn_kwargs: Any) -> Any:
         conn_kwargs[PARAM_INTERNAL_APPLICATION_NAME] = APPLICATION_NAME
     if PARAM_INTERNAL_APPLICATION_VERSION not in conn_kwargs:
         conn_kwargs[PARAM_INTERNAL_APPLICATION_VERSION] = SNOWFLAKE_SQLALCHEMY_VERSION
+    return conn_kwargs
+
+
+def _update_connection_session_parameters(**conn_kwargs: Any) -> Any:
+    if PARAM_QUERY_TAG in conn_kwargs:
+        session_parameters = {}
+        session_parameters.update({"QUERY_TAG": conn_kwargs[PARAM_QUERY_TAG]})
+        conn_kwargs[PARAM_SESSION_PARAMETERS] = session_parameters
     return conn_kwargs
 
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #495 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [x] I am adding new credentials
   - [x] I am adding a new dependency

3. Please describe how your code solves the related issue.
The solution involves integrating the query_tag parameter into the session_parameters dictionary. This dictionary is part of the connection arguments used when establishing a connection to Snowflake through SQLAlchemy. By including query_tag in session_parameters, users can specify a custom query tag to be associated with their queries.

If the user does not explicitly provide a query_tag, the library will revert to its current behavior. In this case, no query tag will be attached to the executed queries. This ensures backward compatibility with existing codebases and prevents any unintended changes in behavior for users who do not wish to utilize the query_tag functionality.

If the user provides a query_tag in the session_parameters dictionary, the library will extract it and set it in the queries being executed against Snowflake. This allows users to dynamically specify custom query tags based on their requirements.

