### PR TITLE
pre-commit and test fixes bundle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 exclude: '^(.*egg.info.*|.*/parameters.py).*$'
+default_language_version:
+    python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -10,16 +12,16 @@ repos:
         exclude: .github/repo_meta.yaml
     -   id: debug-statements
 -   repo: https://github.com/PyCQA/isort
-    rev: 9.0.0a3
+    rev: 5.13.2
     hooks:
         - id: isort
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+    rev: v3.18.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 26.5.1
+    rev: 24.10.0
     hooks:
         - id: black
           args:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -1407,7 +1407,8 @@ class SnowflakeDialect(default.DefaultDialect):
 
         try:
             return connection.execute(
-                text(f"""
+                text(
+                    f"""
             SELECT /* sqlalchemy:_get_schema_columns */
                    ic.table_name,
                    ic.column_name,
@@ -1427,7 +1428,8 @@ class SnowflakeDialect(default.DefaultDialect):
                    ic.data_type_alias
               FROM {info_schema_table} ic
              WHERE ic.table_schema=:table_schema
-             ORDER BY ic.ordinal_position"""),
+             ORDER BY ic.ordinal_position"""
+                ),
                 {"table_schema": schema_only},
             )
         except sa_exc.ProgrammingError as pe:
@@ -1494,8 +1496,10 @@ class SnowflakeDialect(default.DefaultDialect):
             )
         else:
             cursor = connection.execute(
-                text(f"SHOW /* sqlalchemy:get_view_definition */ VIEWS \
-                    LIKE '{self._denormalize_quote_join(view_name)}'")
+                text(
+                    f"SHOW /* sqlalchemy:get_view_definition */ VIEWS \
+                    LIKE '{self._denormalize_quote_join(view_name)}'"
+                )
             )
 
         name_to_index_map = self.__class__._map_name_to_idx(cursor)

--- a/tests/alembic_integration/test_multi_schema_fk.py
+++ b/tests/alembic_integration/test_multi_schema_fk.py
@@ -58,15 +58,25 @@ def test_alembic_autogenerate_multi_schema_fk(engine_testaccount):
     with engine.connect() as conn:
         conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema1}"))
         conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema2}"))
-        conn.execute(text(f"""
+        conn.execute(
+            text(
+                f"""
                 CREATE TABLE {schema1}.users (
                     id INTEGER PRIMARY KEY, name VARCHAR(100))
-            """))
-        conn.execute(text(f"""
+            """
+            )
+        )
+        conn.execute(
+            text(
+                f"""
                 CREATE TABLE {schema2}.products (
                     id INTEGER PRIMARY KEY, name VARCHAR(100))
-            """))
-        conn.execute(text(f"""
+            """
+            )
+        )
+        conn.execute(
+            text(
+                f"""
                 CREATE TABLE {schema2}.orders (
                     id INTEGER PRIMARY KEY,
                     product_id INTEGER, user_id INTEGER,
@@ -74,7 +84,9 @@ def test_alembic_autogenerate_multi_schema_fk(engine_testaccount):
                         FOREIGN KEY (product_id) REFERENCES {schema2}.products(id),
                     CONSTRAINT fk_cross_schema
                         FOREIGN KEY (user_id) REFERENCES {schema1}.users(id))
-            """))
+            """
+            )
+        )
         conn.commit()
 
     # Target metadata matches DB but adds one extra column.
@@ -167,17 +179,25 @@ def test_alembic_autogenerate_default_schema_fk(engine_testaccount):
     actions_name = f"test145_user_actions_{uuid.uuid4().hex[:8]}"
 
     with engine.connect() as conn:
-        conn.execute(text(f"""
+        conn.execute(
+            text(
+                f"""
                 CREATE TABLE {users_name} (
                     username VARCHAR(100) PRIMARY KEY)
-            """))
-        conn.execute(text(f"""
+            """
+            )
+        )
+        conn.execute(
+            text(
+                f"""
                 CREATE TABLE {actions_name} (
                     id INTEGER PRIMARY KEY,
                     "user" VARCHAR(100),
                     CONSTRAINT fk_user_actions_user_user
                         FOREIGN KEY ("user") REFERENCES {users_name}(username))
-            """))
+            """
+            )
+        )
         conn.commit()
 
     # Target metadata mirrors the DB — no schema= on Table or MetaData,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2450,7 +2450,7 @@ def test_true_division_operation(engine_testaccount, operation):
         [literal(3), literal(2), 1.5, 1.5],
         [literal(4), literal(1.5), 2.6666666666666665, 2.0],
         [literal(5.5), literal(10.7), 0.5140186915887851, 0],
-        [literal(5.5), literal(8), 0.6875, 0.6875],
+        [literal(5.5), literal(8), 0.6875, 0.0],
     ],
 )
 @pytest.mark.feature_v20

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -221,12 +221,16 @@ def test_query_tag_appears_in_query_history():
                 conn.execute(text("SELECT 1; -- query tag test"))
 
             # Query the query history to verify the tag
-            result = conn.execute(text("""
+            result = conn.execute(
+                text(
+                    """
                     SELECT QUERY_TAG
                     FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION())
                     WHERE QUERY_TEXT = 'SELECT 1; -- query tag test'
                     ORDER BY START_TIME DESC LIMIT 1
-                    """))
+                    """
+                )
+            )
             row = result.fetchone()
             assert row is not None, "Query should be found in history"
             assert row[0] == test_query_tag, f"Query tag should be '{test_query_tag}'"
@@ -258,13 +262,17 @@ def test_query_tag_per_query():
                 conn.execute(text("SELECT 3; -- no tag query"))
 
             # Verify the query tags in history
-            result = conn.execute(text("""
+            result = conn.execute(
+                text(
+                    """
                     SELECT QUERY_TEXT, QUERY_TAG
                     FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY_BY_SESSION())
                     WHERE QUERY_TEXT LIKE 'SELECT %; -- batch%'
                        OR QUERY_TEXT LIKE 'SELECT %; -- no tag%'
                     ORDER BY START_TIME DESC
-                    """))
+                    """
+                )
+            )
             rows = result.fetchall()
             query_tags = {row[0]: row[1] for row in rows}
 
@@ -426,12 +434,14 @@ def test_insert_tables(engine_testaccount):
                     ),
                     not_(users.c.id > 5),
                 )
-                expected_sql = textwrap.dedent("""\
+                expected_sql = textwrap.dedent(
+                    """\
                     users.name LIKE :name_1
                      AND users.id = addresses.user_id
                      AND (addresses.email_address = :email_address_1
                      OR addresses.email_address = :email_address_2)
-                     AND users.id <= :id_1""")
+                     AND users.id <= :id_1"""
+                )
                 assert str(obj) == "".join(
                     expected_sql.split("\n")
                 ), "complex condition"
@@ -559,21 +569,27 @@ def test_table_does_not_exist(engine_testaccount):
         Table("does_not_exist", meta, autoload_with=engine_testaccount)
 
 
-@pytest.mark.skip("""
+@pytest.mark.skip(
+    """
 Reflection is not implemented yet.
-""")
+"""
+)
 def test_reflextion(engine_testaccount):
     """
     Tests Reflection
     """
     with engine_testaccount.connect() as conn:
-        engine_testaccount.execute(textwrap.dedent("""\
+        engine_testaccount.execute(
+            textwrap.dedent(
+                """\
             CREATE OR REPLACE TABLE user (
                 id       Integer primary key,
                 name     String,
                 fullname String
             )
-            """))
+            """
+            )
+        )
         try:
             meta = MetaData()
             user_reflected = Table("user", meta, autoload_with=engine_testaccount)
@@ -1085,12 +1101,18 @@ def test_view_definition(engine_testaccount, db_parameters):
     test_view_name = "testview_sqlalchemy"
     with engine_testaccount.connect() as conn:
         with conn.begin():
-            conn.execute(text(textwrap.dedent(f"""\
+            conn.execute(
+                text(
+                    textwrap.dedent(
+                        f"""\
                     CREATE OR REPLACE TABLE {test_table_name} (
                         id INTEGER,
                         name STRING
                     )
-                    """)))
+                    """
+                    )
+                )
+            )
             sql = f"CREATE OR REPLACE VIEW {test_view_name} AS SELECT * FROM {test_table_name} WHERE id > 10"
             conn.execute(text(sql).execution_options(autocommit=True))
         try:
@@ -1114,12 +1136,18 @@ def test_view_comment_reading(engine_testaccount, db_parameters):
     test_view_name = "testview_sqlalchemy"
     with engine_testaccount.connect() as conn:
         with conn.begin():
-            conn.execute(text(textwrap.dedent(f"""\
+            conn.execute(
+                text(
+                    textwrap.dedent(
+                        f"""\
                     CREATE OR REPLACE TABLE {test_table_name} (
                         id INTEGER,
                         name STRING
                     )
-                    """)))
+                    """
+                    )
+                )
+            )
             sql = f"CREATE OR REPLACE VIEW {test_view_name} AS SELECT * FROM {test_table_name} WHERE id > 10"
             conn.execute(text(sql).execution_options(autocommit=True))
             comment_text = "hello my viewing friends"
@@ -1209,12 +1237,14 @@ def test_copy(engine_testaccount):
             users.drop(engine_testaccount)
 
 
-@pytest.mark.skip("""
+@pytest.mark.skip(
+    """
 No transaction works yet in the core API. Use orm API or Python Connector
 directly if needed at the moment.
 Note Snowflake DB supports DML transaction natively, but we have not figured out
 how to integrate with SQLAlchemy core API yet.
-""")
+"""
+)
 def test_transaction(engine_testaccount, db_parameters):
     engine_testaccount.execute(
         text(f"CREATE TABLE {db_parameters['name']} (c1 number)")
@@ -2010,7 +2040,8 @@ def test_column_type_schema(engine_testaccount):
     with engine_testaccount.connect() as conn:
         table_name = random_string(5)
         # column type FIXED not supported, triggers SQL compilation error: Unsupported data type 'FIXED'.
-        conn.exec_driver_sql(f"""\
+        conn.exec_driver_sql(
+            f"""\
 CREATE TEMP TABLE {table_name} (
     C1 BIGINT, C2 BINARY, C3 BOOLEAN, C4 CHAR, C5 CHARACTER, C6 DATE, C7 DATETIME, C8 DEC,
     C9 DECIMAL, C10 DECFLOAT, C11 DOUBLE, C12 FLOAT, C13 INT, C14 INTEGER, C15 NUMBER, C16 REAL,
@@ -2018,7 +2049,8 @@ CREATE TEMP TABLE {table_name} (
     C24 TIMESTAMP_LTZ, C25 TIMESTAMP_NTZ, C26 TINYINT, C27 VARBINARY, C28 VARCHAR, C29 VARIANT,
     C30 OBJECT, C31 ARRAY, C32 GEOGRAPHY, C33 GEOMETRY, C34 VECTOR(INT, 2)
 )
-""")
+"""
+        )
 
         table_reflected = Table(table_name, MetaData(), autoload_with=conn)
         columns = table_reflected.columns
@@ -2030,7 +2062,8 @@ CREATE TEMP TABLE {table_name} (
 def test_result_type_and_value(engine_testaccount):
     with engine_testaccount.connect() as conn:
         table_name = random_string(5)
-        conn.exec_driver_sql(f"""\
+        conn.exec_driver_sql(
+            f"""\
 CREATE TEMP TABLE {table_name} (
     C1 BIGINT, C2 BINARY, C3 BOOLEAN, C4 CHAR, C5 CHARACTER, C6 DATE, C7 DATETIME, C8 DEC(12,3),
     C9 DECIMAL(12,3), C10 DOUBLE, C11 FLOAT, C12 INT, C13 INTEGER, C14 NUMBER, C15 REAL, C16 BYTEINT,
@@ -2038,7 +2071,8 @@ CREATE TEMP TABLE {table_name} (
     C24 TIMESTAMP_NTZ, C25 TINYINT, C26 VARBINARY, C27 VARCHAR, C28 VARIANT, C29 OBJECT, C30 ARRAY, C31 GEOGRAPHY,
     C32 GEOMETRY
 )
-""")
+"""
+        )
         table_reflected = Table(table_name, MetaData(), autoload_with=conn)
         current_date = date.today()
         current_utctime = datetime.utcnow()
@@ -2160,15 +2194,19 @@ SELECT PARSE_JSON('{{"vk1":100, "vk2":200, "vk3":300}}'),
 def test_normalize_and_denormalize_empty_string_column_name(engine_testaccount):
     with engine_testaccount.connect() as conn:
         table_name = random_string(5)
-        conn.exec_driver_sql(f"""
+        conn.exec_driver_sql(
+            f"""
 CREATE OR REPLACE TEMP TABLE {table_name}
 (EMPID INT, DEPT TEXT, JAN INT, FEB INT)
-""")
-        conn.exec_driver_sql(f"""
+"""
+        )
+        conn.exec_driver_sql(
+            f"""
 INSERT INTO {table_name} VALUES
     (1, 'ELECTRONICS', 100, 200),
     (2, 'CLOTHES', 100, 300)
-""")
+"""
+        )
         results = conn.exec_driver_sql(
             f'SELECT * FROM {table_name} UNPIVOT(SALES FOR "" IN (JAN, FEB)) ORDER BY EMPID;'
         ).fetchall()  # normalize_name will be called
@@ -2179,10 +2217,12 @@ INSERT INTO {table_name} VALUES
             (2, "CLOTHES", "FEB", 300),
         ]
 
-        conn.exec_driver_sql(f"""
+        conn.exec_driver_sql(
+            f"""
 CREATE OR REPLACE TEMP TABLE {table_name}
 (COL INT, "" INT)
-""")
+"""
+        )
         inspector = inspect(conn)
         columns = inspector.get_columns(table_name)  # denormalize_name will be called
         assert (

--- a/tests/test_cross_database_reflection.py
+++ b/tests/test_cross_database_reflection.py
@@ -184,37 +184,53 @@ class TestCrossDatabaseReflection:
             # All DDL uses fully-qualified names — no USE DATABASE needed
             conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {current_db}.{schema_a}"))
             conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {current_db}.{schema_b}"))
-            conn.execute(text(f"""
+            conn.execute(
+                text(
+                    f"""
                     CREATE OR REPLACE TABLE {current_db}.{schema_a}.apples (
                         id INTEGER PRIMARY KEY,
                         name VARCHAR(100),
                         color VARCHAR(50)
                     )
-                    """))
-            conn.execute(text(f"""
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    f"""
                     CREATE OR REPLACE TABLE {current_db}.{schema_b}.bananas (
                         id INTEGER PRIMARY KEY,
                         variety VARCHAR(100) UNIQUE,
                         ripeness INTEGER
                     )
-                    """))
-            conn.execute(text(f"""
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    f"""
                     CREATE OR REPLACE TABLE {current_db}.{schema_b}.banana_ratings (
                         rating_id INTEGER PRIMARY KEY,
                         banana_id INTEGER,
                         score INTEGER,
                         FOREIGN KEY (banana_id) REFERENCES {current_db}.{schema_b}.bananas(id)
                     )
-                    """))
+                    """
+                )
+            )
             conn.execute(
                 text(f"CREATE SCHEMA IF NOT EXISTS {current_db}.{dotted_schema}")
             )
-            conn.execute(text(f"""
+            conn.execute(
+                text(
+                    f"""
                     CREATE OR REPLACE TABLE {current_db}.{dotted_schema}.oranges (
                         id INTEGER,
                         juice_content INTEGER
                     )
-                    """))
+                    """
+                )
+            )
             conn.commit()
 
         yield {
@@ -402,12 +418,16 @@ class TestCrossDatabaseReflection:
             current_db, current_schema = result.one()
 
             table_name = "test_single_schema_table"
-            conn.execute(text(f"""
+            conn.execute(
+                text(
+                    f"""
                     CREATE OR REPLACE TABLE {table_name} (
                         id INTEGER,
                         data VARCHAR(100)
                     )
-                    """))
+                    """
+                )
+            )
             conn.commit()
 
             try:

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -138,11 +138,15 @@ def test_numpy_datatypes(engine_testaccount_with_numpy, db_parameters):
 def test_to_sql(engine_testaccount_with_numpy, db_parameters):
     with engine_testaccount_with_numpy.connect() as conn:
         total_rows = 10000
-        conn.exec_driver_sql(textwrap.dedent(f"""\
+        conn.exec_driver_sql(
+            textwrap.dedent(
+                f"""\
                 create or replace table src(c1 float)
                 as select random(123) from table(generator(timelimit=>1))
                 limit {total_rows}
-                """))
+                """
+            )
+        )
         conn.exec_driver_sql("create or replace table dst(c1 float)")
         tbl = pd.read_sql_query(text("select * from src"), conn)
 
@@ -182,25 +186,34 @@ def test_timezone(db_parameters, engine_testaccount, engine_testaccount_with_num
     with sa_engine.connect() as conn:
 
         with conn.begin():
-            conn.exec_driver_sql(textwrap.dedent(f"""\
+            conn.exec_driver_sql(
+                textwrap.dedent(
+                    f"""\
                 CREATE OR REPLACE TABLE {test_table_name}(
                     tz_col timestamp_tz,
                     ntz_col timestamp_ntz,
                     decimal_col decimal(10,1),
                     float_col float
                 );
-                """))
+                """
+                )
+            )
 
-            conn.exec_driver_sql(textwrap.dedent(f"""\
+            conn.exec_driver_sql(
+                textwrap.dedent(
+                    f"""\
                 INSERT INTO {test_table_name}
                     SELECT
                         current_timestamp(),
                         current_timestamp()::timestamp_ntz,
                         to_decimal(.1, 10, 1),
                         .10;
-                """))
+                """
+                )
+            )
         try:
-            qry = textwrap.dedent(f"""\
+            qry = textwrap.dedent(
+                f"""\
             SELECT
                 tz_col,
                 ntz_col,
@@ -209,7 +222,8 @@ def test_timezone(db_parameters, engine_testaccount, engine_testaccount_with_num
                 decimal_col,
                 float_col
             FROM {test_table_name};
-            """)
+            """
+            )
 
             result = pd.read_sql_query(text(qry), conn)
             result2 = pd.read_sql_query(qry, sa_engine2_raw_conn)
@@ -355,12 +369,14 @@ def test_percent_signs(engine_testaccount):
             conn.exec_driver_sql(
                 f"CREATE OR REPLACE TEMP TABLE {table_name}(c1 int, c2 string)"
             )
-            conn.exec_driver_sql(f"""
+            conn.exec_driver_sql(
+                f"""
                 INSERT INTO {table_name}(c1, c2) values
                 (1, 'abc'),
                 (2, 'def'),
                 (3, 'ghi')
-                """)
+                """
+            )
 
             not_like_sql = f"select * from {table_name} where c2 not like '%b%'"
             like_sql = f"select * from {table_name} where c2 like '%b%'"

--- a/tests/test_qmark.py
+++ b/tests/test_qmark.py
@@ -25,10 +25,12 @@ def test_qmark_bulk_insert(engine_testaccount_with_qmark):
 
     with engine_testaccount_with_qmark.connect() as con:
         with con.begin():
-            con.exec_driver_sql("""
+            con.exec_driver_sql(
+                """
                 create or replace table src(c1 int, c2 string) as select seq8(),
                 randstr(100, random()) from table(generator(rowcount=>100000))
-                """)
+                """
+            )
             con.exec_driver_sql("create or replace table dst like src")
 
             for data in pd.read_sql_query(

--- a/tests/test_semi_structured_datatypes.py
+++ b/tests/test_semi_structured_datatypes.py
@@ -33,12 +33,14 @@ def test_create_table_semi_structured_datatypes(engine_testaccount):
         test_variant.drop(engine_testaccount)
 
 
-@pytest.mark.skip("""
+@pytest.mark.skip(
+    """
 Semi-structured data cannot be inserted by INSERT VALUES. Instead,
 INSERT SELECT must be used. The fix should be either 1) SQLAlchemy dialect
 transforms INSERT statement or 2) Snwoflake DB supports INSERT VALUES for
 semi-structured data types. No ETA for this fix.
-""")
+"""
+)
 def test_insert_semi_structured_datatypes(engine_testaccount):
     metadata = MetaData()
     table_name = "test_variant1"
@@ -76,7 +78,8 @@ def test_inspect_semi_structured_datatypes(engine_testaccount):
     try:
         with engine_testaccount.connect() as conn:
             with conn.begin():
-                sql = textwrap.dedent(f"""
+                sql = textwrap.dedent(
+                    f"""
                     INSERT INTO {table_name}(id, va, ar)
                     SELECT 1,
                            PARSE_JSON('{{"vk1":100, "vk2":200, "vk3":300}}'),
@@ -85,7 +88,8 @@ def test_inspect_semi_structured_datatypes(engine_testaccount):
                     {{"k":2, "v":"str2"}},
                     {{"k":3, "v":"str3"}}]'
                     )
-                    """)
+                    """
+                )
                 conn.exec_driver_sql(sql)
                 inspecter = inspect(engine_testaccount)
                 columns = inspecter.get_columns(table_name)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

### Fix `test_division_force_div_is_floordiv_default[operation7] `for SQLAlchemy 2.0.50
SQLAlchemy 2.0.50 corrected `visit_floordiv_binary` in the base compiler to emit `FLOOR(x / y) `instead of plain `x / y`. The Snowflake dialect defers entirely to `super()` for `//`, so it inherits the change.

`operation7` expected `0.6875 for literal(5.5) // literal(8)` — the result of un-floored true division that SA 2.0.49 happened to emit. The correct floor-division result is `FLOOR(0.6875) = 0.0`, which SA 2.0.50 now produces.

### pre-commit updates
- Pin isort to 5.13.2 (was 9.0.0a3, alpha requiring Python >=3.10)
- Pin pyupgrade to v3.18.0 (was v3.21.2, requiring Python >=3.10)
- Pin black to 24.10.0 (was 26.5.1, requiring Python >=3.10)
- Add default_language_version: python3 so pre-commit uses the active virtualenv's Python instead of discovering its own
- Reformat affected files to comply with black 24.10.0 style