### PR TITLE
SNOW-893080: bulk_save_objects optimization

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Add `SnowflakeBase`, `SnowflakeSession`, and `mapper_uses_snowflake_bulk` (`snowflake.sqlalchemy.orm`) for ORM bulk INSERT tuning (SNOW-893080, [#441](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/441)). See [README.md](https://github.com/snowflakedb/snowflake-sqlalchemy/blob/main/README.md) — section **Bulk ORM inserts (`SnowflakeBase` and `SnowflakeSession`)**.
 - Emit `SnowflakeWarning` at DDL compile time when `Identity()` is used on a primary key column, alerting users that ORM flush operations will raise a `FlushError`. The warning is emitted once per unique `(table, column)` pair per Python process. Use `Sequence()` instead.
 - Optimise reflection performance (SNOW-689531, [#656](https://github.com/snowflakedb/snowflake-sqlalchemy/pull/656)):
   - Add `get_multi_columns`, `get_multi_pk_constraint`, `get_multi_unique_constraints`, `get_multi_foreign_keys` for SQLAlchemy 2.x bulk reflection — each issues one schema-wide query per reflection pass instead of one query per table.

--- a/README.md
+++ b/README.md
@@ -703,6 +703,54 @@ class SnowflakeImpl(DefaultImpl):
 
 See [Alembic Documentation](http://alembic.zzzcomputing.com/) for general usage.
 
+### Bulk ORM inserts (`SnowflakeBase` and `SnowflakeSession`)
+
+SQLAlchemy’s `Session.bulk_save_objects()` can emit many small `INSERT` statements when each row omits a different subset of nullable columns, because the driver batches rows that share the same rendered column list ([issue #441](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/441)). Snowflake SQLAlchemy provides an opt-in pair:
+
+- **`SnowflakeBase`** — declarative base (SQLAlchemy 2.x) or abstract mixin (1.4: `class Model(SnowflakeBase, YourBase):`) that marks mapped classes for bulk tuning.
+- **`SnowflakeSession`** — `Session` subclass that passes **`render_nulls=True`** into bulk **INSERT** paths for those classes so explicit ``None`` is sent as SQL ``NULL`` and executemany batching works for rows that already share the **same parameter keys**. You can also set **`__snowflake_sqlalchemy_bulk__ = True`** on a mapped class instead of inheriting `SnowflakeBase`.
+- **`mapper_uses_snowflake_bulk(mapper)`** — returns whether a class or mapper is opted in.
+
+Use a session factory bound to `SnowflakeSession`:
+
+```python
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from snowflake.sqlalchemy import SnowflakeBase, SnowflakeSession
+
+
+class Widget(SnowflakeBase):
+    __tablename__ = "widget"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    tag = Column(String, nullable=True)
+
+
+engine = create_engine("snowflake://...")
+Session = sessionmaker(class_=SnowflakeSession, bind=engine)
+
+with Session() as session:
+    session.bulk_save_objects(
+        [
+            Widget(id=1, name="a", tag=None),
+            # Same attribute keys on every row (use explicit ``None`` for “unset”
+            # optional columns) so SQLAlchemy can batch one INSERT.
+            Widget(id=2, name="b", tag=None),
+        ]
+    )
+    session.commit()
+```
+
+SQLAlchemy groups bulk rows by the **set of keys** each row carries (ORM instance `__dict__` / state, or mapping dict keys). **Omitting** an optional column on one row and setting it on another still produces **different INSERT shapes**, even with `SnowflakeSession`, until every row exposes the **same keys** (typically by passing **`None`** for “missing” optional fields). With uniform keys, **`render_nulls=True`** (what `SnowflakeSession` enables for opted-in mappers) keeps explicit `NULL`s in the statement so executemany batching works as intended.
+
+For **`bulk_insert_mappings`**, omitting the `render_nulls` argument on `SnowflakeSession` defaults it to **`True`** for opted-in mappers and **`False`** otherwise. Pass `render_nulls=True` or `False` explicitly to override. Use the **same keys in every mapping dict** (include `None` for absent optional values) if you need a single INSERT batch.
+
+**Important limitations (from SQLAlchemy bulk semantics):**
+
+- With **`render_nulls=True`**, columns inserted as **explicit `NULL` do not invoke server-side SQL defaults** on those columns. If you rely on `server_default` for a nullable column, either use the normal unit-of-work `add()` / flush path for those rows or set the value in Python.
+- Bulk APIs skip most ORM events and relationship handling; see the [SQLAlchemy bulk operations](https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#orm-bulk-insert-statements) documentation.
+
 ### Key Pair Authentication Support
 
 Snowflake SQLAlchemy supports key pair authentication by leveraging its Snowflake Connector for Python underpinnings. See [Using Key Pair Authentication](https://docs.snowflake.net/manuals/user-guide/python-connector-example.html#using-key-pair-authentication) for steps to create the private and public keys.

--- a/src/snowflake/sqlalchemy/__init__.py
+++ b/src/snowflake/sqlalchemy/__init__.py
@@ -64,6 +64,7 @@ from .custom_types import (  # noqa
     VARIANT,
     VECTOR,
 )
+from .orm import SnowflakeBase, SnowflakeSession, mapper_uses_snowflake_bulk  # noqa
 from .sql.custom_schema import (  # noqa
     DynamicTable,
     HybridTable,
@@ -157,10 +158,16 @@ _enums = (
     "TableOptionKey",
     "SnowflakeKeyword",
 )
+_orm = (
+    "SnowflakeBase",
+    "SnowflakeSession",
+    "mapper_uses_snowflake_bulk",
+)
 __all__ = (
     *_custom_types,
     *_custom_commands,
     *_custom_tables,
     *_custom_table_options,
     *_enums,
+    *_orm,
 )

--- a/src/snowflake/sqlalchemy/orm.py
+++ b/src/snowflake/sqlalchemy/orm.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+from __future__ import annotations
+
+import itertools
+from typing import Any, Iterable
+
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.base import _class_to_mapper
+from sqlalchemy.orm.util import attributes
+
+from snowflake.sqlalchemy.compat import IS_VERSION_20
+
+if IS_VERSION_20:
+    from sqlalchemy.orm import DeclarativeBase
+
+    class SnowflakeBase(DeclarativeBase):
+        """Declarative base that opts into :class:`SnowflakeSession` bulk tuning.
+
+        Subclass this base for mapped classes that should use
+        ``render_nulls=True`` during bulk INSERTs (see SQLAlchemy bulk caveats).
+        For fewer INSERT batches, each row must expose the **same parameter
+        keys** (use explicit ``None`` for unset optional columns rather than
+        omitting attributes or mapping keys).
+
+        Requires SQLAlchemy 2.0+. On SQLAlchemy 1.4, use :class:`SnowflakeBase`
+        as an abstract mixin: ``class MyModel(SnowflakeBase, YourDeclarativeBase)``.
+        """
+
+        __abstract__ = True
+        __snowflake_sqlalchemy_bulk__ = True
+
+else:
+
+    class SnowflakeBase:
+        """Abstract mixin for SQLAlchemy 1.4 declarative models.
+
+        Use multiple inheritance with your declarative base, mixin first:
+
+        .. code-block:: python
+
+            Base = declarative_base()
+
+            class MyModel(SnowflakeBase, Base):
+                __tablename__ = "my_model"
+        """
+
+        __abstract__ = True
+        __snowflake_sqlalchemy_bulk__ = True
+
+
+def mapper_uses_snowflake_bulk(mapper_or_class) -> bool:
+    """Return True if the mapped class was declared with :class:`SnowflakeBase`."""
+    mapper = _class_to_mapper(mapper_or_class)
+    return bool(getattr(mapper.class_, "__snowflake_sqlalchemy_bulk__", False))
+
+
+_RENDER_NULLS_AUTO = object()
+
+
+class SnowflakeSession(Session):
+    """Session that enables SQLAlchemy ``render_nulls`` for Snowflake-tuned mappers.
+
+    For INSERT batches of instances whose class inherits :class:`SnowflakeBase`
+    (or sets ``__snowflake_sqlalchemy_bulk__ = True``), bulk operations pass
+    ``render_nulls=True`` so explicit ``None`` values are rendered as NULL and
+    executemany batching works when every row already shares the same key set
+    (see snowflake-sqlalchemy issue 441).
+
+    :meth:`bulk_insert_mappings` defaults ``render_nulls`` to that same rule
+    when the fourth argument is omitted (using an internal sentinel). Pass
+    ``render_nulls=True`` or ``False`` explicitly to override.
+    """
+
+    def bulk_insert_mappings(
+        self,
+        mapper: Any,
+        mappings: Iterable[dict[str, Any]],
+        return_defaults: bool = False,
+        render_nulls: Any = _RENDER_NULLS_AUTO,
+    ) -> None:
+        if render_nulls is _RENDER_NULLS_AUTO:
+            render_nulls = mapper_uses_snowflake_bulk(mapper)
+        super().bulk_insert_mappings(
+            mapper,
+            mappings,
+            return_defaults=return_defaults,
+            render_nulls=render_nulls,
+        )
+
+    def bulk_save_objects(
+        self,
+        objects: Iterable[object],
+        return_defaults: bool = False,
+        update_changed_only: bool = True,
+        preserve_order: bool = True,
+    ) -> None:
+        obj_states = (attributes.instance_state(obj) for obj in objects)
+
+        if not preserve_order:
+            obj_states = sorted(
+                obj_states,
+                key=lambda state: (id(state.mapper), state.key is not None),
+            )
+
+        def grouping_key(state):
+            return (state.mapper, state.key is not None)
+
+        for (mapper, isupdate), states in itertools.groupby(obj_states, grouping_key):
+            state_list = list(states)
+            use_render_nulls = (not isupdate) and mapper_uses_snowflake_bulk(mapper)
+            if IS_VERSION_20:
+                self._bulk_save_mappings(
+                    mapper,
+                    state_list,
+                    isupdate=isupdate,
+                    isstates=True,
+                    return_defaults=return_defaults,
+                    update_changed_only=update_changed_only,
+                    render_nulls=use_render_nulls,
+                )
+            else:
+                self._bulk_save_mappings(
+                    mapper,
+                    state_list,
+                    isupdate,
+                    True,
+                    return_defaults,
+                    update_changed_only,
+                    use_render_nulls,
+                )

--- a/tests/test_snowflake_orm.py
+++ b/tests/test_snowflake_orm.py
@@ -1,0 +1,434 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import Column, Integer, String, Text, create_engine, event, text
+from sqlalchemy.orm import Session
+
+from snowflake.sqlalchemy.compat import IS_VERSION_20
+from snowflake.sqlalchemy.orm import (
+    SnowflakeBase,
+    SnowflakeSession,
+    mapper_uses_snowflake_bulk,
+)
+
+if IS_VERSION_20:
+    from sqlalchemy.orm import DeclarativeBase
+
+    class _PlainBase(DeclarativeBase):
+        __abstract__ = True
+
+
+if IS_VERSION_20:
+
+    class _SfModel(SnowflakeBase):
+        __tablename__ = "snowflake_orm_sf"
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
+
+    class _PlainModel(_PlainBase):
+        __tablename__ = "snowflake_orm_plain"
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
+
+    class _WideBulkModel(SnowflakeBase):
+        """Optional nullable columns for batching / e2e tests."""
+
+        __tablename__ = "snowflake_orm_wide"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+        tag = Column(String, nullable=True)
+        note = Column(Text, nullable=True)
+
+    class _TaggedManualBulk(_PlainBase):
+        """Opt-in via ``__snowflake_sqlalchemy_bulk__`` without ``SnowflakeBase``."""
+
+        __tablename__ = "snowflake_orm_tagged"
+        __snowflake_sqlalchemy_bulk__ = True
+        id = Column(Integer, primary_key=True)
+        label = Column(String)
+
+else:
+    from sqlalchemy.orm import declarative_base
+
+    _Base = declarative_base()
+
+    class _SfModel(SnowflakeBase, _Base):
+        __tablename__ = "snowflake_orm_sf"
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
+
+    class _PlainModel(_Base):
+        __tablename__ = "snowflake_orm_plain"
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
+
+    class _WideBulkModel(SnowflakeBase, _Base):
+        __tablename__ = "snowflake_orm_wide"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+        tag = Column(String, nullable=True)
+        note = Column(Text, nullable=True)
+
+    class _TaggedManualBulk(_Base):
+        __tablename__ = "snowflake_orm_tagged"
+        __snowflake_sqlalchemy_bulk__ = True
+        id = Column(Integer, primary_key=True)
+        label = Column(String)
+
+
+@pytest.fixture
+def sqlite_engine():
+    engine = create_engine("sqlite:///:memory:")
+    yield engine
+    engine.dispose()
+
+
+def test_public_exports_from_snowflake_sqlalchemy():
+    from snowflake.sqlalchemy import SnowflakeBase as SB
+    from snowflake.sqlalchemy import SnowflakeSession as SS
+    from snowflake.sqlalchemy import mapper_uses_snowflake_bulk as M
+
+    assert SB is SnowflakeBase
+    assert SS is SnowflakeSession
+    assert M is mapper_uses_snowflake_bulk
+
+
+def test_mapper_uses_snowflake_bulk_true(sqlite_engine):
+    _SfModel.metadata.create_all(sqlite_engine)
+    assert mapper_uses_snowflake_bulk(_SfModel) is True
+
+
+def test_mapper_uses_snowflake_bulk_false(sqlite_engine):
+    _PlainModel.metadata.create_all(sqlite_engine)
+    assert mapper_uses_snowflake_bulk(_PlainModel) is False
+
+
+def test_mapper_uses_snowflake_bulk_manual_class_flag(sqlite_engine):
+    _TaggedManualBulk.metadata.create_all(sqlite_engine)
+    assert mapper_uses_snowflake_bulk(_TaggedManualBulk) is True
+
+
+def test_snowflake_model_invalid_keyword_raises_typeerror():
+    with pytest.raises(TypeError, match="invalid keyword"):
+        _SfModel(id=1, name="ok", not_a_column="bad")
+
+
+def test_snowflake_model_user_supplied_values_preserved():
+    row = _SfModel(id=7, name="saved")
+    assert row.id == 7
+    assert row.name == "saved"
+
+
+def test_snowflake_session_bulk_save_objects_render_nulls_for_sf_model(sqlite_engine):
+    _SfModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+    row = _SfModel(name="a")
+
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_save_objects([row])
+
+    mock_bm.assert_called_once()
+    _args, kwargs = mock_bm.call_args
+    if IS_VERSION_20:
+        assert kwargs.get("render_nulls") is True
+    else:
+        # self, mapper, states, isupdate, isstates, return_defaults,
+        # update_changed_only, render_nulls
+        assert _args[7] is True
+
+
+def test_snowflake_session_bulk_save_objects_render_nulls_false_for_plain(
+    sqlite_engine,
+):
+    _PlainModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+    row = _PlainModel(name="b")
+
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_save_objects([row])
+
+    mock_bm.assert_called_once()
+    _args, kwargs = mock_bm.call_args
+    if IS_VERSION_20:
+        assert kwargs.get("render_nulls") is False
+    else:
+        assert _args[7] is False
+
+
+def test_snowflake_session_bulk_insert_mappings_auto_render_nulls(sqlite_engine):
+    _SfModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_insert_mappings(_SfModel, [{"id": 1, "name": "x"}])
+
+    mock_bm.assert_called_once()
+    _args, kwargs = mock_bm.call_args
+    if IS_VERSION_20:
+        assert kwargs.get("render_nulls") is True
+    else:
+        # self, mapper, states, isupdate, isstates, return_defaults,
+        # update_changed_only, render_nulls
+        assert _args[7] is True
+
+
+def test_snowflake_session_bulk_insert_mappings_explicit_render_nulls_false(
+    sqlite_engine,
+):
+    _SfModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_insert_mappings(
+            _SfModel, [{"id": 1, "name": "x"}], render_nulls=False
+        )
+
+    mock_bm.assert_called_once()
+    _args, kwargs = mock_bm.call_args
+    if IS_VERSION_20:
+        assert kwargs.get("render_nulls") is False
+    else:
+        assert _args[7] is False
+
+
+def test_bulk_save_objects_empty_list_does_not_call_bulk_mappings(sqlite_engine):
+    _SfModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_save_objects([])
+    mock_bm.assert_not_called()
+
+
+def test_bulk_save_objects_mixed_sf_and_plain_two_bulk_calls(sqlite_engine):
+    _SfModel.metadata.create_all(sqlite_engine)
+    _PlainModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_save_objects(
+            [
+                _SfModel(id=1, name="sf"),
+                _PlainModel(id=2, name="plain"),
+            ]
+        )
+
+    assert mock_bm.call_count == 2
+    calls = mock_bm.call_args_list
+    # First group is Snowflake-tuned INSERT → render_nulls True
+    args0, kwargs0 = calls[0]
+    args1, kwargs1 = calls[1]
+    if IS_VERSION_20:
+        assert kwargs0.get("render_nulls") is True
+        assert kwargs1.get("render_nulls") is False
+    else:
+        assert args0[7] is True
+        assert args1[7] is False
+
+
+def test_bulk_save_objects_manual_flag_gets_render_nulls(sqlite_engine):
+    _TaggedManualBulk.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+    row = _TaggedManualBulk(id=1, label="x")
+
+    with patch.object(
+        SnowflakeSession, "_bulk_save_mappings", autospec=True
+    ) as mock_bm:
+        session.bulk_save_objects([row])
+
+    mock_bm.assert_called_once()
+    _args, kwargs = mock_bm.call_args
+    if IS_VERSION_20:
+        assert kwargs.get("render_nulls") is True
+    else:
+        assert _args[7] is True
+
+
+def test_plain_session_sf_model_still_default_render_nulls_false(sqlite_engine):
+    """Regression: stock Session must not implicitly enable Snowflake bulk tuning."""
+    _SfModel.metadata.create_all(sqlite_engine)
+    session = Session(bind=sqlite_engine)
+    row = _SfModel(id=1, name="a")
+
+    with patch.object(Session, "_bulk_save_mappings", autospec=True) as mock_bm:
+        session.bulk_save_objects([row])
+
+    mock_bm.assert_called_once()
+    _args, kwargs = mock_bm.call_args
+    if IS_VERSION_20:
+        assert kwargs.get("render_nulls") is False
+    else:
+        assert _args[7] is False
+
+
+def test_e2e_bulk_save_objects_inserts_optional_columns(sqlite_engine):
+    """Mixed optional values persist; uniform explicit keys recommended for batching."""
+    _WideBulkModel.metadata.create_all(sqlite_engine)
+    session = SnowflakeSession(bind=sqlite_engine)
+    session.bulk_save_objects(
+        [
+            _WideBulkModel(id=1, name="a", tag="t1", note=None),
+            _WideBulkModel(id=2, name="b", tag=None, note=None),
+            _WideBulkModel(id=3, name="c", tag=None, note="n3"),
+        ]
+    )
+    session.commit()
+
+    with session.bind.connect() as conn:
+        rows = conn.execute(
+            text("SELECT id, name, tag, note FROM snowflake_orm_wide ORDER BY id")
+        ).fetchall()
+    assert len(rows) == 3
+    assert rows[0] == (1, "a", "t1", None)
+    assert rows[1] == (2, "b", None, None)
+    assert rows[2][0:2] == (3, "c")
+
+
+def test_e2e_bulk_insert_uniform_mapping_keys_single_insert(sqlite_engine):
+    """Same keys in every mapping (explicit NULLs) → one INSERT with SnowflakeSession."""
+    _WideBulkModel.metadata.create_all(sqlite_engine)
+    statements: list[str] = []
+
+    def _capture(
+        conn,
+        cursor,
+        statement,
+        parameters,
+        context,
+        executemany,
+    ):
+        if "INSERT" in statement.upper():
+            statements.append(statement)
+
+    event.listen(sqlite_engine, "before_cursor_execute", _capture)
+    try:
+        session = SnowflakeSession(bind=sqlite_engine)
+        session.bulk_insert_mappings(
+            _WideBulkModel,
+            [
+                {"id": 1, "name": "a", "tag": None, "note": None},
+                {"id": 2, "name": "b", "tag": "x", "note": None},
+            ],
+        )
+        session.commit()
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", _capture)
+
+    assert len(statements) == 1
+
+
+def test_e2e_bulk_insert_missing_keys_split_batches(sqlite_engine):
+    """Differing mapping keys still produce multiple INSERTs (SQLAlchemy grouping)."""
+    _WideBulkModel.metadata.create_all(sqlite_engine)
+    statements: list[str] = []
+
+    def _capture(
+        conn,
+        cursor,
+        statement,
+        parameters,
+        context,
+        executemany,
+    ):
+        if "INSERT" in statement.upper():
+            statements.append(statement)
+
+    event.listen(sqlite_engine, "before_cursor_execute", _capture)
+    try:
+        session = SnowflakeSession(bind=sqlite_engine)
+        session.bulk_insert_mappings(
+            _WideBulkModel,
+            [
+                {"id": 1, "name": "a"},
+                {"id": 2, "name": "b", "tag": "x"},
+            ],
+        )
+        session.commit()
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", _capture)
+
+    assert len(statements) == 2
+
+
+def test_e2e_bulk_save_objects_uniform_optional_keys_single_insert(sqlite_engine):
+    """Explicit None on all optional columns → one INSERT with SnowflakeSession."""
+    _WideBulkModel.metadata.create_all(sqlite_engine)
+    statements: list[str] = []
+
+    def _capture(
+        conn,
+        cursor,
+        statement,
+        parameters,
+        context,
+        executemany,
+    ):
+        if "INSERT" in statement.upper():
+            statements.append(statement)
+
+    event.listen(sqlite_engine, "before_cursor_execute", _capture)
+    try:
+        session = SnowflakeSession(bind=sqlite_engine)
+        session.bulk_save_objects(
+            [
+                _WideBulkModel(id=1, name="a", tag=None, note=None),
+                _WideBulkModel(id=2, name="b", tag="x", note=None),
+            ]
+        )
+        session.commit()
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", _capture)
+
+    assert len(statements) == 1
+
+
+def test_e2e_bulk_save_objects_omitted_optional_splits_batches(sqlite_engine):
+    """Omitting an optional attribute on one row still yields multiple INSERTs."""
+    _WideBulkModel.metadata.create_all(sqlite_engine)
+    statements: list[str] = []
+
+    def _capture(
+        conn,
+        cursor,
+        statement,
+        parameters,
+        context,
+        executemany,
+    ):
+        if "INSERT" in statement.upper():
+            statements.append(statement)
+
+    event.listen(sqlite_engine, "before_cursor_execute", _capture)
+    try:
+        session = SnowflakeSession(bind=sqlite_engine)
+        session.bulk_save_objects(
+            [
+                _WideBulkModel(id=1, name="a"),
+                _WideBulkModel(id=2, name="b", tag="x", note=None),
+            ]
+        )
+        session.commit()
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", _capture)
+
+    assert len(statements) == 2


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Adds optional ORM helpers for bulk `INSERT` batching ([#441](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/441), SNOW-893080): `SnowflakeBase`, `SnowflakeSession`, and `mapper_uses_snowflake_bulk` in `snowflake.sqlalchemy.orm`, re-exported from `snowflake.sqlalchemy.SnowflakeSession` passes SQLAlchemy `render_nulls=True` on bulk `INSERT` paths for opted-in mappers (subclasses of `SnowflakeBase` or classes with `__snowflake_sqlalchemy_bulk__ = True`). For `bulk_insert_mappings`, omitting `render_nulls` uses the same opt-in rule; callers can still pass `render_nulls=True` or `False` explicitly.
