### PR TITLE
SNOW-3480955: table reflection improvements

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at:
 # Unreleased Notes
 
 - Fix `regexp_match` and `regexp_replace` flags rendered as bound parameters instead of literal strings ([#SNOW-3573046](https://github.com/snowflakedb/snowflake-sqlalchemy)). Flags passed to `ColumnElement.regexp_match(..., flags=...)` and `ColumnElement.regexp_replace(..., flags=...)` were processed through the standard parameter pipeline, producing incorrect SQL. Flags are now rendered as inline string literals, matching Snowflake's expected `REGEXP_LIKE(col, pattern, 'i')` / `REGEXP_REPLACE(col, pattern, replacement, 'i')` syntax.
+- Fix inconsistent identifier quoting in `_StructuredTypeInfoManager.get_table_columns`. The `DESC TABLE` fallback path used raw denormalised names in an f-string while all other reflection paths apply `ip.quote(denormalize_name(...))` via `_always_quote_join`. Schema and table components are now consistently double-quoted before the statement is constructed, and the method delegates to `get_table_columns_by_full_name` to collapse the two previously divergent code paths.
 
 # Release Notes
 

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -89,13 +89,10 @@ class _StructuredTypeInfoManager:
             )
             table_name = str(parts[-1])
 
-        table_schema = self.name_utils.denormalize_name(schema)
-        table_name = self.name_utils.denormalize_name(table_name)
-        result = self._execute_desc(f"{table_schema}.{table_name}")
-        if not result:
-            return []
-
-        return self._parse_desc_result(result)
+        ip = self.name_utils.identifier_preparer
+        quoted_schema = ip.quote(self.name_utils.denormalize_name(schema))
+        quoted_table = ip.quote(self.name_utils.denormalize_name(table_name))
+        return self.get_table_columns_by_full_name(f"{quoted_schema}.{quoted_table}")
 
     def _parse_desc_result(self, result):
         """Parse DESC TABLE result into column information"""

--- a/tests/test_structured_datatypes.py
+++ b/tests/test_structured_datatypes.py
@@ -25,6 +25,7 @@ from snowflake.sqlalchemy import NUMBER, IcebergTable, SnowflakeTable
 from snowflake.sqlalchemy.custom_types import ARRAY, MAP, OBJECT, TEXT
 from snowflake.sqlalchemy.exc import StructuredTypeNotSupportedInTableColumnsError
 from snowflake.sqlalchemy.name_utils import _NameUtils
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 from snowflake.sqlalchemy.structured_type_info_manager import _StructuredTypeInfoManager
 
 
@@ -603,14 +604,10 @@ def test_structured_type_not_supported_in_table_columns_error(
 
 
 @patch.object(_StructuredTypeInfoManager, "_execute_desc")
-@patch.object(_NameUtils, "denormalize_name")
-def test_structured_type_on_dropped_table(
-    mocked_denormalize_name_method, mocked_execute_desc_method
-):
+def test_structured_type_on_dropped_table(mocked_execute_desc_method):
     mocked_execute_desc_method.return_value = None
-    mocked_denormalize_name_method.side_effect = lambda v: v
     structured_type_info = _StructuredTypeInfoManager(
-        None, _NameUtils(None), "mySchema"
+        None, _NameUtils(SnowflakeDialect().identifier_preparer), "mySchema"
     )
     result = structured_type_info.get_column_info(
         "mySchema", "dropped_table", "structured_type_col"
@@ -619,10 +616,7 @@ def test_structured_type_on_dropped_table(
 
 
 @patch.object(_StructuredTypeInfoManager, "_execute_desc")
-@patch.object(_NameUtils, "denormalize_name")
-def test_structured_type_on_table_with_map(
-    mocked_denormalize_name_method, mocked_execute_desc_method
-):
+def test_structured_type_on_table_with_map(mocked_execute_desc_method):
     mocked_execute_desc_method.return_value = [
         [
             "myCol",
@@ -637,9 +631,8 @@ def test_structured_type_on_table_with_map(
             "MapColumn",
         ]
     ]
-    mocked_denormalize_name_method.side_effect = lambda v: v
     structured_type_info = _StructuredTypeInfoManager(
-        None, _NameUtils(None), "mySchema"
+        None, _NameUtils(SnowflakeDialect().identifier_preparer), "mySchema"
     )
     result = structured_type_info.get_column_info("mySchema", "dropped_table", "myCol")
     assert result is not None

--- a/tests/test_unit_structured_type_info_manager.py
+++ b/tests/test_unit_structured_type_info_manager.py
@@ -1,0 +1,204 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+"""
+Unit tests for _StructuredTypeInfoManager.get_table_columns identifier quoting.
+
+These tests guard against the SQL injection vulnerability reported in
+SNOW-3480955, where unquoted identifiers in the DESC TABLE fallback path
+allowed arbitrary SQL to be injected via table_name / schema.
+
+The tests assert the *correct* (post-fix) behaviour:
+  - Every identifier component is double-quoted in the emitted SQL.
+  - An injection payload embedded in a name is enclosed in double-quotes and
+    cannot execute as a separate SQL statement.
+
+All tests run without a live Snowflake connection — the connection is mocked
+and we inspect the SQL string that would be sent to the server.
+"""
+
+import re
+from unittest.mock import MagicMock
+
+from snowflake.sqlalchemy.name_utils import _NameUtils
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+from snowflake.sqlalchemy.structured_type_info_manager import _StructuredTypeInfoManager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(default_schema="PUBLIC"):
+    """Return a (_StructuredTypeInfoManager, captured_sql list) pair.
+
+    The connection is mocked; every SQL string passed to _execute_desc is
+    appended to *captured_sql* so tests can assert on what would be sent.
+    """
+    dialect = SnowflakeDialect()
+    name_utils = _NameUtils(dialect.identifier_preparer)
+
+    captured_sql: list[str] = []
+
+    def _capture_execute(text_clause):
+        captured_sql.append(text_clause.text)
+        return iter([])  # empty result — _parse_desc_result returns []
+
+    conn = MagicMock()
+    conn.execute.side_effect = _capture_execute
+
+    manager = _StructuredTypeInfoManager(conn, name_utils, default_schema)
+    return manager, captured_sql
+
+
+def _first_sql(captured: list[str]) -> str:
+    assert captured, "No SQL was captured — _execute_desc was never called"
+    return captured[0]
+
+
+# ---------------------------------------------------------------------------
+# Quoting correctness — normal identifiers
+# ---------------------------------------------------------------------------
+
+
+def test_plain_lowercase_identifiers_are_quoted():
+    """Plain lowercase schema + table are uppercased then double-quoted."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("mytable", schema="myschema")
+
+    sql = _first_sql(captured)
+    assert (
+        '"MYSCHEMA"."MYTABLE"' in sql
+    ), f"Expected double-quoted MYSCHEMA.MYTABLE in SQL, got: {sql!r}"
+
+
+def test_plain_uppercase_identifiers_are_quoted():
+    """Identifiers that arrive already uppercased are still double-quoted."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("MYTABLE", schema="MYSCHEMA")
+
+    sql = _first_sql(captured)
+    assert (
+        '"MYSCHEMA"."MYTABLE"' in sql
+    ), f"Expected double-quoted MYSCHEMA.MYTABLE in SQL, got: {sql!r}"
+
+
+def test_mixed_case_identifier_is_quoted():
+    """Mixed-case names that require quoting are enclosed in double-quotes."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("MyTable", schema="MySchema")
+
+    sql = _first_sql(captured)
+    # Mixed-case names are returned unchanged by denormalize_name; ip.quote
+    # wraps them in double-quotes because lc != value.
+    assert '"MyTable"' in sql, f'Expected "MyTable" quoted in SQL, got: {sql!r}'
+    assert '"MySchema"' in sql, f'Expected "MySchema" quoted in SQL, got: {sql!r}'
+
+
+def test_default_schema_used_when_schema_is_none():
+    """When schema=None the default_schema provided at construction is used."""
+    manager, captured = _make_manager(default_schema="myschema")
+    manager.get_table_columns("mytable", schema=None)
+
+    sql = _first_sql(captured)
+    assert (
+        '"MYSCHEMA"' in sql
+    ), f"Expected default schema MYSCHEMA to appear quoted, got: {sql!r}"
+    assert '"MYTABLE"' in sql
+
+
+def test_dotted_table_name_uses_only_last_component():
+    """A table_name of 'schema.table' splits on '.'; only the last part is used."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("myschema.mytable", schema="myschema")
+
+    sql = _first_sql(captured)
+    # Exactly one schema qualifier — 'myschema' should not appear twice
+    assert (
+        sql.count('"MYSCHEMA"') == 1
+    ), f"Schema appeared more than once in SQL, got: {sql!r}"
+    assert '"MYTABLE"' in sql
+
+
+# ---------------------------------------------------------------------------
+# SQL injection — table_name payload
+# ---------------------------------------------------------------------------
+
+
+def test_semicolon_in_table_name_is_enclosed_in_double_quotes():
+    """Semicolons in table_name must not escape double-quote enclosure (SNOW-3480955)."""
+    payload = "foo; SELECT 1--"
+    manager, captured = _make_manager()
+    manager.get_table_columns(payload, schema="myschema")
+
+    sql = _first_sql(captured)
+    # The payload must appear inside double-quotes in the SQL string
+    assert (
+        f'"{payload}"' in sql
+    ), f"Payload was not enclosed in double-quotes; got: {sql!r}"
+    # No bare semicolon must appear outside a quoted identifier
+    # Strip everything inside double-quoted segments, then check for semicolons
+    stripped = re.sub(r'"[^"]*"', "", sql)
+    assert (
+        ";" not in stripped
+    ), f"Semicolon escaped double-quote enclosure; got: {sql!r}"
+
+
+def test_drop_statement_injection_in_table_name_is_quoted():
+    """Classic DROP TABLE injection payload in table_name is neutralised by quoting."""
+    payload = "x'; DROP TABLE users--"
+    manager, captured = _make_manager()
+    manager.get_table_columns(payload, schema="myschema")
+
+    sql = _first_sql(captured)
+    assert f'"{payload}"' in sql, f"Payload not enclosed in double-quotes; got: {sql!r}"
+    stripped = re.sub(r'"[^"]*"', "", sql)
+    assert (
+        "DROP" not in stripped
+    ), f"DROP keyword escaped double-quote enclosure; got: {sql!r}"
+
+
+def test_newline_injection_in_table_name_is_quoted():
+    """Newline characters in table_name are enclosed in double-quotes."""
+    payload = "foo\nSELECT 1"
+    manager, captured = _make_manager()
+    manager.get_table_columns(payload, schema="myschema")
+
+    sql = _first_sql(captured)
+    assert f'"{payload}"' in sql, f"Payload not enclosed in double-quotes; got: {sql!r}"
+
+
+# ---------------------------------------------------------------------------
+# SQL injection — schema payload
+# ---------------------------------------------------------------------------
+
+
+def test_semicolon_in_schema_is_enclosed_in_double_quotes():
+    """Injection payload in schema is also double-quoted (SNOW-3480955)."""
+    payload = "myschema; SELECT 1--"
+    manager, captured = _make_manager()
+    manager.get_table_columns("mytable", schema=payload)
+
+    sql = _first_sql(captured)
+    assert (
+        f'"{payload}"' in sql
+    ), f"Schema payload not enclosed in double-quotes; got: {sql!r}"
+    stripped = re.sub(r'"[^"]*"', "", sql)
+    assert (
+        ";" not in stripped
+    ), f"Semicolon escaped double-quote enclosure in schema; got: {sql!r}"
+
+
+# ---------------------------------------------------------------------------
+# DESC TABLE statement shape
+# ---------------------------------------------------------------------------
+
+
+def test_desc_table_statement_structure():
+    """The emitted SQL is a DESC TABLE … TYPE = COLUMNS statement."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("mytable", schema="myschema")
+
+    sql = _first_sql(captured)
+    assert sql.startswith("DESC"), f"Expected DESC statement, got: {sql!r}"
+    assert "TYPE = COLUMNS" in sql, f"Missing TYPE = COLUMNS clause, got: {sql!r}"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-3480955

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Fix inconsistent identifier quoting in the `DESC TABLE` structured-type fallback path
- `_StructuredTypeInfoManager.get_table_columns` was the only reflection path that built a `DESC TABLE` identifier string via raw f-string concatenation on denormalised names. Every other path in the dialect applies `ip.quote(denormalize_name(...))` — either directly or through `_always_quote_join`. Schema and table components are now double-quoted consistently before the statement is constructed, matching the established pattern.
- `get_table_columns` is simplified by delegating to the existing `get_table_columns_by_full_name` once quoting is applied. This collapses two previously divergent code paths (the SA 2.x / `cache_column_metadata=True` path and the SA 1.4 fallback) into one.
- Two tests in `test_structured_datatypes.py` (`test_structured_type_on_dropped_table`, `test_structured_type_on_table_with_map`) were constructed with `_NameUtils(None)` and a `denormalize_name`
  patch to compensate. The patch masked a latent dependency on a real `identifier_preparer` that the quoting alignment exposed. Both tests now use `_NameUtils(SnowflakeDialect().identifier_preparer) `and drop the unnecessary patch, making them consistent with the rest of the test suite.
- Added `tests/test_unit_structured_type_info_manager.py` with 10 unit tests covering quoting correctness for plain, uppercase, mixed-case, dotted, and special-character identifiers in both the schema and table name positions.
