### PR TITLE
SNOW-3480955 follow-up: split database-qualified schema before quoting in structured-type reflection

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,8 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Fix double-escaped identifier quoting for database-qualified schemas in `_StructuredTypeInfoManager.get_table_columns`. Since v1.10.1 the schema was quoted as a single identifier, so a qualified schema such as `"MYDB"."MYSCHEMA"` became `"""MYDB"".""MYSCHEMA"""` and the `DESC TABLE` fallback failed (emitting a `Failed to reflect table ... sqlalchemy:_get_schema_columns` warning) for every structured-typed table when reflecting a non-default `database.schema`. The schema is now split on the dot and each component is double-quoted individually, preserving the SNOW-3480955 injection guard while correctly handling qualified schemas.
+
 # Release Notes
 
 - v1.10.1 (June 15, 2026)

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -83,16 +83,39 @@ class _StructuredTypeInfoManager:
         """Get all columns in a table in a schema"""
         schema = schema if schema else self.default_schema
 
+        ip = self.name_utils.identifier_preparer
+
         if "." in str(table_name):
-            parts = self.name_utils.identifier_preparer._split_schema_by_dot(
-                str(table_name)
-            )
+            parts = ip._split_schema_by_dot(str(table_name))
             table_name = str(parts[-1])
 
+        # Quote each component of a (possibly database-qualified) schema
+        # separately instead of quoting the whole dotted string as a single
+        # identifier. Quoting ``"MYDB"."MYSCHEMA"`` as one identifier double-
+        # escapes the existing quotes (``"""MYDB"".""MYSCHEMA"""``) and breaks
+        # the DESC TABLE fallback. Splitting on the dot — while preserving
+        # explicit quotes around a component (e.g. ``"my.schema"``) — keeps the
+        # injection guard (every component is still double-quoted) and mirrors
+        # the schema-wide reflection path's ``_always_quote_join`` behaviour.
+        components = [
+            self._quote_component(component)
+            for component in ip._split_schema_by_dot(schema)
+        ]
+        components.append(self._quote_component(table_name))
+        return self.get_table_columns_by_full_name(".".join(components))
+
+    def _quote_component(self, component) -> str:
+        """Unconditionally double-quote a single identifier component.
+
+        A component flagged as explicitly quoted (``quote=True``) is taken
+        verbatim; otherwise it is denormalized first so a plain lowercase name
+        matches how Snowflake stores it.
+        """
         ip = self.name_utils.identifier_preparer
-        quoted_schema = ip.quote(self.name_utils.denormalize_name(schema))
-        quoted_table = ip.quote(self.name_utils.denormalize_name(table_name))
-        return self.get_table_columns_by_full_name(f"{quoted_schema}.{quoted_table}")
+        name = str(component)
+        if getattr(component, "quote", None):
+            return ip.quote_identifier(name)
+        return ip.quote_identifier(self.name_utils.denormalize_name(name))
 
     def _parse_desc_result(self, result):
         """Parse DESC TABLE result into column information"""

--- a/tests/test_unit_structured_type_info_manager.py
+++ b/tests/test_unit_structured_type_info_manager.py
@@ -202,3 +202,44 @@ def test_desc_table_statement_structure():
     sql = _first_sql(captured)
     assert sql.startswith("DESC"), f"Expected DESC statement, got: {sql!r}"
     assert "TYPE = COLUMNS" in sql, f"Missing TYPE = COLUMNS clause, got: {sql!r}"
+
+
+# ---------------------------------------------------------------------------
+# Database-qualified schema quoting (regression: see issue)
+# ---------------------------------------------------------------------------
+
+
+def test_unquoted_database_qualified_schema_is_split_and_quoted():
+    """``MYDB.MYSCHEMA`` must become ``"MYDB"."MYSCHEMA"``, not a single quoted
+    identifier ``"MYDB.MYSCHEMA"``."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("mytable", schema="mydb.myschema")
+
+    sql = _first_sql(captured)
+    assert (
+        '"MYDB"."MYSCHEMA"."MYTABLE"' in sql
+    ), f"Qualified schema not split into quoted components; got: {sql!r}"
+
+
+def test_quoted_database_qualified_schema_is_not_double_escaped():
+    """An already-quoted qualified schema must be preserved, not re-quoted as a
+    single identifier with the inner quotes doubled (the regression)."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("mytable", schema='"MYDB"."MYSCHEMA"')
+
+    sql = _first_sql(captured)
+    assert (
+        '"MYDB"."MYSCHEMA"."MYTABLE"' in sql
+    ), f"Already-quoted qualified schema was double-escaped; got: {sql!r}"
+    assert '"""' not in sql, f"Found triple double-quote (double escaping); got: {sql!r}"
+
+
+def test_quoted_component_with_literal_dot_is_preserved():
+    """A quoted component containing a literal dot is treated as one identifier."""
+    manager, captured = _make_manager()
+    manager.get_table_columns("mytable", schema='"my.schema"')
+
+    sql = _first_sql(captured)
+    assert (
+        '"my.schema"."MYTABLE"' in sql
+    ), f"Quoted component with a literal dot was mis-split; got: {sql!r}"


### PR DESCRIPTION
1. What GitHub issue is this PR addressing?

   Fixes #697

2. Pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. How does this code solve the issue?

   `_StructuredTypeInfoManager.get_table_columns` quoted a database-qualified
   schema as a **single** identifier via `ip.quote(denormalize_name(schema))`.
   For `"MYDB"."MYSCHEMA"` this double-escapes the existing quotes into
   `"""MYDB"".""MYSCHEMA"""`, so the `DESC TABLE` fallback fails and a
   `Failed to reflect table ... sqlalchemy:_get_schema_columns` warning is
   emitted for every structured-typed table when reflecting a non-default
   `database.schema` (regression introduced in 1.10.1, SNOW-3480955).

   The schema is now split with `_split_schema_by_dot` and each component is
   double-quoted individually (explicitly-quoted components are kept verbatim),
   mirroring the schema-wide reflection path's `_always_quote_join`. This keeps
   the SNOW-3480955 injection guard — every component is still fully
   double-quoted — while correctly handling qualified schemas.

   Emitted `DESC` for `schema='"MYDB"."MYSCHEMA"'`, table `MY_TABLE`:
   - Before: `... TABLE """MYDB"".""MYSCHEMA"""."MY_TABLE" ...`  ❌
   - After:  `... TABLE "MYDB"."MYSCHEMA"."MY_TABLE" ...`        ✅

   Adds regression tests in `tests/test_unit_structured_type_info_manager.py`
   (unquoted and already-quoted qualified schemas, plus a quoted component
   containing a literal dot). All existing unit tests — including the
   SNOW-3480955 injection tests — still pass.
