### PR TITLE
fix: Use the correct NullType.

### DIFF
--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -578,7 +578,7 @@ class SnowflakeDialect(default.DefaultDialect):
                 sa_util.warn(
                     f"Did not recognize type '{coltype}' of column '{column_name}'"
                 )
-                col_type = sqltypes.NULLTYPE
+                col_type = sqltypes.NullType
             else:
                 if issubclass(col_type, FLOAT):
                     col_type_kw["precision"] = numeric_precision


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   It seemed silly to create an issue for something that's not typically a practical problem. But if this line is hit as is, you get
   
   ```
    >           type_instance = col_type(**col_type_kw)
    E           TypeError: 'NullType' object is not callable
   ```

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The originally referenced NULLTYPE is already an instance of `NullType`, so when the code goes to instantiate it, it fails. I imagine this code path is not currently tested then...

but it's not obvious to me how to go about adding any tests that depend on the connection like this function. Or at the very least, writing such a test without your test infrastructure would seem to be challenging.