### PR TITLE
Fixing exception while getting info for StructuredType columns.

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,7 +7,7 @@ Snowflake Documentation is available at:
 Source code is also available at:
 <https://github.com/snowflakedb/snowflake-sqlalchemy>
 # Unreleased Notes
-
+- Fix exception for structured type columns dropped while collecting meetadata
 # Release Notes
 - v1.7.6(July 10, 2025)
   - Fix get_multi_indexes issue, wrong assign of returned indexes when processing multiple indexes in a table

--- a/src/snowflake/sqlalchemy/name_utils.py
+++ b/src/snowflake/sqlalchemy/name_utils.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+
+from sqlalchemy.sql.compiler import IdentifierPreparer
+from sqlalchemy.sql.elements import quoted_name
+
+
+class _NameUtils:
+
+    def __init__(self, identifier_preparer: IdentifierPreparer):
+        self.identifier_preparer = identifier_preparer
+
+    def normalize_name(self, name):
+        if name is None:
+            return None
+        if name == "":
+            return ""
+        if name.upper() == name and not self.identifier_preparer._requires_quotes(
+            name.lower()
+        ):
+            return name.lower()
+        elif name.lower() == name:
+            return quoted_name(name, quote=True)
+        else:
+            return name
+
+    def denormalize_name(self, name):
+        if name is None:
+            return None
+        if name == "":
+            return ""
+        elif name.lower() == name and not self.identifier_preparer._requires_quotes(
+            name.lower()
+        ):
+            name = name.upper()
+        return name

--- a/src/snowflake/sqlalchemy/name_utils.py
+++ b/src/snowflake/sqlalchemy/name_utils.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql.elements import quoted_name
 
 class _NameUtils:
 
-    def __init__(self, identifier_preparer: IdentifierPreparer):
+    def __init__(self, identifier_preparer: IdentifierPreparer) -> None:
         self.identifier_preparer = identifier_preparer
 
     def normalize_name(self, name):

--- a/src/snowflake/sqlalchemy/parser/custom_type_parser.py
+++ b/src/snowflake/sqlalchemy/parser/custom_type_parser.py
@@ -2,9 +2,8 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 from typing import List
 
-import sqlalchemy.types as sqltypes
-from sqlalchemy.sql.type_api import TypeEngine
-from sqlalchemy.types import (
+import sqlalchemy.sql.sqltypes as sqltypes
+from sqlalchemy.sql.sqltypes import (
     BIGINT,
     BINARY,
     BOOLEAN,
@@ -21,6 +20,7 @@ from sqlalchemy.types import (
     VARCHAR,
     NullType,
 )
+from sqlalchemy.sql.type_api import TypeEngine
 
 from ..custom_types import (
     _CUSTOM_DECIMAL,

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -481,7 +481,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
         schema_name = self.denormalize_name(schema)
 
-        result = self._query_all_columns_info(connection, schema_name)
+        result = self._query_all_columns_info(connection, schema_name, **kw)
 
         current_database, default_schema = self._current_database_schema(
             connection, **kw
@@ -600,7 +600,8 @@ class SnowflakeDialect(default.DefaultDialect):
                 prefixes_found.append(valid_prefix.name)
         return prefixes_found
 
-    def _query_all_columns_info(connection, schema_name):
+    @reflection.cache
+    def _query_all_columns_info(connection, schema_name, **kw):
         try:
             return connection.execute(
                 text(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -482,6 +482,8 @@ class SnowflakeDialect(default.DefaultDialect):
         schema_name = self.denormalize_name(schema)
 
         result = self._query_all_columns_info(connection, schema_name, **kw)
+        if result is None:
+            return None
 
         current_database, default_schema = self._current_database_schema(
             connection, **kw

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -481,7 +481,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
         schema_name = self.denormalize_name(schema)
 
-        result = self._get_all_columns_info(connection, schema_name)
+        result = self._query_all_columns_info(connection, schema_name)
 
         current_database, default_schema = self._current_database_schema(
             connection, **kw
@@ -600,7 +600,7 @@ class SnowflakeDialect(default.DefaultDialect):
                 prefixes_found.append(valid_prefix.name)
         return prefixes_found
 
-    def _get_all_columns_info(connection, schema_name):
+    def _query_all_columns_info(connection, schema_name):
         try:
             return connection.execute(
                 text(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -601,7 +601,7 @@ class SnowflakeDialect(default.DefaultDialect):
         return prefixes_found
 
     @reflection.cache
-    def _query_all_columns_info(connection, schema_name, **kw):
+    def _query_all_columns_info(self, connection, schema_name, **kw):
         try:
             return connection.execute(
                 text(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -555,7 +555,7 @@ class SnowflakeDialect(default.DefaultDialect):
                     col_type_kw["length"] = character_maximum_length
                 elif issubclass(col_type, StructuredType):
                     column_info = structured_type_info_manager.get_column_info(
-                        schema_name, table_name, column_name
+                        schema_name, table_name, column_name, **kw
                     )
                     if column_info:
                         ans[table_name].append(column_info)

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -57,16 +57,14 @@ class _StructuredTypeInfoManager:
             )
         return True
 
-    def _table_columns_as_dict(self, columns: list[dict]) -> dict:
+    def _table_columns_as_dict(self, columns: list) -> dict:
         result = {}
         for column in columns:
             result[column["name"]] = column
         return result
 
     @reflection.cache
-    def _get_table_columns(
-        self, table_name: str, schema: str = None, **kw
-    ) -> list[dict]:
+    def _get_table_columns(self, table_name: str, schema: str = None, **kw) -> list:
         """Get all columns in a table in a schema"""
         ans = []
 

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -24,7 +24,7 @@ class _StructuredTypeInfoManager:
         default_schema (str): The default schema to use when none is specified
     """
 
-    def __init__(self, connection, name_utils: _NameUtils, default_schema: str) -> None:
+    def __init__(self, connection, name_utils: _NameUtils, default_schema: str):
         self.connection = connection
         self.full_columns_descriptions = {}
         self.name_utils = name_utils
@@ -32,7 +32,7 @@ class _StructuredTypeInfoManager:
 
     def get_column_info(
         self, schema_name: str, table_name: str, column_name: str, **kw
-    ) -> dict:
+    ):
         self._load_structured_type_info(schema_name, table_name, **kw)
         if (
             (schema_name, table_name) in self.full_columns_descriptions
@@ -43,9 +43,7 @@ class _StructuredTypeInfoManager:
             ]
         return None
 
-    def _load_structured_type_info(
-        self, schema_name: str, table_name: str, **kw
-    ) -> bool:
+    def _load_structured_type_info(self, schema_name: str, table_name: str, **kw):
         """Get column information for a structured type"""
         if (schema_name, table_name) not in self.full_columns_descriptions:
 
@@ -59,14 +57,14 @@ class _StructuredTypeInfoManager:
             )
         return True
 
-    def _table_columns_as_dict(self, columns: list) -> dict:
+    def _table_columns_as_dict(self, columns: list):
         result = {}
         for column in columns:
             result[column["name"]] = column
         return result
 
     @reflection.cache
-    def _get_table_columns(self, table_name: str, schema: str = None, **kw) -> list:
+    def _get_table_columns(self, table_name: str, schema: str = None, **kw):
         """Get all columns in a table in a schema"""
         ans = []
 

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -29,7 +29,9 @@ class _StructuredTypeInfoManager:
         self.name_utils = name_utils
         self.default_schema = default_schema
 
-    def get_column_info(self, schema_name: str, table_name: str, column_name: str):
+    def get_column_info(
+        self, schema_name: str, table_name: str, column_name: str, **kwargs
+    ):
         self._load_structured_type_info(schema_name, table_name)
         if (
             (schema_name, table_name) in self.full_columns_descriptions

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -4,7 +4,6 @@
 import re
 
 from sqlalchemy import util as sa_util
-from sqlalchemy.engine import reflection
 from sqlalchemy.sql import text
 
 from snowflake.sqlalchemy.name_utils import _NameUtils
@@ -63,7 +62,6 @@ class _StructuredTypeInfoManager:
             result[column["name"]] = column
         return result
 
-    @reflection.cache
     def _get_table_columns(self, table_name: str, schema: str = None, **kw):
         """Get all columns in a table in a schema"""
         ans = []

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -29,10 +29,8 @@ class _StructuredTypeInfoManager:
         self.name_utils = name_utils
         self.default_schema = default_schema
 
-    def get_column_info(
-        self, schema_name: str, table_name: str, column_name: str, **kw
-    ):
-        self._load_structured_type_info(schema_name, table_name, **kw)
+    def get_column_info(self, schema_name: str, table_name: str, column_name: str):
+        self._load_structured_type_info(schema_name, table_name)
         if (
             (schema_name, table_name) in self.full_columns_descriptions
             and column_name in self.full_columns_descriptions[(schema_name, table_name)]
@@ -42,11 +40,11 @@ class _StructuredTypeInfoManager:
             ]
         return None
 
-    def _load_structured_type_info(self, schema_name: str, table_name: str, **kw):
+    def _load_structured_type_info(self, schema_name: str, table_name: str):
         """Get column information for a structured type"""
         if (schema_name, table_name) not in self.full_columns_descriptions:
 
-            column_definitions = self._get_table_columns(table_name, schema_name, **kw)
+            column_definitions = self.get_table_columns(table_name, schema_name)
             if not column_definitions:
                 self.full_columns_descriptions[(schema_name, table_name)] = {}
                 return False
@@ -62,7 +60,7 @@ class _StructuredTypeInfoManager:
             result[column["name"]] = column
         return result
 
-    def _get_table_columns(self, table_name: str, schema: str = None, **kw):
+    def get_table_columns(self, table_name: str, schema: str = None):
         """Get all columns in a table in a schema"""
         ans = []
 

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -31,9 +31,9 @@ class _StructuredTypeInfoManager:
         self.default_schema = default_schema
 
     def get_column_info(
-        self, schema_name: str, table_name: str, column_name: str
+        self, schema_name: str, table_name: str, column_name: str, **kw
     ) -> dict:
-        self._load_structured_type_info(schema_name, table_name)
+        self._load_structured_type_info(schema_name, table_name, **kw)
         if (
             (schema_name, table_name) in self.full_columns_descriptions
             and column_name in self.full_columns_descriptions[(schema_name, table_name)]
@@ -43,11 +43,13 @@ class _StructuredTypeInfoManager:
             ]
         return None
 
-    def _load_structured_type_info(self, schema_name: str, table_name: str) -> bool:
+    def _load_structured_type_info(
+        self, schema_name: str, table_name: str, **kw
+    ) -> bool:
         """Get column information for a structured type"""
         if (schema_name, table_name) not in self.full_columns_descriptions:
 
-            column_definitions = self._get_table_columns(table_name, schema_name)
+            column_definitions = self._get_table_columns(table_name, schema_name, **kw)
             if not column_definitions:
                 self.full_columns_descriptions[(schema_name, table_name)] = {}
                 return False

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -32,7 +32,7 @@ class _StructuredTypeInfoManager:
 
     def get_column_info(
         self, schema_name: str, table_name: str, column_name: str
-    ) -> dict | None:
+    ) -> dict:
         self._load_structured_type_info(schema_name, table_name)
         if (
             (schema_name, table_name) in self.full_columns_descriptions

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+
+import re
+
+from sqlalchemy import exc as sa_exc
+from sqlalchemy import util as sa_util
+from sqlalchemy.engine import reflection
+from sqlalchemy.sql import text
+
+from snowflake.sqlalchemy.name_utils import _NameUtils
+from snowflake.sqlalchemy.parser.custom_type_parser import NullType, parse_type
+
+
+class _StructuredTypeInfoManager:
+    """
+    Manager for handling structured type information in Snowflake tables.
+    This class is responsible for retrieving, caching, and providing
+    column information for structured types in Snowflake tables. It maintains
+    a cache of column descriptions to avoid repeated database queries.
+    Attributes:
+        connection: The database connection to use for queries
+        full_columns_descriptions (dict): Cache of column descriptions by schema and table
+        name_utils (_NameUtils): Utility for normalizing and denormalizing names
+        default_schema (str): The default schema to use when none is specified
+    """
+
+    def __init__(self, connection, name_utils: _NameUtils, default_schema: str):
+        self.connection = connection
+        self.full_columns_descriptions = {}
+        self.name_utils = name_utils
+        self.default_schema = default_schema
+
+    def get_column_info(self, schema_name, table_name, column_name):
+        self._load_structured_type_info(schema_name, table_name)
+        if (
+            (schema_name, table_name) in self.full_columns_descriptions
+            and column_name in self.full_columns_descriptions[(schema_name, table_name)]
+        ):
+            return self.full_columns_descriptions[(schema_name, table_name)][
+                column_name
+            ]
+        return None
+
+    def _load_structured_type_info(self, schema_name, table_name):
+        """Get column information for a structured type"""
+        if (schema_name, table_name) not in self.full_columns_descriptions:
+
+            column_definitions = self._get_table_columns(table_name, schema_name)
+            if not column_definitions:
+                self.full_columns_descriptions[(schema_name, table_name)] = {}
+                return False
+
+            self.full_columns_descriptions[(schema_name, table_name)] = (
+                self._table_columns_as_dict(column_definitions)
+            )
+        return True
+
+    def _table_columns_as_dict(self, columns):
+        result = {}
+        for column in columns:
+            result[column["name"]] = column
+        return result
+
+    @reflection.cache
+    def _get_table_columns(self, table_name, schema=None, **kw):
+        """Get all columns in a table in a schema"""
+        ans = []
+
+        schema = schema if schema else self.default_schema
+
+        table_schema = self.name_utils.denormalize_name(schema)
+        table_name = self.name_utils.denormalize_name(table_name)
+        result = self._execute_desc(table_schema, table_name)
+        if not result:
+            return []
+
+        for desc_data in result:
+            column_name = desc_data[0]
+            coltype = desc_data[1]
+            is_nullable = desc_data[3]
+            column_default = desc_data[4]
+            primary_key = desc_data[5]
+            comment = desc_data[9]
+
+            column_name = self.name_utils.normalize_name(column_name)
+            if column_name.startswith("sys_clustering_column"):
+                continue  # ignoring clustering column
+            type_instance = parse_type(coltype)
+            if isinstance(type_instance, NullType):
+                sa_util.warn(
+                    f"Did not recognize type '{coltype}' of column '{column_name}'"
+                )
+
+            identity = None
+            match = re.match(
+                r"IDENTITY START (?P<start>\d+) INCREMENT (?P<increment>\d+) (?P<order_type>ORDER|NOORDER)",
+                column_default if column_default else "",
+            )
+            if match:
+                identity = {
+                    "start": int(match.group("start")),
+                    "increment": int(match.group("increment")),
+                    "order_type": match.group("order_type"),
+                }
+            is_identity = identity is not None
+
+            ans.append(
+                {
+                    "name": column_name,
+                    "type": type_instance,
+                    "nullable": is_nullable == "Y",
+                    "default": None if is_identity else column_default,
+                    "autoincrement": is_identity,
+                    "comment": comment if comment != "" else None,
+                    "primary_key": primary_key == "Y",
+                }
+            )
+
+            if is_identity:
+                ans[-1]["identity"] = identity
+
+        # If we didn't find any columns for the table, the table doesn't exist.
+        if len(ans) == 0:
+            raise sa_exc.NoSuchTableError()
+        return ans
+
+    def _execute_desc(self, table_schema: str, table_name: str):
+        """Execute a DESC command handling a possible exception.
+        Exception can be caused by another session dropping the table while
+        once this process has started"""
+        try:
+            return self.connection.execute(
+                text(
+                    "DESC /* sqlalchemy:_get_schema_columns */"
+                    f" TABLE {table_schema}.{table_name} TYPE = COLUMNS"
+                )
+            )
+        except Exception:
+            return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,7 +239,7 @@ def assert_text_in_buf():
 
         assert occurrences == ocurrences_found, (
             f"Expected {occurrences} of {expected}, got {ocurrences_found} "
-            f"occurrences in {ocurrences_found}."
+            f"occurrences in {buflines}."
         )
         buf.flush()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,11 +232,14 @@ def assert_text_in_buf():
     def go(expected, occurrences=1):
         assert buf.buffer
         buflines = [rec.getMessage() for rec in buf.buffer]
+        ocurrences_found = 0
+        for line in buflines:
+            if line.find(expected) != -1:
+                ocurrences_found += 1
 
-        ocurrences_found = buflines.count(expected)
         assert occurrences == ocurrences_found, (
             f"Expected {occurrences} of {expected}, got {ocurrences_found} "
-            f"occurrences in {buflines}."
+            f"occurrences in {ocurrences_found}."
         )
         buf.flush()
 

--- a/tests/sqlalchemy_test_suite/test_suite_20.py
+++ b/tests/sqlalchemy_test_suite/test_suite_20.py
@@ -213,3 +213,15 @@ class BizarroCharacterTest(_BizarroCharacterTest):
     @testing.requires.foreign_key_constraint_reflection
     def test_fk_ref(self, connection, metadata, use_composite, tablename, columnname):
         super().test_fk_ref(connection, metadata, use_composite, tablename, columnname)
+
+    @column_names()
+    @table_names()
+    @testing.requires.identity_columns
+    def test_reflect_identity(self, connection, metadata, tablename, columnname):
+        super().test_reflect_identity(connection, metadata, tablename, columnname)
+
+    @column_names()
+    @table_names()
+    @testing.requires.comment_reflection
+    def test_reflect_comments(self, connection, metadata, tablename, columnname):
+        super().test_reflect_comments(connection, metadata, tablename, columnname)

--- a/tests/sqlalchemy_test_suite/test_suite_20.py
+++ b/tests/sqlalchemy_test_suite/test_suite_20.py
@@ -190,6 +190,14 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
 
 class BizarroCharacterTest(_BizarroCharacterTest):
 
+    def column_names_without_id():
+        return testing.combinations(
+            ("(3)",),
+            ("col%p",),
+            ("[brack]",),
+            argnames="columnname",
+        )
+
     def column_names():
         return testing.combinations(
             ("id",),
@@ -220,7 +228,7 @@ class BizarroCharacterTest(_BizarroCharacterTest):
     def test_reflect_identity(self, tablename, columnname, connection, metadata):
         super().test_reflect_identity(tablename, columnname, connection, metadata)
 
-    @column_names()
+    @column_names_without_id()
     @table_names()
     @testing.requires.comment_reflection
     def test_reflect_comments(self, tablename, columnname, connection, metadata):

--- a/tests/sqlalchemy_test_suite/test_suite_20.py
+++ b/tests/sqlalchemy_test_suite/test_suite_20.py
@@ -6,9 +6,7 @@ from sqlalchemy import Integer, testing
 from sqlalchemy.schema import Column, Sequence, Table
 from sqlalchemy.testing import config
 from sqlalchemy.testing.assertions import eq_
-from sqlalchemy.testing.suite import (
-    BizarroCharacterFKResolutionTest as _BizarroCharacterFKResolutionTest,
-)
+from sqlalchemy.testing.suite import BizarroCharacterTest as _BizarroCharacterTest
 from sqlalchemy.testing.suite import (
     CompositeKeyReflectionTest as _CompositeKeyReflectionTest,
 )
@@ -190,7 +188,8 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
         super().test_pk_column_order()
 
 
-class BizarroCharacterFKResolutionTest(_BizarroCharacterFKResolutionTest):
+class BizarroCharacterTest(_BizarroCharacterTest):
+
     @testing.combinations(
         ("id",), ("(3)",), ("col%p",), ("[brack]",), argnames="columnname"
     )

--- a/tests/sqlalchemy_test_suite/test_suite_20.py
+++ b/tests/sqlalchemy_test_suite/test_suite_20.py
@@ -190,15 +190,23 @@ class CompositeKeyReflectionTest(_CompositeKeyReflectionTest):
 
 class BizarroCharacterTest(_BizarroCharacterTest):
 
-    @testing.combinations(
-        ("id",), ("(3)",), ("col%p",), ("[brack]",), argnames="columnname"
-    )
+    def column_names():
+        return testing.combinations(
+            ("id",),
+            ("(3)",),
+            ("col%p",),
+            ("[brack]",),
+            argnames="columnname",
+        )
+
+    def table_names():
+        return testing.combinations(
+            ("plain",),
+            ("(2)",),
+            ("[brackets]",),
+            argnames="tablename",
+        )
+
     @testing.variation("use_composite", [True, False])
-    @testing.combinations(
-        ("plain",),
-        ("(2)",),
-        ("[brackets]",),
-        argnames="tablename",
-    )
     def test_fk_ref(self, connection, metadata, use_composite, tablename, columnname):
         super().test_fk_ref(connection, metadata, use_composite, tablename, columnname)

--- a/tests/sqlalchemy_test_suite/test_suite_20.py
+++ b/tests/sqlalchemy_test_suite/test_suite_20.py
@@ -217,11 +217,11 @@ class BizarroCharacterTest(_BizarroCharacterTest):
     @column_names()
     @table_names()
     @testing.requires.identity_columns
-    def test_reflect_identity(self, connection, metadata, tablename, columnname):
-        super().test_reflect_identity(connection, metadata, tablename, columnname)
+    def test_reflect_identity(self, tablename, columnname, connection, metadata):
+        super().test_reflect_identity(tablename, columnname, connection, metadata)
 
     @column_names()
     @table_names()
     @testing.requires.comment_reflection
-    def test_reflect_comments(self, connection, metadata, tablename, columnname):
-        super().test_reflect_comments(connection, metadata, tablename, columnname)
+    def test_reflect_comments(self, tablename, columnname, connection, metadata):
+        super().test_reflect_comments(tablename, columnname, connection, metadata)

--- a/tests/sqlalchemy_test_suite/test_suite_20.py
+++ b/tests/sqlalchemy_test_suite/test_suite_20.py
@@ -208,5 +208,8 @@ class BizarroCharacterTest(_BizarroCharacterTest):
         )
 
     @testing.variation("use_composite", [True, False])
+    @column_names()
+    @table_names()
+    @testing.requires.foreign_key_constraint_reflection
     def test_fk_ref(self, connection, metadata, use_composite, tablename, columnname):
         super().test_fk_ref(connection, metadata, use_composite, tablename, columnname)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1576,7 +1576,7 @@ def test_too_many_columns_detection(engine_testaccount, db_parameters):
     with patch.object(engine_testaccount, "connect") as conn:
         conn.return_value = connection
         with patch.object(
-            inspector.dialect, "_get_all_columns_info", side_effect=mock_helper
+            inspector.dialect, "_query_all_columns_info", side_effect=mock_helper
         ):
             with pytest.raises(Exception) as exception:
                 print(exception)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -148,8 +148,9 @@ def test_begin_autocommit(engine_testaccount, assert_text_in_buf):
             s = select(test_table_1)
             results = conn.execute(s).fetchall()
             assert len(results) == 1, results
+
             assert_text_in_buf(
-                "COMMIT using DBAPI connection.commit(), DBAPI should ignore due to autocommit mode",
+                "COMMIT using DBAPI connection.commit()",
                 occurrences=1,
             )
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -110,7 +110,7 @@ def test_connect_autocommit(engine_testaccount, assert_text_in_buf):
             results = conn.execute(s).fetchall()
             assert len(results) == 1, results
             assert_text_in_buf(
-                "ROLLBACK using DBAPI connection.rollback(), DBAPI should ignore due to autocommit mode",
+                "ROLLBACK using DBAPI connection.rollback()",
                 occurrences=1,
             )
 


### PR DESCRIPTION
Map and Array type information is not stored in information_schema.columns table, so it is required to execute a DESC command for tables with structured types. If table is drop once SELECT on columns table but before executing DESC an exception is raised. Fix basically consists in caching the exception and ignoring the table because it does not exists anymore
Additionally updated test cases broken from a SQLAlchemy update.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes JIRA #606

2. Fill out the following pre-review checklist:

   - [ X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Refactor the code to extract all logic related to finding out the StructuredType column information.  Adding exception handling to the DESC TABLE command execution