### PR TITLE
SNOW-3573046: fix regex flags

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,8 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Fix `regexp_match` and `regexp_replace` flags rendered as bound parameters instead of literal strings ([#SNOW-3573046](https://github.com/snowflakedb/snowflake-sqlalchemy)). Flags passed to `ColumnElement.regexp_match(..., flags=...)` and `ColumnElement.regexp_replace(..., flags=...)` were processed through the standard parameter pipeline, producing incorrect SQL. Flags are now rendered as inline string literals, matching Snowflake's expected `REGEXP_LIKE(col, pattern, 'i')` / `REGEXP_REPLACE(col, pattern, replacement, 'i')` syntax.
+
 # Release Notes
 
 - v1.10.0 (May 20, 2026)

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -793,7 +793,7 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         pattern = self.process(binary.right, **kw)
         flags = binary.modifiers["flags"]
         if flags is not None:
-            flags = self.process(flags, **kw)
+            flags = self.render_literal_value(flags, sqltypes.STRINGTYPE)
         return string, pattern, flags
 
     def visit_regexp_match_op_binary(self, binary, operator, **kw):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -125,6 +125,34 @@ class TestSnowflakeCompiler(AssertsCompiledSQL):
             "SELECT table1.name FROM table1 WHERE table1.name NOT ILIKE %(name_1)s ESCAPE '\\\\'",
         )
 
+    def test_regexp_match_with_flags_compilation(self):
+        statement = select(table1.c.name).where(
+            table1.c.name.regexp_match("ann", flags="i")
+        )
+        self.assert_compile(
+            statement,
+            "SELECT table1.name FROM table1 WHERE REGEXP_LIKE(table1.name, %(name_1)s, 'i')",
+            dialect="snowflake",
+        )
+
+    def test_not_regexp_match_with_flags_compilation(self):
+        statement = select(table1.c.name).where(
+            ~table1.c.name.regexp_match("ann", flags="i")
+        )
+        self.assert_compile(
+            statement,
+            "SELECT table1.name FROM table1 WHERE NOT REGEXP_LIKE(table1.name, %(name_1)s, 'i')",
+            dialect="snowflake",
+        )
+
+    def test_regexp_replace_with_flags_compilation(self):
+        statement = select(table1.c.name.regexp_replace("ann", "bob", flags="i"))
+        self.assert_compile(
+            statement,
+            "SELECT REGEXP_REPLACE(table1.name, %(name_1)s, %(name_2)s, 'i') AS anon_1 FROM table1",
+            dialect="snowflake",
+        )
+
     def test_drop_table_comment(self):
         self.assert_compile(DropTableComment(table1), "COMMENT ON TABLE table1 IS ''")
         self.assert_compile(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-3573046

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Fix regex flags compilation — `regexp_match` and `regexp_replace` flags were passed through `self.process()`, which treated them as bound parameters and could produce incorrect SQL. Flags are now rendered as literal string values via `render_literal_value()`, matching Snowflake's expected `REGEXP_LIKE(col, pattern, 'i')` syntax.