### PR TITLE
Getting values for specific columns instead of trying to fetch all co…

### DIFF
--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -654,21 +654,13 @@ class SnowflakeDialect(default.DefaultDialect):
                 f" TABLE {table_schema}.{table_name} TYPE = COLUMNS"
             )
         )
-        for (
-            column_name,
-            coltype,
-            _kind,
-            is_nullable,
-            column_default,
-            primary_key,
-            _unique_key,
-            _check,
-            _expression,
-            comment,
-            _policy_name,
-            _privacy_domain,
-            _name_mapping,
-        ) in result:
+        for desc_data in result:
+            column_name = desc_data[0]
+            coltype = desc_data[1]
+            is_nullable = desc_data[3]
+            column_default = desc_data[4]
+            primary_key = desc_data[5]
+            comment = desc_data[9]
 
             column_name = self.normalize_name(column_name)
             if column_name.startswith("sys_clustering_column"):


### PR DESCRIPTION
…lumns.

Trying to get all columns generates errors when parameters enable extra columns for describe table command.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2128660
2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously, the code was trying to fetch all columns for a table, which generated errors when parameters enabled extra columns for the describe table command.  New code gets the values by index for needed columns only