### PR TITLE
Added flag to allow override SnowflakeDialect div_is_floor_div flag

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at:
 # Release Notes
 - (Unreleased)
   - Fix return value of snowflake get_table_names
+  - Fix flag `div_is_floordiv` to `False` in `SnowflakeDialect` to avoid division wrong CAST when trying to do a integer division when using `/`
 
 - v1.7.2(December 18, 2024)
   - Fix quoting of `_` as column name

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,7 +10,10 @@ Source code is also available at:
 # Release Notes
 - (Unreleased)
   - Fix return value of snowflake get_table_names
-  - Fix flag `div_is_floordiv` to `False` in `SnowflakeDialect` to avoid division wrong CAST when trying to do a integer division when using `/`
+  - Added `force_div_is_floordiv` flag to override `div_is_floordiv` new default value `False` in `SnowflakeDialect`.
+    - With the flag in `False`, the `/` division operator will be treated as a float division and `//` as a floor division.
+    - This flag is added to maintain backward compatibility with the previous behavior of Snowflake Dialect division.
+    - This flag will be removed in the future and Snowflake Dialect will use `div_is_floor_div` as `False`.
 
 - v1.7.2(December 18, 2024)
   - Fix quoting of `_` as column name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,11 @@ extra-dependencies = ["SQLAlchemy>=1.4.19,<2.0.0"]
 features = ["development", "pandas"]
 python = "3.8"
 
+[tool.hatch.envs.sa14.scripts]
+test-dialect = "pytest --ignore_v20_test -ra -vvv --tb=short --cov snowflake.sqlalchemy --cov-append --junitxml ./junit.xml --ignore=tests/sqlalchemy_test_suite tests/"
+test-dialect-compatibility = "pytest --ignore_v20_test -ra -vvv --tb=short --cov snowflake.sqlalchemy --cov-append --junitxml ./junit.xml tests/sqlalchemy_test_suite"
+test-dialect-aws = "pytest --ignore_v20_test -m \"aws\" -ra -vvv --tb=short --cov snowflake.sqlalchemy --cov-append --junitxml ./junit.xml --ignore=tests/sqlalchemy_test_suite tests/"
+
 [tool.hatch.envs.default.env-vars]
 COVERAGE_FILE = "coverage.xml"
 SQLACHEMY_WARN_20 = "1"
@@ -134,4 +139,5 @@ markers = [
   "requires_external_volume: tests that needs a external volume to be executed",
   "external: tests that could but should only run on our external CI",
   "feature_max_lob_size: tests that could but should only run on our external CI",
+  "feature_v20: tests that could but should only run on SqlAlchemy v20",
 ]

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -148,7 +148,6 @@ class SnowflakeDialect(default.DefaultDialect):
 
     supports_identity_columns = True
 
-
     def __init__(
         self,
         force_div_is_floordiv: bool = True,

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -148,12 +148,20 @@ class SnowflakeDialect(default.DefaultDialect):
 
     supports_identity_columns = True
 
+
     def __init__(
         self,
+        force_div_is_floordiv: bool = True,
         isolation_level: Optional[str] = SnowflakeIsolationLevel.READ_COMMITTED.value,
         **kwargs: Any,
     ):
         super().__init__(isolation_level=isolation_level, **kwargs)
+        self.force_div_is_floordiv = force_div_is_floordiv
+        self.div_is_floordiv = force_div_is_floordiv
+
+    def initialize(self, connection):
+        super().initialize(connection)
+        self.div_is_floordiv = self.force_div_is_floordiv
 
     @classmethod
     def dbapi(cls):

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -79,6 +79,9 @@ class SnowflakeDialect(default.DefaultDialect):
     colspecs = colspecs
     ischema_names = ischema_names
 
+    # target database treats the / division operator as “floor division”
+    div_is_floordiv = False
+
     # all str types must be converted in Unicode
     convert_unicode = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,26 @@ snowflake.connector.connection.DEFAULT_CONFIGURATION[
 TEST_SCHEMA = f"sqlalchemy_tests_{str(uuid.uuid4()).replace('-', '_')}"
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--ignore_v20_test",
+        action="store_true",
+        default=False,
+        help="skip sqlalchemy 2.0 exclusive tests",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--ignore_v20_test"):
+        # --ignore_v20_test given in cli: skip sqlalchemy 2.0 tests
+        skip_feature_v2 = pytest.mark.skip(
+            reason="need remove --ignore_v20_test option to run"
+        )
+        for item in items:
+            if "feature_v20" in item.keywords:
+                item.add_marker(skip_feature_v2)
+
+
 @pytest.fixture(scope="session")
 def on_travis():
     return os.getenv("TRAVIS", "").lower() == "true"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -139,6 +139,7 @@ def test_outer_lateral_join():
     )
 
 
+@pytest.mark.feature_v20
 def test_division_operator_with_force_div_is_floordiv_false():
     col1 = column("col1", Integer)
     col2 = column("col2", Integer)
@@ -149,6 +150,7 @@ def test_division_operator_with_force_div_is_floordiv_false():
     )
 
 
+@pytest.mark.feature_v20
 def test_division_operator_with_denominator_expr_force_div_is_floordiv_false():
     col1 = column("col1", Integer)
     col2 = column("col2", Integer)
@@ -159,23 +161,20 @@ def test_division_operator_with_denominator_expr_force_div_is_floordiv_false():
     )
 
 
+@pytest.mark.feature_v20
 def test_division_operator_with_force_div_is_floordiv_default_true():
     col1 = column("col1", Integer)
     col2 = column("col2", Integer)
     stmt = col1 / col2
-    assert (
-        str(stmt.compile(dialect=SnowflakeDialect())) == "col1 / CAST(col2 AS NUMERIC)"
-    )
+    assert str(stmt.compile(dialect=SnowflakeDialect())) == "col1 / col2"
 
 
+@pytest.mark.feature_v20
 def test_division_operator_with_denominator_expr_force_div_is_floordiv_default_true():
     col1 = column("col1", Integer)
     col2 = column("col2", Integer)
     stmt = col1 / func.sqrt(col2)
-    assert (
-        str(stmt.compile(dialect=SnowflakeDialect()))
-        == "col1 / CAST(sqrt(col2) AS NUMERIC)"
-    )
+    assert str(stmt.compile(dialect=SnowflakeDialect())) == "col1 / sqrt(col2)"
 
 
 @pytest.mark.feature_v20

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -135,3 +135,33 @@ def test_outer_lateral_join():
         str(stmt.compile(dialect=snowdialect.dialect()))
         == "SELECT colname AS label \nFROM abc JOIN LATERAL flatten(PARSE_JSON(colname2)) AS anon_1 GROUP BY colname"
     )
+
+
+def test_division_operator():
+    col1 = column("col1")
+    col2 = column("col2")
+    stmt = col1 / col2
+    assert str(stmt.compile(dialect=snowdialect.dialect())) == "col1 / col2"
+
+
+def test_division_operator_with_denominator_expr():
+    col1 = column("col1")
+    col2 = column("col2")
+    stmt = col1 / func.sqrt(col2)
+    assert str(stmt.compile(dialect=snowdialect.dialect())) == "col1 / sqrt(col2)"
+
+
+def test_floor_division_operator():
+    col1 = column("col1")
+    col2 = column("col2")
+    stmt = col1 // col2
+    assert str(stmt.compile(dialect=snowdialect.dialect())) == "FLOOR(col1 / col2)"
+
+
+def test_floor_division_operator_with_denominator_expr():
+    col1 = column("col1")
+    col2 = column("col2")
+    stmt = col1 // func.sqrt(col2)
+    assert (
+        str(stmt.compile(dialect=snowdialect.dialect())) == "FLOOR(col1 / sqrt(col2))"
+    )

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -2,12 +2,14 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import pytest
 from sqlalchemy import Integer, String, and_, func, insert, select
 from sqlalchemy.schema import DropColumnComment, DropTableComment
 from sqlalchemy.sql import column, quoted_name, table
 from sqlalchemy.testing.assertions import AssertsCompiledSQL
 
 from snowflake.sqlalchemy import snowdialect
+from src.snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 
 table1 = table(
     "table1", column("id", Integer), column("name", String), column("value", Integer)
@@ -137,31 +139,79 @@ def test_outer_lateral_join():
     )
 
 
-def test_division_operator():
-    col1 = column("col1")
-    col2 = column("col2")
+def test_division_operator_with_force_div_is_floordiv_false():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
     stmt = col1 / col2
-    assert str(stmt.compile(dialect=snowdialect.dialect())) == "col1 / col2"
+    assert (
+        str(stmt.compile(dialect=SnowflakeDialect(force_div_is_floordiv=False)))
+        == "col1 / col2"
+    )
 
 
-def test_division_operator_with_denominator_expr():
-    col1 = column("col1")
-    col2 = column("col2")
+def test_division_operator_with_denominator_expr_force_div_is_floordiv_false():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
     stmt = col1 / func.sqrt(col2)
-    assert str(stmt.compile(dialect=snowdialect.dialect())) == "col1 / sqrt(col2)"
+    assert (
+        str(stmt.compile(dialect=SnowflakeDialect(force_div_is_floordiv=False)))
+        == "col1 / sqrt(col2)"
+    )
 
 
-def test_floor_division_operator():
-    col1 = column("col1")
-    col2 = column("col2")
+def test_division_operator_with_force_div_is_floordiv_default_true():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
+    stmt = col1 / col2
+    assert (
+        str(stmt.compile(dialect=SnowflakeDialect())) == "col1 / CAST(col2 AS NUMERIC)"
+    )
+
+
+def test_division_operator_with_denominator_expr_force_div_is_floordiv_default_true():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
+    stmt = col1 / func.sqrt(col2)
+    assert (
+        str(stmt.compile(dialect=SnowflakeDialect()))
+        == "col1 / CAST(sqrt(col2) AS NUMERIC)"
+    )
+
+
+@pytest.mark.feature_v20
+def test_floor_division_operator_force_div_is_floordiv_false():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
     stmt = col1 // col2
-    assert str(stmt.compile(dialect=snowdialect.dialect())) == "FLOOR(col1 / col2)"
+    assert (
+        str(stmt.compile(dialect=SnowflakeDialect(force_div_is_floordiv=False)))
+        == "FLOOR(col1 / col2)"
+    )
 
 
-def test_floor_division_operator_with_denominator_expr():
-    col1 = column("col1")
-    col2 = column("col2")
+@pytest.mark.feature_v20
+def test_floor_division_operator_with_denominator_expr_force_div_is_floordiv_false():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
     stmt = col1 // func.sqrt(col2)
     assert (
-        str(stmt.compile(dialect=snowdialect.dialect())) == "FLOOR(col1 / sqrt(col2))"
+        str(stmt.compile(dialect=SnowflakeDialect(force_div_is_floordiv=False)))
+        == "FLOOR(col1 / sqrt(col2))"
     )
+
+
+@pytest.mark.feature_v20
+def test_floor_division_operator_force_div_is_floordiv_default_true():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
+    stmt = col1 // col2
+    assert str(stmt.compile(dialect=SnowflakeDialect())) == "col1 / col2"
+
+
+@pytest.mark.feature_v20
+def test_floor_division_operator_with_denominator_expr_force_div_is_floordiv_default_true():
+    col1 = column("col1", Integer)
+    col2 = column("col2", Integer)
+    stmt = col1 // func.sqrt(col2)
+    res = stmt.compile(dialect=SnowflakeDialect())
+    assert str(res) == "FLOOR(col1 / sqrt(col2))"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #543 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The default behavior of the flag div_is_floor_div was changed to False. This ensures that Python and Snowflake operators match the right division. In this first version a flag would be added `force_div_is_floor_div` to override the current behavior.
