### PR TITLE
Snow 893080 feat bulk save base model

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Add `SnowflakeBase`, `snowflake_declarative_base()`, and `SnowflakeSession` to enable efficient bulk inserts for ORM models with nullable optional columns (SNOW-893080, [#441](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/441)). When `session.bulk_save_objects()` is used with models that have randomly populated nullable columns, SQLAlchemy normally groups objects by their set of non-None column keys, producing O(N) separate INSERT statements. `SnowflakeBase` / `snowflake_declarative_base()` pre-populate all plain-nullable columns at construction time, and `SnowflakeSession` passes `render_nulls=True` so all objects share the same parameter-key set and are batched into a single `executemany` INSERT.
 - Emit `SnowflakeWarning` at DDL compile time when `Identity()` is used on a primary key column, alerting users that ORM flush operations will raise a `FlushError`. The warning is emitted once per unique `(table, column)` pair per Python process. Use `Sequence()` instead.
 - Optimise reflection performance (SNOW-689531, [#656](https://github.com/snowflakedb/snowflake-sqlalchemy/pull/656)):
   - Add `get_multi_columns`, `get_multi_pk_constraint`, `get_multi_unique_constraints`, `get_multi_foreign_keys` for SQLAlchemy 2.x bulk reflection — each issues one schema-wide query per reflection pass instead of one query per table.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Table of contents:
     * [Alembic Support](#alembic-support)
     * [Key Pair Authentication Support](#key-pair-authentication-support)
     * [Merge Command Support](#merge-command-support)
+    * [Bulk Insert Optimization for ORM Models](#bulk-insert-optimization-for-orm-models)
     * [CopyIntoStorage Support](#copyintostorage-support)
     * [Iceberg Table with Snowflake Catalog support](#iceberg-table-with-snowflake-catalog-support)
     * [Hybrid Table support](#hybrid-table-support)
@@ -773,6 +774,90 @@ merge.when_matched_then_update().values(val=t2.c.newval)
 merge.when_not_matched_then_insert().values(val=t2.c.newval, status=t2.c.newstatus)
 connection.execute(merge)
 ```
+
+### Bulk Insert Optimization for ORM Models
+
+When using `Session.bulk_save_objects()` with models that have nullable optional
+columns, SQLAlchemy groups objects into separate INSERT batches based on each
+object's set of non-`None` column keys. If some objects were constructed without
+supplying every nullable column, they produce different key sets and SQLAlchemy
+emits O(N) INSERT statements instead of a single `executemany` batch.
+
+Snowflake SQLAlchemy provides two components that together solve this problem:
+
+- **`SnowflakeBase`** (SQLAlchemy 2.x only) — a `DeclarativeBase` subclass
+  whose constructor pre-populates every plain-nullable column with `None` (or
+  its scalar Python default) at construction time, so all instances share the
+  same column-key set regardless of which kwargs the caller supplied.
+- **`snowflake_declarative_base()`** — a factory function compatible with both
+  SQLAlchemy 1.4 and 2.x that produces a declarative base with the same
+  pre-population behaviour.
+- **`SnowflakeSession`** — a `Session` subclass that passes `render_nulls=True`
+  to the internal bulk-save call, preventing pre-populated `None` values from
+  being stripped before grouping. Must be used together with `SnowflakeBase` or
+  `snowflake_declarative_base()` for full effect.
+
+**SQLAlchemy 2.x example:**
+
+```python
+from sqlalchemy import Column, Integer, String, create_engine
+from snowflake.sqlalchemy import SnowflakeBase, SnowflakeSession
+
+class MyModel(SnowflakeBase):
+    __tablename__ = "my_model"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)       # nullable, no default
+    status = Column(String, default="active")  # scalar default
+
+engine = create_engine("snowflake://...")
+SnowflakeBase.metadata.create_all(engine)
+
+session = SnowflakeSession(bind=engine)
+# All objects share the same column-key set — emits a single executemany INSERT
+session.bulk_save_objects([
+    MyModel(id=1),
+    MyModel(id=2, name="foo"),
+    MyModel(id=3, status="inactive"),
+])
+session.commit()
+```
+
+**SQLAlchemy 1.4 and 2.x compatible example:**
+
+```python
+from sqlalchemy import Column, Integer, String, create_engine
+from snowflake.sqlalchemy import snowflake_declarative_base, SnowflakeSession
+
+Base = snowflake_declarative_base()
+
+class MyModel(Base):
+    __tablename__ = "my_model"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    status = Column(String, default="active")
+
+engine = create_engine("snowflake://...")
+Base.metadata.create_all(engine)
+
+session = SnowflakeSession(bind=engine)
+session.bulk_save_objects([
+    MyModel(id=1),
+    MyModel(id=2, name="foo"),
+])
+session.commit()
+```
+
+**Notes:**
+
+- `SnowflakeBase` is only available in SQLAlchemy 2.x. Use
+  `snowflake_declarative_base()` when your code must run on both SA 1.4 and 2.x.
+- Columns with `server_default`, callable Python defaults (`default=fn`), or
+  SQL-expression defaults (`default=func.now()`) are intentionally left absent
+  from pre-population. Objects that differ on such columns may still be placed in
+  separate INSERT batches — this is the same behaviour as stock SQLAlchemy.
+- `SnowflakeSession` alone (without the matching base class) is not sufficient:
+  the base class is required to unify the column-key sets before `SnowflakeSession`
+  can batch them together.
 
 ### CopyIntoStorage Support
 

--- a/src/snowflake/sqlalchemy/__init__.py
+++ b/src/snowflake/sqlalchemy/__init__.py
@@ -28,6 +28,7 @@ from sqlalchemy.types import (  # noqa
 )
 
 from . import base, snowdialect  # noqa
+from .compat import IS_VERSION_20
 from .custom_commands import (  # noqa
     AWSBucket,
     AzureContainer,
@@ -64,6 +65,7 @@ from .custom_types import (  # noqa
     VARIANT,
     VECTOR,
 )
+from .orm import SnowflakeSession, snowflake_declarative_base  # noqa
 from .sql.custom_schema import (  # noqa
     DynamicTable,
     HybridTable,
@@ -81,6 +83,10 @@ from .sql.custom_schema.options import (  # noqa
     TargetLagOption,
     TimeUnit,
 )
+
+if IS_VERSION_20:
+    from .orm import SnowflakeBase  # noqa
+
 from .util import _url as URL  # noqa
 
 base.dialect = dialect = snowdialect.dialect
@@ -157,10 +163,20 @@ _enums = (
     "TableOptionKey",
     "SnowflakeKeyword",
 )
+
+_orm = (
+    "SnowflakeSession",
+    "snowflake_declarative_base",
+)
+
+_orm_v20 = ("SnowflakeBase",) if IS_VERSION_20 else ()
+
 __all__ = (
     *_custom_types,
     *_custom_commands,
     *_custom_tables,
     *_custom_table_options,
     *_enums,
+    *_orm,
+    *_orm_v20,
 )

--- a/src/snowflake/sqlalchemy/orm.py
+++ b/src/snowflake/sqlalchemy/orm.py
@@ -1,0 +1,232 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+"""ORM utilities for efficient bulk inserts with Snowflake.
+
+This module provides two components that together solve the ``bulk_save_objects``
+batch-fragmentation problem (SNOW-893080, GitHub #441):
+
+**SnowflakeBase / snowflake_declarative_base**
+    A custom declarative base whose ``__init__`` pre-populates every mapped
+    column that has no server-side or callable default with its Python-level
+    scalar default (or ``None``).  This ensures that every model instance
+    always has the same set of column keys in its ``__dict__`` (the ORM
+    ``state_dict``), regardless of which kwargs the caller supplied.
+
+**SnowflakeSession**
+    A ``Session`` subclass that overrides ``bulk_save_objects`` to pass
+    ``render_nulls=True`` to ``_bulk_save_mappings``.  Without this flag,
+    SQLAlchemy strips ``None`` values from the parameter dict before grouping
+    rows into INSERT batches, so objects with ``col=None`` and objects with
+    ``col='hello'`` still produce different parameter-key sets and are emitted
+    as separate INSERT statements.
+
+Together, both parts are required: the base class normalises the key set, and
+the session override prevents the normalised ``None`` values from being stripped
+before grouping.
+
+Limitation
+----------
+Columns with ``server_default``, callable Python defaults (``default=fn``), or
+SQL-expression defaults (``default=func.now()``) are intentionally left absent
+from the pre-populated ``state_dict``.  If some objects supply an explicit value
+for such a column while others do not, those objects will still produce different
+parameter-key sets and may be placed in separate INSERT batches.  This is the
+same behaviour as stock SQLAlchemy and is not made worse by this module.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import Session, attributes
+
+from .compat import IS_VERSION_20
+
+
+def _snowflake_constructor(self, **kwargs):
+    """Custom ORM instance constructor that pre-populates mapped columns.
+
+    Mirrors SA's own ``mapper._insert_cols_as_none`` logic (SA 2.x
+    mapper.py L2764-2776; SA 1.4 mapper.py L2233-2249): primary keys,
+    server defaults, all client-side defaults (callable and
+    SQL-expression), and ``should_evaluate_none`` columns are intentionally
+    left absent from ``state_dict`` so that their normal SA handling is
+    preserved.
+
+    For all remaining mapped columns:
+    - columns with a scalar Python ``default`` are pre-populated with
+      that scalar value;
+    - columns with no default at all are pre-populated with ``None``.
+
+    This is intentionally called *after* SA's instrumented init so that
+    SA's event hooks run first.  User-supplied kwargs always take
+    precedence — we skip any column whose attribute key was already
+    present in ``kwargs``.
+    """
+    cls_ = type(self)
+
+    # Apply user-supplied kwargs first (mirrors _declarative_constructor).
+    for k, v in kwargs.items():
+        if not hasattr(cls_, k):
+            raise TypeError(f"{k!r} is an invalid keyword argument for {cls_.__name__}")
+        setattr(self, k, v)
+
+    # Pre-populate remaining column attributes.
+    # Follows the same exclusion logic as SA's mapper._insert_cols_as_none.
+    mapper = sa_inspect(cls_).mapper
+    for attr in mapper.column_attrs:
+        if attr.key in kwargs:
+            # User supplied a value — do not overwrite.
+            continue
+
+        col = attr.columns[0]
+
+        if col.primary_key:
+            # Leave absent: PKs are either user-supplied or DB-generated.
+            # Setting None would corrupt autoincrement PK handling and send
+            # an explicit NULL PK in the INSERT.
+            continue
+
+        if col.server_default is not None:
+            # Leave absent: server default must fire on the DB side.
+            # If we include an explicit NULL in the INSERT, SA's crud.py
+            # _scan_cols fires the "column IS in parameters" branch and
+            # sends NULL, overriding the server default entirely.
+            continue
+
+        if col.type.should_evaluate_none:
+            # Leave absent: JSON and similar types use should_evaluate_none=True
+            # to distinguish "store JSON null" from "omit the column".
+            continue
+
+        if col.default is not None:
+            if col.default.is_scalar:
+                # Pre-populate with the known Python literal so that all
+                # objects share this key in their state_dict.
+                setattr(self, attr.key, col.default.arg)
+            # else: callable or SQL-expression default — leave absent so SA
+            # invokes it with an ExecutionContext (or sequences) at INSERT time.
+        else:
+            # No default of any kind: pre-populate with None.
+            # render_nulls=True (in SnowflakeSession) then includes this
+            # column in every INSERT, unifying the parameter-key set.
+            setattr(self, attr.key, None)
+
+
+def snowflake_declarative_base(**kw):
+    """Create a declarative base with the Snowflake bulk-insert constructor.
+
+    Works with both SQLAlchemy 1.4 and 2.x.  The returned base class
+    installs ``_snowflake_constructor`` as ``__init__`` on every mapped
+    model, so that every instance pre-populates all plain-nullable columns
+    with ``None`` (or their scalar default) at construction time.
+
+    Use this together with :class:`SnowflakeSession` to enable single-batch
+    ``bulk_save_objects`` inserts for models with nullable optional columns.
+
+    Parameters
+    ----------
+    **kw:
+        Forwarded verbatim to ``sqlalchemy.orm.declarative_base()``.
+    """
+    from sqlalchemy.orm import declarative_base
+
+    return declarative_base(constructor=_snowflake_constructor, **kw)
+
+
+# SA 2.x only: class-based DeclarativeBase subclass.
+# SA 1.4 does not have DeclarativeBase so the class definition is guarded.
+if IS_VERSION_20:
+    from sqlalchemy.orm import DeclarativeBase
+
+    class SnowflakeBase(DeclarativeBase):
+        """Declarative base for Snowflake ORM models with efficient bulk inserts.
+
+        Subclass your models from ``SnowflakeBase`` (SQLAlchemy 2.x) instead
+        of the default ``DeclarativeBase`` to enable single-batch
+        ``bulk_save_objects`` behaviour.
+
+        Use together with :class:`SnowflakeSession`.
+
+        Example::
+
+            from snowflake.sqlalchemy import SnowflakeBase, SnowflakeSession
+
+            class MyModel(SnowflakeBase):
+                __tablename__ = "my_model"
+                id = Column(Integer, primary_key=True)
+                name = Column(String)   # nullable, no default
+
+            session = SnowflakeSession(bind=engine)
+            session.bulk_save_objects([MyModel(id=1), MyModel(id=2, name="foo")])
+            # Both objects go in a single INSERT (executemany).
+        """
+
+        def __init__(self, **kwargs):
+            _snowflake_constructor(self, **kwargs)
+
+
+class SnowflakeSession(Session):
+    """Session subclass enabling efficient bulk inserts.
+
+    Overrides :meth:`bulk_save_objects` to pass ``render_nulls=True`` to
+    the internal ``_bulk_save_mappings`` call.  This prevents ``None``
+    values that were pre-populated by ``_snowflake_constructor`` from being
+    stripped out of the INSERT parameter dict, so that all objects produce
+    the same parameter-key set and are placed in a single ``executemany``
+    INSERT batch.
+
+    Must be used together with :class:`SnowflakeBase` (SA 2.x) or
+    :func:`snowflake_declarative_base` (SA 1.4 / 2.x) for full effect.
+
+    SA version compatibility
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+    ``Session._bulk_save_mappings`` is called with keyword arguments, which
+    is valid for both SA 1.4 (positional-or-keyword) and SA 2.x
+    (keyword-only after ``*``).  Verified against SA 1.4.54 and SA 2.0.48.
+
+    Note: ``super().bulk_save_objects()`` hardcodes ``render_nulls=False``
+    with no override hook (SA 2.x session.py:4571; SA 1.4 equivalent).
+    This override replicates the ``itertools.groupby`` dispatch logic from
+    both SA versions to inject ``render_nulls=True``.
+    """
+
+    def bulk_save_objects(
+        self,
+        objects,
+        return_defaults=False,
+        update_changed_only=True,
+        preserve_order=True,
+    ):
+        """Bulk-save ORM objects using a single batched INSERT per mapper.
+
+        Identical to :meth:`sqlalchemy.orm.Session.bulk_save_objects` except
+        that ``render_nulls=True`` is passed to the underlying
+        ``_bulk_save_mappings`` call.  See the class docstring for details.
+        """
+        obj_states = (attributes.instance_state(obj) for obj in objects)
+
+        if not preserve_order:
+            # Group common mappers/persistence states together so that
+            # itertools.groupby yields one group per mapper type.
+            obj_states = sorted(
+                obj_states,
+                key=lambda state: (id(state.mapper), state.key is not None),
+            )
+
+        def grouping_key(state):
+            return (state.mapper, state.key is not None)
+
+        for (mapper, isupdate), states in itertools.groupby(obj_states, grouping_key):
+            self._bulk_save_mappings(
+                mapper,
+                states,
+                isupdate=isupdate,
+                isstates=True,
+                return_defaults=return_defaults,
+                update_changed_only=update_changed_only,
+                render_nulls=True,  # key difference from stock Session
+            )

--- a/tests/test_unit_orm.py
+++ b/tests/test_unit_orm.py
@@ -1,0 +1,421 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+"""Unit tests for SnowflakeBase, snowflake_declarative_base, and SnowflakeSession.
+
+No database connection required — these tests use in-memory SQLite.
+"""
+
+from unittest import mock
+
+import pytest
+from sqlalchemy import JSON, Column, Integer, String, func, text
+from sqlalchemy.orm import Session, declarative_base
+
+from snowflake.sqlalchemy.compat import IS_VERSION_20
+
+# ---------------------------------------------------------------------------
+# Helpers — model builders
+# ---------------------------------------------------------------------------
+
+
+def _make_model_for_base(base_cls, table_suffix=""):
+    """Return a mapped model class with a variety of column types."""
+
+    class MyModel(base_cls):
+        __tablename__ = f"my_model_sf{table_suffix}"
+
+        id = Column(Integer, primary_key=True)
+        # Plain nullable — should be pre-populated with None
+        name = Column(String)
+        # Server default — should NOT be pre-populated
+        created_at = Column(String, server_default=text("'now'"))
+        # Scalar Python default — should be pre-populated with the value
+        status = Column(String, default="active")
+        # Callable Python default — should NOT be pre-populated
+        token = Column(String, default=lambda: "generated")
+        # SQL-expression default — should NOT be pre-populated
+        ts = Column(String, default=func.now())
+        # JSON column (should_evaluate_none=True) — should NOT be pre-populated
+        metadata_json = Column("metadata_json", JSON)
+
+    return MyModel
+
+
+def _user_keys(d):
+    """Return state_dict keys that are not SA internals."""
+    return {k for k in d if not k.startswith("_sa")}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def snowflake_base():
+    """SnowflakeBase class (SA 2.x DeclarativeBase subclass)."""
+    from snowflake.sqlalchemy.orm import SnowflakeBase
+
+    return SnowflakeBase
+
+
+@pytest.fixture(scope="module")
+def sf_declarative_base():
+    """A base produced by snowflake_declarative_base()."""
+    from snowflake.sqlalchemy.orm import snowflake_declarative_base
+
+    return snowflake_declarative_base()
+
+
+@pytest.fixture(scope="module")
+def snowflake_session_cls():
+    """SnowflakeSession class."""
+    from snowflake.sqlalchemy.orm import SnowflakeSession
+
+    return SnowflakeSession
+
+
+# ---------------------------------------------------------------------------
+# Tests: SnowflakeBase constructor (SA 2.x class-based)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not IS_VERSION_20, reason="SnowflakeBase requires SQLAlchemy 2.x")
+class TestSnowflakeBaseConstructor:
+    """Verify _snowflake_constructor behaviour via SnowflakeBase."""
+
+    @pytest.fixture(scope="class")
+    def MyModel(self, snowflake_base):
+        return _make_model_for_base(snowflake_base, "_cls")
+
+    def test_plain_nullable_column_prepopulated_none(self, MyModel):
+        """Plain nullable column (no default) must be in state_dict as None."""
+        obj = MyModel(id=1)
+        assert "name" in obj.__dict__, "plain nullable column must be in state_dict"
+        assert obj.__dict__["name"] is None
+
+    def test_primary_key_not_prepopulated(self, MyModel):
+        """Primary key column must NOT be pre-populated with None."""
+        obj = MyModel()
+        assert "id" not in obj.__dict__, "PK column must be absent from state_dict"
+
+    def test_primary_key_user_value_preserved(self, MyModel):
+        """Primary key supplied by user must appear in state_dict."""
+        obj = MyModel(id=42)
+        assert obj.__dict__.get("id") == 42
+
+    def test_server_default_column_not_prepopulated(self, MyModel):
+        """server_default column must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert (
+            "created_at" not in obj.__dict__
+        ), "server_default column must be absent from state_dict"
+
+    def test_scalar_default_column_prepopulated_with_value(self, MyModel):
+        """Scalar Python default column must be pre-populated with the scalar value."""
+        obj = MyModel(id=1)
+        assert "status" in obj.__dict__, "scalar-default column must be in state_dict"
+        assert obj.__dict__["status"] == "active"
+
+    def test_callable_default_column_not_prepopulated(self, MyModel):
+        """Callable Python default column must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert (
+            "token" not in obj.__dict__
+        ), "callable-default column must be absent from state_dict"
+
+    def test_sql_expression_default_column_not_prepopulated(self, MyModel):
+        """SQL-expression default column must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert (
+            "ts" not in obj.__dict__
+        ), "sql-expression-default column must be absent from state_dict"
+
+    def test_should_evaluate_none_column_not_prepopulated(self, MyModel):
+        """Column with should_evaluate_none=True (e.g. JSON) must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert (
+            "metadata_json" not in obj.__dict__
+        ), "should_evaluate_none column must be absent from state_dict"
+
+    def test_user_supplied_server_default_column_preserved(self, MyModel):
+        """User-supplied value for a server_default column must be preserved."""
+        obj = MyModel(id=1, created_at="2025-01-01")
+        assert obj.__dict__["created_at"] == "2025-01-01"
+
+    def test_user_supplied_value_preserved(self, MyModel):
+        """User-supplied kwargs must appear in state_dict with the given value."""
+        obj = MyModel(id=1, name="hello")
+        assert obj.__dict__["name"] == "hello"
+
+    def test_user_supplied_overrides_scalar_default(self, MyModel):
+        """User value for scalar-default column must override the pre-populated default."""
+        obj = MyModel(id=1, status="pending")
+        assert obj.__dict__["status"] == "pending"
+
+    def test_invalid_kwarg_raises_type_error(self, MyModel):
+        """Unknown keyword arguments must raise TypeError."""
+        with pytest.raises(TypeError):
+            MyModel(id=1, nonexistent_column="value")
+
+    def test_all_objects_produce_same_state_dict_keys(self, MyModel):
+        """Objects with different nullable columns provided must share the same
+        state_dict key set — the core bulk-batching requirement."""
+        obj1 = MyModel(id=1)
+        obj2 = MyModel(id=2, name="foo")
+        obj3 = MyModel(id=3, status="inactive")
+
+        keys1 = _user_keys(obj1.__dict__)
+        keys2 = _user_keys(obj2.__dict__)
+        keys3 = _user_keys(obj3.__dict__)
+        assert keys1 == keys2 == keys3, (
+            f"All objects must have the same state_dict key set: "
+            f"{keys1} vs {keys2} vs {keys3}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: snowflake_declarative_base (function-based factory)
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeDeclarativeBase:
+    """Verify snowflake_declarative_base produces the same constructor behaviour."""
+
+    @pytest.fixture(scope="class")
+    def MyModel(self, sf_declarative_base):
+        return _make_model_for_base(sf_declarative_base, "_fn")
+
+    def test_plain_nullable_column_prepopulated_none(self, MyModel):
+        """Plain nullable column must be in state_dict as None."""
+        obj = MyModel(id=1)
+        assert "name" in obj.__dict__
+        assert obj.__dict__["name"] is None
+
+    def test_primary_key_not_prepopulated(self, MyModel):
+        """Primary key column must NOT be pre-populated."""
+        obj = MyModel()
+        assert "id" not in obj.__dict__
+
+    def test_server_default_column_not_prepopulated(self, MyModel):
+        """server_default column must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert "created_at" not in obj.__dict__
+
+    def test_scalar_default_column_prepopulated(self, MyModel):
+        """Scalar Python default must be pre-populated with the scalar value."""
+        obj = MyModel(id=1)
+        assert obj.__dict__.get("status") == "active"
+
+    def test_callable_default_not_prepopulated(self, MyModel):
+        """Callable default column must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert "token" not in obj.__dict__
+
+    def test_sql_expression_default_not_prepopulated(self, MyModel):
+        """SQL-expression default column must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert "ts" not in obj.__dict__
+
+    def test_should_evaluate_none_column_not_prepopulated(self, MyModel):
+        """Column with should_evaluate_none=True (e.g. JSON) must NOT be pre-populated."""
+        obj = MyModel(id=1)
+        assert "metadata_json" not in obj.__dict__
+
+    def test_all_objects_produce_same_state_dict_keys(self, MyModel):
+        """Core batching invariant: same key set regardless of provided kwargs."""
+        obj1 = MyModel(id=1)
+        obj2 = MyModel(id=2, name="bar")
+        assert _user_keys(obj1.__dict__) == _user_keys(obj2.__dict__)
+
+    def test_invalid_kwarg_raises_type_error(self, MyModel):
+        """Unknown keyword arguments must raise TypeError."""
+        with pytest.raises(TypeError):
+            MyModel(id=1, nonexistent_column="value")
+
+
+# ---------------------------------------------------------------------------
+# Tests: SnowflakeSession.bulk_save_objects calls _bulk_save_mappings with
+# render_nulls=True
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeSession:
+    """Verify SnowflakeSession overrides bulk_save_objects with render_nulls=True."""
+
+    def test_bulk_save_objects_passes_render_nulls_true(self, snowflake_session_cls):
+        """SnowflakeSession.bulk_save_objects must call _bulk_save_mappings
+        with render_nulls=True."""
+        from sqlalchemy import create_engine
+
+        engine = create_engine("sqlite:///:memory:")
+        Base = declarative_base()
+
+        class Item(Base):
+            __tablename__ = "item"
+
+            id = Column(Integer, primary_key=True)
+            name = Column(String)
+
+        Base.metadata.create_all(engine)
+
+        session = snowflake_session_cls(bind=engine)
+
+        render_nulls_values = []
+        original = session._bulk_save_mappings
+
+        def capturing(*args, **kwargs):
+            render_nulls_values.append(kwargs.get("render_nulls"))
+            return original(*args, **kwargs)
+
+        with mock.patch.object(session, "_bulk_save_mappings", side_effect=capturing):
+            session.bulk_save_objects([Item(id=1, name="a"), Item(id=2, name="b")])
+
+        assert render_nulls_values, "Expected at least one call to _bulk_save_mappings"
+        assert all(
+            v is True for v in render_nulls_values
+        ), f"All calls must use render_nulls=True, got: {render_nulls_values}"
+
+    def test_bulk_save_objects_signature_compatible(self, snowflake_session_cls):
+        """SnowflakeSession.bulk_save_objects must accept the same kwargs as
+        Session.bulk_save_objects."""
+        import inspect
+
+        sig = inspect.signature(snowflake_session_cls.bulk_save_objects)
+        params = set(sig.parameters.keys())
+        expected = {
+            "self",
+            "objects",
+            "return_defaults",
+            "update_changed_only",
+            "preserve_order",
+        }
+        assert expected.issubset(params), f"Missing params: {expected - params}"
+
+    def test_is_session_subclass(self, snowflake_session_cls):
+        """SnowflakeSession must be a subclass of sqlalchemy.orm.Session."""
+        assert issubclass(snowflake_session_cls, Session)
+
+
+# ---------------------------------------------------------------------------
+# Tests: SnowflakeBase + SnowflakeSession end-to-end (SA 2.x)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not IS_VERSION_20, reason="SnowflakeBase requires SQLAlchemy 2.x")
+class TestSnowflakeBaseWithSessionEndToEnd:
+    """Verify that SnowflakeBase + SnowflakeSession together produce uniform
+    parameter-key sets for bulk_save_objects, exercising the full pipeline."""
+
+    def test_all_objects_same_params_with_render_nulls(self, snowflake_session_cls):
+        """Objects with different nullable-column populations must all produce
+        the same parameter dict keys when passed through SnowflakeBase +
+        SnowflakeSession.bulk_save_objects."""
+        from sqlalchemy import create_engine
+
+        from snowflake.sqlalchemy.orm import SnowflakeBase
+
+        class Widget(SnowflakeBase):
+            __tablename__ = "widget_e2e"
+
+            id = Column(Integer, primary_key=True)
+            label = Column(String)
+            color = Column(String)
+
+        engine = create_engine("sqlite:///:memory:")
+        SnowflakeBase.metadata.create_all(engine)
+
+        session = snowflake_session_cls(bind=engine)
+
+        # Create objects with different columns supplied — all should have
+        # the same state_dict keys thanks to SnowflakeBase.
+        objs = [
+            Widget(id=1),
+            Widget(id=2, label="foo"),
+            Widget(id=3, color="red"),
+            Widget(id=4, label="bar", color="blue"),
+        ]
+
+        # Verify uniform key sets
+        key_sets = [_user_keys(o.__dict__) for o in objs]
+        assert all(
+            ks == key_sets[0] for ks in key_sets
+        ), f"Key sets differ across objects: {key_sets}"
+
+        # Capture render_nulls from _bulk_save_mappings calls
+        render_nulls_values = []
+        original = session._bulk_save_mappings
+
+        def capturing(*args, **kwargs):
+            render_nulls_values.append(kwargs.get("render_nulls"))
+            return original(*args, **kwargs)
+
+        with mock.patch.object(session, "_bulk_save_mappings", side_effect=capturing):
+            session.bulk_save_objects(objs)
+
+        assert render_nulls_values, "Expected _bulk_save_mappings to be called"
+        assert all(v is True for v in render_nulls_values)
+        # Only one call expected since all objects share the same mapper
+        assert (
+            len(render_nulls_values) == 1
+        ), f"Expected single _bulk_save_mappings call but got {len(render_nulls_values)}"
+
+    def test_bulk_save_objects_empty_list(self, snowflake_session_cls):
+        """Passing an empty list to bulk_save_objects must not raise."""
+        from sqlalchemy import create_engine
+
+        engine = create_engine("sqlite:///:memory:")
+        session = snowflake_session_cls(bind=engine)
+        # Should be a no-op
+        session.bulk_save_objects([])
+
+
+# ---------------------------------------------------------------------------
+# Tests: public exports from snowflake.sqlalchemy top-level package
+# ---------------------------------------------------------------------------
+
+
+class TestPublicExports:
+    """Verify SnowflakeBase, snowflake_declarative_base, and SnowflakeSession
+    are importable from snowflake.sqlalchemy."""
+
+    def test_snowflake_session_exported(self):
+        from snowflake.sqlalchemy import SnowflakeSession  # noqa: F401
+
+        assert SnowflakeSession is not None
+
+    def test_snowflake_declarative_base_exported(self):
+        from snowflake.sqlalchemy import snowflake_declarative_base  # noqa: F401
+
+        assert callable(snowflake_declarative_base)
+
+    @pytest.mark.skipif(
+        not IS_VERSION_20, reason="SnowflakeBase requires SQLAlchemy 2.x"
+    )
+    def test_snowflake_base_exported(self):
+        from snowflake.sqlalchemy import SnowflakeBase  # noqa: F401
+
+        assert SnowflakeBase is not None
+
+    @pytest.mark.skipif(
+        not IS_VERSION_20, reason="SnowflakeBase requires SQLAlchemy 2.x"
+    )
+    def test_snowflake_base_in_all(self):
+        """SnowflakeBase must be listed in __all__ on SA 2.x."""
+        import snowflake.sqlalchemy as sf
+
+        assert "SnowflakeBase" in sf.__all__
+
+    def test_snowflake_session_in_all(self):
+        """SnowflakeSession must be listed in __all__."""
+        import snowflake.sqlalchemy as sf
+
+        assert "SnowflakeSession" in sf.__all__
+
+    def test_snowflake_declarative_base_in_all(self):
+        """snowflake_declarative_base must be listed in __all__."""
+        import snowflake.sqlalchemy as sf
+
+        assert "snowflake_declarative_base" in sf.__all__


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #441 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Fixes #441.

  `session.bulk_save_objects()` emits O(N) `INSERT` statements when ORM models have randomly-populated nullable columns, because SQLAlchemy groups rows by their set of
  non-None parameter keys.

  How

  Two new components in `src/snowflake/sqlalchemy/orm.py`:

  - `SnowflakeBase` / `snowflake_declarative_base()` — declarative base whose `__init__` pre-populates every plain-nullable column with `None` (or its scalar default) so all instances share the same key set. Primary keys, server_default, callable, and SQL-expression defaults are excluded, mirroring SQLAlchemy's own `_insert_cols_as_none` logic.
  - `SnowflakeSession` — Session subclass that passes `render_nulls=True` to the internal bulk-save call, preventing pre-populated Nones from being stripped before grouping.

  Both parts are required. `SnowflakeBase` is SA 2.x only; `snowflake_declarative_base()` works on SA 1.4 and 2.x. All three names exported from snowflake.sqlalchemy.

  Tests

  Unit tests in `tests/test_unit_orm.py` (no database required) cover column pre-population rules, key-set uniformity, `render_nulls=True` call, and public exports.
