### PR TITLE
Bump `pypa/gh-action-pypi-publish` to fix deployment issue

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06
+      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Relates to #380 and #469

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This fixes the PyPI publishing step by bumping the `pypa/gh-action-pypi-publish`
   action to the latest tag ([v1.9.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.9.0)).

   You can see the failure in
   https://github.com/snowflakedb/snowflake-sqlalchemy/actions/runs/9845961499/job/27182670129:

   ```
   InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2.
   ```

   See https://github.com/pypa/gh-action-pypi-publish/pull/219 and
   https://discuss.python.org/t/status-or-funding-for-metadata-2-2-in-pypi/46137/36 for
   more details.
