### PR TITLE
Add support for autoincrement in ORM

### DIFF
--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -14,7 +14,7 @@ from sqlalchemy import (
     inspect,
     select,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+from sqlalchemy.orm import Mapped, Session, declarative_base, mapped_column
 from sqlalchemy.orm.exc import FlushError
 from sqlalchemy.sql import text
 from sqlalchemy.sql.ddl import CreateTable
@@ -152,8 +152,7 @@ def test_orm_autoincrement_without_snowflake_table_fails(engine_testaccount):
     auto-generated primary key after INSERT, resulting in a FlushError.
     """
 
-    class Base(DeclarativeBase):
-        pass
+    Base = declarative_base()
 
     class User(Base):
         __tablename__ = "test_orm_autoincrement_no_sf_table"
@@ -180,8 +179,7 @@ def test_orm_autoincrement_with_snowflake_table(engine_testaccount):
     This works around the lack of INSERT ... RETURNING support in Snowflake.
     """
 
-    class Base(DeclarativeBase):
-        pass
+    Base = declarative_base()
 
     class User(Base):
         __tablename__ = "test_orm_autoincrement"

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -14,7 +14,7 @@ from sqlalchemy import (
     inspect,
     select,
 )
-from sqlalchemy.orm import Mapped, Session, declarative_base, mapped_column
+from sqlalchemy.orm import Session, declarative_base
 from sqlalchemy.orm.exc import FlushError
 from sqlalchemy.sql import text
 from sqlalchemy.sql.ddl import CreateTable
@@ -157,8 +157,8 @@ def test_orm_autoincrement_without_snowflake_table_fails(engine_testaccount):
     class User(Base):
         __tablename__ = "test_orm_autoincrement_no_sf_table"
 
-        id: Mapped[int] = mapped_column(primary_key=True)
-        name: Mapped[str] = mapped_column()
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
 
     try:
         Base.metadata.create_all(engine_testaccount)
@@ -184,8 +184,8 @@ def test_orm_autoincrement_with_snowflake_table(engine_testaccount):
     class User(Base):
         __tablename__ = "test_orm_autoincrement"
 
-        id: Mapped[int] = mapped_column(primary_key=True)
-        name: Mapped[str] = mapped_column()
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
 
         @classmethod
         def __table_cls__(cls, name, metadata, *arg, **kw):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #611

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously, autoincrement was only available when using SQLAlchemy Core. With implicit sequence support, autoincrement now also works for the SnowflakeTable ORM mapping.