### PR TITLE
#570 - Add structured type support for hybrid tables

### DIFF
--- a/src/snowflake/sqlalchemy/sql/custom_schema/hybrid_table.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/hybrid_table.py
@@ -32,6 +32,7 @@ class HybridTable(CustomTableBase):
 
     __table_prefixes__ = [CustomTablePrefix.HYBRID]
     _enforce_primary_keys: bool = True
+    _support_structured_types = True
 
     def __init__(
         self,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #570 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   #570 already describes the complete issue. As described there, currently `HybridTable` inherits from `CustomTableBase` which 
   sets `_support_structured_types = False`. However, `HybridTable` does not override this class variable, hence when trying to deploy a new array column snowflake-sqlalchemy will throw an error that structured data types are not supported on HybridTables. That latter claim is not true as they are supported, as long as they are not part of a constraint or index. Hence, this PR simply overrides the class variable on `HybridTable` (i.e. sets `_support_structured_types = True` to be more in line with the [Snowflake Documentation](https://docs.snowflake.com/user-guide/tables-hybrid-limitations#limitations)).

If more checks are needed (e.g. perform checks on whether the field occurs in an index or PK) feel free to add those, or make suggestions for them. My time is fairly limited to work on that.