### PR TITLE
Stop SQLAlchemy warnings about registering 'flatten' twice

### DIFF
--- a/src/snowflake/sqlalchemy/__init__.py
+++ b/src/snowflake/sqlalchemy/__init__.py
@@ -61,6 +61,7 @@ from .custom_types import (
     VARBINARY,
     VARIANT,
 )
+from .functions import flatten as flatten
 from .util import _url as URL
 
 base.dialect = dialect = snowdialect.dialect

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -13,14 +13,13 @@ from sqlalchemy.engine import default
 from sqlalchemy.orm import context
 from sqlalchemy.orm.context import _MapperEntity
 from sqlalchemy.schema import Sequence, Table
-from sqlalchemy.sql import compiler, expression, functions
+from sqlalchemy.sql import compiler, expression
 from sqlalchemy.sql.base import CompileState
 from sqlalchemy.sql.elements import quoted_name
 from sqlalchemy.sql.selectable import Lateral, SelectState
 
 from .compat import IS_VERSION_20, args_reducer, string_types
 from .custom_commands import AWSBucket, AzureContainer, ExternalStage
-from .functions import flatten
 from .util import (
     _find_left_clause_to_join_from,
     _set_connection_interpolate_empty_sequences,
@@ -1064,5 +1063,3 @@ class SnowflakeTypeCompiler(compiler.GenericTypeCompiler):
 
 
 construct_arguments = [(Table, {"clusterby": None})]
-
-functions.register_function("flatten", flatten)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What issue is this PR addressing?

   When loading `snowflake-sqlalchemy==1.6.1` a warning is emitted about the `flatten` function being registered multiple times. It causes confusion as it's we had to check that our code wasn't overriding the function, while in reality it's `snowflake-sqlalchemy` registering it twice. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  As noted in [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.GenericFunction):
  > Subclasses of [GenericFunction](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.GenericFunction) are automatically registered under the name of the class.
  
  Which in this case means that current code is registering the function twice - once on class import time and another by explicitly calling `register_function`. This PR removes the explicit registration and pushes the class import to be executed immediately when importing the library.
