### PR TITLE
SNOW-689531: optimize sigle table reflection

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,7 +20,8 @@ Source code is also available at:
   - Add `_always_quote_join` helper that always quotes denormalised identifiers — ensures correct SQL for case-sensitive table and schema names in per-table reflection paths.
   - Fix foreign key `referred_schema` resolution to include the explicitly reflected schema in the same-schema set, preventing incorrect cross-schema references when reflecting a non-default schema.
   - Add shared row-parsing helpers (`_parse_pk_rows`, `_parse_uk_rows`, `_parse_fk_rows`) so correctness fixes propagate to both per-table and schema-wide reflection paths.
-  - `cache_column_metadata=True` opt-in enables per-table `SHOW … IN TABLE` queries for `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, and `get_indexes` on both SQLAlchemy versions.
+  - `cache_column_metadata=True` opt-in enables per-table `SHOW … IN TABLE` queries for `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, and `get_indexes` on SQLAlchemy 1.4.
+  - On SQLAlchemy 2.x, `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, and `get_indexes` now automatically use per-table `SHOW … IN TABLE` queries without any opt-in flag. Previously these methods always issued `SHOW … IN SCHEMA` even for single-table Inspector calls (e.g. `pandas.read_sql_table()`), causing ~20-second delays on schemas with thousands of tables (SNOW-689531).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -537,9 +537,11 @@ inspector = inspect(engine)
 columns = inspector.get_columns('my_table', schema='public')
 ```
 
-**SQLAlchemy 1.4 and per-table optimisation (opt-in)**
+**Per-table optimisation**
 
-In SQLAlchemy 1.4, `MetaData.reflect()` calls `get_columns`, `get_pk_constraint`, etc. per table. For schemas with many tables this generates many round-trips. Add `cache_column_metadata=True` to the connection URL to opt in to per-table `SHOW … IN TABLE` and `DESC TABLE` queries for `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, `get_indexes`, and `get_columns`. Each query targets only the requested table and is not cached, so it always reflects the current state.
+On **SQLAlchemy 2.x**, `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, `get_indexes`, and `get_columns` automatically use per-table queries (`SHOW … IN TABLE`, `DESC TABLE`) for single-table Inspector calls (e.g. `Inspector.get_pk_constraint()`, `pandas.read_sql_table()`). `MetaData.reflect()` continues to use the schema-wide `get_multi_*` hooks, which issue one query per reflection pass.
+
+On **SQLAlchemy 1.4**, `MetaData.reflect()` calls the singular methods per-table. Add `cache_column_metadata=True` to the connection URL to opt in to per-table queries for `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, `get_indexes`, and `get_columns`. Without this flag, the existing schema-wide queries are used unchanged.
 
 ```python
 engine = create_engine(URL(
@@ -550,11 +552,9 @@ engine = create_engine(URL(
     schema = 'public',
     warehouse = 'testwh',
     role='myrole',
-    cache_column_metadata=True,
+    cache_column_metadata=True,  # SA 1.4 only: enables per-table reflection
 ))
 ```
-
-This flag also enables the per-table path for the singular `Inspector` methods (`get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, `get_indexes`) under SQLAlchemy 2.x.
 
 **Performance Implications**
 

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -637,9 +637,9 @@ class SnowflakeDialect(default.DefaultDialect):
     # ---------------------------------------------------------------------------
 
     def _get_table_unique_constraints(self, connection, table_name, schema, **kw):
-        """SHOW UNIQUE KEYS IN TABLE — single-table path (cache_column_metadata=True).
+        """SHOW UNIQUE KEYS IN TABLE — single-table path.
 
-        Results are cached by the calling method's @reflection.cache decorator.
+        Called by get_unique_constraints when _is_single_table_reflection returns True.
         """
         full_name = self._always_quote_join(schema, table_name)
         try:
@@ -711,15 +711,15 @@ class SnowflakeDialect(default.DefaultDialect):
     # ---------------------------------------------------------------------------
 
     def _get_table_foreign_keys(self, connection, table_name, schema, **kw):
-        """SHOW IMPORTED KEYS IN TABLE — single-table path (cache_column_metadata=True).
+        """SHOW IMPORTED KEYS IN TABLE — single-table path.
+
+        Called by get_foreign_keys when _is_single_table_reflection returns True.
 
         referred_schema is set to None when the FK target is in the same schema as
         the table being reflected.  The same-schema set always includes the
         explicitly-reflected schema so that cross-session-schema scenarios
         (e.g. USE SCHEMA called after engine creation, or reflecting a non-default
         schema) are handled correctly.
-
-        Results are cached by the calling method's @reflection.cache decorator.
         """
         full_name = self._always_quote_join(schema, table_name)
         _, current_schema = self._current_database_schema(connection, **kw)
@@ -1519,13 +1519,13 @@ class SnowflakeDialect(default.DefaultDialect):
         return dict(indexes)
 
     def _get_table_indexes(self, connection, table_name, schema, **kw):
-        """SHOW INDEXES IN TABLE — single-table path (cache_column_metadata=True).
+        """SHOW INDEXES IN TABLE — single-table path.
+
+        Called by get_indexes when _is_single_table_reflection returns True.
 
         For non-hybrid tables Snowflake returns an empty result set (not an
         error), so the list will simply be empty.  The SYS_INDEX primary-key
         sentinel is filtered out, consistent with the schema-wide path.
-
-        Results are cached by the calling method's @reflection.cache decorator.
         """
         full_name = self._always_quote_join(schema, table_name)
         try:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -1544,9 +1544,16 @@ class SnowflakeDialect(default.DefaultDialect):
     def get_indexes(self, connection, tablename, schema, **kw):
         """Gets the indexes definition."""
         schema = schema or self.default_schema_name
-        table_name = self.normalize_name(str(tablename))
         if self._is_single_table_reflection(schema, **kw):
-            return self._get_table_indexes(connection, table_name, schema, **kw)
+            # Pass the raw string so _always_quote_join can correctly
+            # denormalize (uppercase) it.  normalize_name() wraps plain
+            # lowercase strings in quoted_name(quote=True), and
+            # quoted_name.upper() is intentionally a no-op for quote=True
+            # objects, which would cause _always_quote_join to emit
+            # "table_name" (case-sensitive lowercase) instead of the
+            # correct "TABLE_NAME" (case-insensitive uppercase).
+            return self._get_table_indexes(connection, str(tablename), schema, **kw)
+        table_name = self.normalize_name(str(tablename))
         data = self.get_multi_indexes(
             connection=connection, schema=schema, filter_names=[table_name], **kw
         )

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -558,9 +558,9 @@ class SnowflakeDialect(default.DefaultDialect):
     # ---------------------------------------------------------------------------
 
     def _get_table_primary_keys(self, connection, table_name, schema, **kw):
-        """SHOW PRIMARY KEYS IN TABLE — single-table path (cache_column_metadata=True).
+        """SHOW PRIMARY KEYS IN TABLE — single-table path.
 
-        Results are cached by the calling method's @reflection.cache decorator.
+        Called by get_pk_constraint when _is_single_table_reflection returns True.
         """
         full_name = self._always_quote_join(schema, table_name)
         try:
@@ -1150,34 +1150,34 @@ class SnowflakeDialect(default.DefaultDialect):
     def _is_single_table_reflection(self, schema, **kw):
         """Return True when a single-table SHOW command should be used for PK/UK/FK.
 
-        Opt-in via ``cache_column_metadata=true`` on the engine URL or
-        connect_args.  When disabled (the default) all reflection uses the
-        existing schema-wide queries unchanged, preserving backward compatibility.
-
         SA 2.x path (IS_VERSION_20=True):
           ``get_multi_pk_constraint`` / ``get_multi_unique_constraints`` /
           ``get_multi_foreign_keys`` are used by MetaData.reflect(), so any call
           to the singular get_pk_constraint / get_unique_constraints /
-          get_foreign_keys is inherently single-table (Inspector,
-          pandas.read_sql_table).  No info_cache inspection required.
+          get_foreign_keys / get_indexes is inherently single-table (Inspector,
+          pandas.read_sql_table).  Always returns True; no opt-in required.
 
         SA 1.4 path (IS_VERSION_20=False):
           MetaData.reflect() calls the singular methods per-table and populates
-          ``_get_schema_tables_info`` early in the reflection pass.  The
-          presence of that key in info_cache is the signal that multi-table
-          reflection is in progress; fall back to the schema-wide cached query.
+          ``_get_schema_tables_info`` early in the reflection pass.  Opt-in via
+          ``cache_column_metadata=true`` on the engine URL or connect_args.
+          When disabled (the default) all reflection uses the existing
+          schema-wide queries unchanged, preserving backward compatibility.
+          The presence of the tables-info key in info_cache signals that
+          multi-table reflection is in progress; fall back to schema-wide query.
 
         Note: @reflection.cache caches results for the lifetime of a connection.
         DDL executed mid-session will not be visible in reflection until a new
         connection is obtained, regardless of which path is used.
         """
-        if not getattr(self, "_cache_column_metadata", False):
-            return False
-
         if IS_VERSION_20:
             # SA 2.x: get_multi_* handles MetaData.reflect(); singular calls
             # are always single-table at this point.
             return True
+
+        # SA 1.4: opt-in required for backward compatibility.
+        if not getattr(self, "_cache_column_metadata", False):
+            return False
 
         # SA 1.4: detect whether MetaData.reflect() is in progress.
         # @reflection.cache stores keys as (fn.__name__, args_tuple, kwargs_tuple).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,3 +335,24 @@ def _ensure_optional_dependencies(item):
     """Skip optional-dependency tests when the dependency is unavailable."""
     if "pandas" in item.keywords:
         pytest.importorskip("pandas")
+
+
+def poll_until(fn, *, timeout: float = 15, interval: float = 1):
+    """Poll ``fn()`` every *interval* seconds until it returns a truthy value.
+
+    Returns the first truthy result, or the last (falsy) result once *timeout*
+    is exceeded.
+
+    Use this instead of ``pytest.mark.flaky(reruns=N)`` when the test creates
+    Snowflake objects (tables, indexes, etc.) that should not be torn down and
+    recreated on every retry attempt.  Re-running the whole test via
+    ``pytest-rerunfailures`` would execute the fixture teardown and re-run
+    setup DDL on each attempt, which is wasteful and can hit object-already-
+    exists errors.  Polling within the test body avoids touching the data.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        result = fn()
+        if result or time.monotonic() > deadline:
+            return result
+        time.sleep(interval)

--- a/tests/test_index_reflection.py
+++ b/tests/test_index_reflection.py
@@ -6,17 +6,18 @@ from sqlalchemy import MetaData, inspect
 from sqlalchemy.sql.ddl import CreateSchema, DropSchema
 
 from tests.conftest import poll_until
+from tests.util import random_string
 
 
 @pytest.mark.aws
 def test_indexes_reflection(engine_testaccount, db_parameters, sql_compiler):
-    table_name = "test_hybrid_table_2"
-    index_name = "INDEX_NAME_2"
+    table_name = "test_hybrid_table_" + random_string(6)
+    index_name = "INDEX_NAME_" + random_string(6).upper()
     schema = db_parameters["schema"]
     index_columns = ["name", "name2"]
 
     create_table_sql = f"""
-   CREATE OR REPLACE HYBRID TABLE {schema}.{table_name} (
+   CREATE HYBRID TABLE {schema}.{table_name} (
         id INT primary key,
         name VARCHAR,
         name2 VARCHAR,
@@ -33,8 +34,8 @@ def test_indexes_reflection(engine_testaccount, db_parameters, sql_compiler):
         # to propagate before SHOW INDEXES IN TABLE reflects the new index.
         indexes = poll_until(
             lambda: inspect(engine_testaccount).get_indexes(table_name, schema),
-            timeout=15,
-            interval=1,
+            timeout=10,
+            interval=0.5,
         )
 
         assert len(indexes) == 1

--- a/tests/test_index_reflection.py
+++ b/tests/test_index_reflection.py
@@ -5,18 +5,18 @@ import pytest
 from sqlalchemy import MetaData, inspect
 from sqlalchemy.sql.ddl import CreateSchema, DropSchema
 
+from tests.conftest import poll_until
+
 
 @pytest.mark.aws
 def test_indexes_reflection(engine_testaccount, db_parameters, sql_compiler):
-    metadata = MetaData()
-
     table_name = "test_hybrid_table_2"
     index_name = "INDEX_NAME_2"
     schema = db_parameters["schema"]
     index_columns = ["name", "name2"]
 
     create_table_sql = f"""
-   CREATE HYBRID TABLE {table_name} (
+   CREATE OR REPLACE HYBRID TABLE {schema}.{table_name} (
         id INT primary key,
         name VARCHAR,
         name2 VARCHAR,
@@ -26,19 +26,25 @@ def test_indexes_reflection(engine_testaccount, db_parameters, sql_compiler):
 
     with engine_testaccount.connect() as connection:
         connection.exec_driver_sql(create_table_sql)
-
-    insp = inspect(engine_testaccount)
+        connection.commit()
 
     try:
-        with engine_testaccount.connect():
-            # Prefixes reflection not supported, example: "HYBRID, DYNAMIC"
-            indexes = insp.get_indexes(table_name, schema)
-            assert len(indexes) == 1
-            assert indexes[0].get("name") == index_name
-            assert indexes[0].get("column_names") == index_columns
+        # On AWS, Hybrid Table (Unistore) index metadata can take a few seconds
+        # to propagate before SHOW INDEXES IN TABLE reflects the new index.
+        indexes = poll_until(
+            lambda: inspect(engine_testaccount).get_indexes(table_name, schema),
+            timeout=15,
+            interval=1,
+        )
+
+        assert len(indexes) == 1
+        assert indexes[0].get("name") == index_name
+        assert indexes[0].get("column_names") == index_columns
 
     finally:
-        metadata.drop_all(engine_testaccount)
+        with engine_testaccount.connect() as connection:
+            connection.exec_driver_sql(f"DROP TABLE IF EXISTS {schema}.{table_name}")
+            connection.commit()
 
 
 @pytest.mark.aws

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -361,3 +361,29 @@ class TestSingleTableDispatchSA2:
 
         tbl_mock.assert_called_once()
         assert result == expected
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_indexes_passes_raw_tablename_not_normalized(self):
+        """get_indexes must pass the raw tablename string to _get_table_indexes.
+
+        normalize_name() converts plain lowercase strings to
+        quoted_name(quote=True).  quoted_name.upper() is a deliberate no-op
+        when quote=True, so if the normalized form reaches _always_quote_join
+        the identifier stays lowercase and Snowflake treats it as a
+        case-sensitive lookup — failing to find a table stored as UPPERCASE.
+        """
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        received = {}
+
+        def capture(conn, table_name, schema, **kw):
+            received["table_name"] = table_name
+            return []
+
+        with mock.patch.object(dialect, "_get_table_indexes", side_effect=capture):
+            dialect.get_indexes(connection, "my_table", schema="PUBLIC")
+
+        # Must be a plain str, not a quoted_name, so denormalize_name can
+        # uppercase it correctly inside _always_quote_join.
+        assert received["table_name"] == "my_table"
+        assert type(received["table_name"]) is str

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -290,74 +290,49 @@ class TestSingleTableDispatchSA2:
     without requiring cache_column_metadata=True."""
 
     @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
-    def test_get_pk_constraint_uses_table_path(self):
+    @pytest.mark.parametrize(
+        "public_method,table_method,schema_method,expected",
+        [
+            (
+                "get_pk_constraint",
+                "_get_table_primary_keys",
+                "_get_schema_primary_keys",
+                {"constrained_columns": ["id"], "name": "pk_foo"},
+            ),
+            (
+                "get_unique_constraints",
+                "_get_table_unique_constraints",
+                "_get_schema_unique_constraints",
+                [{"column_names": ["email"], "name": "uq_email"}],
+            ),
+            (
+                "get_foreign_keys",
+                "_get_table_foreign_keys",
+                "_get_schema_foreign_keys",
+                [{"referred_table": "bar", "constrained_columns": ["bar_id"]}],
+            ),
+            (
+                "get_indexes",
+                "_get_table_indexes",
+                "get_multi_indexes",
+                [{"name": "idx_foo", "column_names": ["col1"], "unique": False}],
+            ),
+        ],
+    )
+    def test_uses_table_path(
+        self, public_method, table_method, schema_method, expected
+    ):
         dialect = _make_dialect()
         connection = mock.Mock()
-        expected = {"constrained_columns": ["id"], "name": "pk_foo"}
 
         with mock.patch.object(
-            dialect, "_get_table_primary_keys", return_value=expected
+            dialect, table_method, return_value=expected
         ) as tbl_mock, mock.patch.object(
             dialect,
-            "_get_schema_primary_keys",
-            side_effect=AssertionError("schema-wide PK query must not be called"),
-        ) as schema_mock:
-            result = dialect.get_pk_constraint(connection, "foo", schema="PUBLIC")
-
-        tbl_mock.assert_called_once()
-        schema_mock.assert_not_called()
-        assert result == expected
-
-    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
-    def test_get_unique_constraints_uses_table_path(self):
-        dialect = _make_dialect()
-        connection = mock.Mock()
-        expected = [{"column_names": ["email"], "name": "uq_email"}]
-
-        with mock.patch.object(
-            dialect, "_get_table_unique_constraints", return_value=expected
-        ) as tbl_mock, mock.patch.object(
-            dialect,
-            "_get_schema_unique_constraints",
-            side_effect=AssertionError("schema-wide UK query must not be called"),
+            schema_method,
+            side_effect=AssertionError(f"{schema_method} must not be called"),
         ):
-            result = dialect.get_unique_constraints(connection, "foo", schema="PUBLIC")
-
-        tbl_mock.assert_called_once()
-        assert result == expected
-
-    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
-    def test_get_foreign_keys_uses_table_path(self):
-        dialect = _make_dialect()
-        connection = mock.Mock()
-        expected = [{"referred_table": "bar", "constrained_columns": ["bar_id"]}]
-
-        with mock.patch.object(
-            dialect, "_get_table_foreign_keys", return_value=expected
-        ) as tbl_mock, mock.patch.object(
-            dialect,
-            "_get_schema_foreign_keys",
-            side_effect=AssertionError("schema-wide FK query must not be called"),
-        ):
-            result = dialect.get_foreign_keys(connection, "foo", schema="PUBLIC")
-
-        tbl_mock.assert_called_once()
-        assert result == expected
-
-    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
-    def test_get_indexes_uses_table_path(self):
-        dialect = _make_dialect()
-        connection = mock.Mock()
-        expected = [{"name": "idx_foo", "column_names": ["col1"], "unique": False}]
-
-        with mock.patch.object(
-            dialect, "_get_table_indexes", return_value=expected
-        ) as tbl_mock, mock.patch.object(
-            dialect,
-            "get_multi_indexes",
-            side_effect=AssertionError("schema-wide index query must not be called"),
-        ):
-            result = dialect.get_indexes(connection, "foo", schema="PUBLIC")
+            result = getattr(dialect, public_method)(connection, "foo", schema="PUBLIC")
 
         tbl_mock.assert_called_once()
         assert result == expected

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -8,6 +8,17 @@ import pytest
 from sqlalchemy.engine.url import URL
 
 from snowflake.sqlalchemy import base
+from snowflake.sqlalchemy.compat import IS_VERSION_20
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+
+def _make_dialect(**attrs):
+    """Return a SnowflakeDialect instance without a live connection."""
+    dialect = SnowflakeDialect()
+    dialect.default_schema_name = "PUBLIC"
+    for k, v in attrs.items():
+        setattr(dialect, k, v)
+    return dialect
 
 
 def test_create_connect_args():
@@ -216,4 +227,137 @@ def test_get_server_version_info_parsing(raw_value, expected):
     if expected is None:
         assert result is None
     else:
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# _is_single_table_reflection (SNOW-689531)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSingleTableReflection:
+    """Unit tests for the _is_single_table_reflection heuristic."""
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_sa2_returns_true_without_opt_in(self):
+        """SA 2.x: singular calls are always single-table; no flag required."""
+        assert _make_dialect()._is_single_table_reflection("PUBLIC") is True
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_sa2_returns_true_with_info_cache_present(self):
+        """SA 2.x: info_cache presence is irrelevant — get_multi_* handles bulk."""
+        assert (
+            _make_dialect()._is_single_table_reflection("PUBLIC", info_cache={}) is True
+        )
+
+    @mock.patch("snowflake.sqlalchemy.snowdialect.IS_VERSION_20", False)
+    def test_sa14_returns_false_without_opt_in(self):
+        """SA 1.4: defaults to schema-wide queries for backward compatibility."""
+        assert _make_dialect()._is_single_table_reflection("PUBLIC") is False
+
+    @mock.patch("snowflake.sqlalchemy.snowdialect.IS_VERSION_20", False)
+    def test_sa14_returns_true_with_opt_in_no_info_cache(self):
+        """SA 1.4 + cache_column_metadata=True + no info_cache → single-table path."""
+        dialect = _make_dialect(_cache_column_metadata=True)
+        assert dialect._is_single_table_reflection("PUBLIC", info_cache=None) is True
+
+    @mock.patch("snowflake.sqlalchemy.snowdialect.IS_VERSION_20", False)
+    def test_sa14_returns_false_when_metadata_reflect_in_progress(self):
+        """SA 1.4 + MetaData.reflect() in progress → fall back to schema-wide query."""
+        dialect = _make_dialect(_cache_column_metadata=True)
+        tables_info_key = (dialect._get_schema_tables_info.__name__, ("PUBLIC",), ())
+        assert (
+            dialect._is_single_table_reflection(
+                "PUBLIC", info_cache={tables_info_key: {}}
+            )
+            is False
+        )
+
+    @mock.patch("snowflake.sqlalchemy.snowdialect.IS_VERSION_20", False)
+    def test_sa14_returns_true_when_schema_tables_not_yet_cached(self):
+        """SA 1.4 + cache_column_metadata=True + empty cache → single-table path."""
+        dialect = _make_dialect(_cache_column_metadata=True)
+        assert dialect._is_single_table_reflection("PUBLIC", info_cache={}) is True
+
+
+# ---------------------------------------------------------------------------
+# Single-table dispatch on SA 2.x (SNOW-689531)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleTableDispatchSA2:
+    """SA 2.x: singular reflection methods must route to table-specific queries
+    without requiring cache_column_metadata=True."""
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_pk_constraint_uses_table_path(self):
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        expected = {"constrained_columns": ["id"], "name": "pk_foo"}
+
+        with mock.patch.object(
+            dialect, "_get_table_primary_keys", return_value=expected
+        ) as tbl_mock, mock.patch.object(
+            dialect,
+            "_get_schema_primary_keys",
+            side_effect=AssertionError("schema-wide PK query must not be called"),
+        ) as schema_mock:
+            result = dialect.get_pk_constraint(connection, "foo", schema="PUBLIC")
+
+        tbl_mock.assert_called_once()
+        schema_mock.assert_not_called()
+        assert result == expected
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_unique_constraints_uses_table_path(self):
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        expected = [{"column_names": ["email"], "name": "uq_email"}]
+
+        with mock.patch.object(
+            dialect, "_get_table_unique_constraints", return_value=expected
+        ) as tbl_mock, mock.patch.object(
+            dialect,
+            "_get_schema_unique_constraints",
+            side_effect=AssertionError("schema-wide UK query must not be called"),
+        ):
+            result = dialect.get_unique_constraints(connection, "foo", schema="PUBLIC")
+
+        tbl_mock.assert_called_once()
+        assert result == expected
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_foreign_keys_uses_table_path(self):
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        expected = [{"referred_table": "bar", "constrained_columns": ["bar_id"]}]
+
+        with mock.patch.object(
+            dialect, "_get_table_foreign_keys", return_value=expected
+        ) as tbl_mock, mock.patch.object(
+            dialect,
+            "_get_schema_foreign_keys",
+            side_effect=AssertionError("schema-wide FK query must not be called"),
+        ):
+            result = dialect.get_foreign_keys(connection, "foo", schema="PUBLIC")
+
+        tbl_mock.assert_called_once()
+        assert result == expected
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_indexes_uses_table_path(self):
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        expected = [{"name": "idx_foo", "column_names": ["col1"], "unique": False}]
+
+        with mock.patch.object(
+            dialect, "_get_table_indexes", return_value=expected
+        ) as tbl_mock, mock.patch.object(
+            dialect,
+            "get_multi_indexes",
+            side_effect=AssertionError("schema-wide index query must not be called"),
+        ):
+            result = dialect.get_indexes(connection, "foo", schema="PUBLIC")
+
+        tbl_mock.assert_called_once()
         assert result == expected


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNO689531

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Problem

  `get_pk_constraint`, `get_unique_constraints`, `get_foreign_keys`, and `get_indexes` always issued `SHOW … IN SCHEMA` even when called for a single table (e.g. via Inspector or `pandas.read_sql_table()`). On schemas with thousands of tables this causes ~20-second delays per call.

  PR #656 introduced per-table `SHOW … IN TABLE` code paths but gated them behind `cache_column_metadata=True` on
  all SQLAlchemy versions. On SQLAlchemy 2.x this opt-in is unnecessary: `MetaData.reflect()` routes through
  `get_multi_pk_constraint` / `get_multi_unique_constraints` / `get_multi_foreign_keys` / `get_multi_indexes`, so any
  call reaching the singular methods is inherently single-table.

  Fix

  In `_is_single_table_reflection`, move the `IS_VERSION_20` check before the `_cache_column_metadata` guard:

  - SA 2.x: always returns True — the `get_multi_*` hooks own bulk reflection; singular calls are always single-table.
  - SA 1.4: unchanged — `cache_column_metadata=True` opt-in is still required, and the info-cache heuristic still detects `MetaData.reflect()` in progress.

  `get_columns` was already automatic on SA 2.x via the `IS_VERSION_20` guard introduced in #656; this PR applies
  the same logic to the four remaining reflection methods.
