### PR TITLE
mraba/quoting-unification: unify always-quote identifier logic into `_NameUtil`

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,15 @@ Source code is also available at:
 # Unreleased Notes
 
 - Fix double-escaped identifier quoting for database-qualified schemas in `_StructuredTypeInfoManager.get_table_columns`. Since v1.10.1 the schema was quoted as a single identifier, so a qualified schema such as `"MYDB"."MYSCHEMA"` became `"""MYDB"".""MYSCHEMA"""` and the `DESC TABLE` fallback failed (emitting a `Failed to reflect table ... sqlalchemy:_get_schema_columns` warning) for every structured-typed table when reflecting a non-default `database.schema`. The schema is now split on the dot and each component is double-quoted individually, preserving the SNOW-3480955 injection guard while correctly handling qualified schemas.
+- Unify always-quote identifier logic into `_NameUtils`. Move the canonical
+  `_quote_component` / `always_quote_join` helpers onto `_NameUtils` so
+  `SnowflakeDialect._always_quote_join`, `_get_full_schema_name`, and
+  `_StructuredTypeInfoManager.get_table_columns` all share one implementation,
+  eliminating the divergence that caused the v1.10.1 regression. As a
+  side-effect, corrects the quoting of `quoted_name("myschema", True)` (an
+  explicitly case-sensitive lowercase identifier): the old `_always_quote_join`
+  called `str()` before inspecting the `quote` attribute, silently uppercasing
+  the name to `"MYSCHEMA"` and discarding the case-sensitivity signal.
 
 # Release Notes
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,15 +10,6 @@ Source code is also available at:
 # Unreleased Notes
 
 - Fix double-escaped identifier quoting for database-qualified schemas in `_StructuredTypeInfoManager.get_table_columns`. Since v1.10.1 the schema was quoted as a single identifier, so a qualified schema such as `"MYDB"."MYSCHEMA"` became `"""MYDB"".""MYSCHEMA"""` and the `DESC TABLE` fallback failed (emitting a `Failed to reflect table ... sqlalchemy:_get_schema_columns` warning) for every structured-typed table when reflecting a non-default `database.schema`. The schema is now split on the dot and each component is double-quoted individually, preserving the SNOW-3480955 injection guard while correctly handling qualified schemas.
-- Unify always-quote identifier logic into `_NameUtils`. Move the canonical
-  `_quote_component` / `always_quote_join` helpers onto `_NameUtils` so
-  `SnowflakeDialect._always_quote_join`, `_get_full_schema_name`, and
-  `_StructuredTypeInfoManager.get_table_columns` all share one implementation,
-  eliminating the divergence that caused the v1.10.1 regression. As a
-  side-effect, corrects the quoting of `quoted_name("myschema", True)` (an
-  explicitly case-sensitive lowercase identifier): the old `_always_quote_join`
-  called `str()` before inspecting the `quote` attribute, silently uppercasing
-  the name to `"MYSCHEMA"` and discarding the case-sensitivity signal.
 
 # Release Notes
 

--- a/src/snowflake/sqlalchemy/name_utils.py
+++ b/src/snowflake/sqlalchemy/name_utils.py
@@ -1,6 +1,9 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 
+import operator
+from functools import reduce
+
 from sqlalchemy.sql.compiler import IdentifierPreparer
 from sqlalchemy.sql.elements import quoted_name
 
@@ -61,3 +64,42 @@ class _NameUtils:
         ):
             name = name.upper()
         return name
+
+    def _quote_component(self, component) -> str:
+        """Unconditionally double-quote a single pre-split identifier component.
+
+        Components marked ``quote=True`` are taken verbatim (case preserved);
+        others are denormalized first so a plain lowercase name maps to the
+        Snowflake-stored uppercase form.
+
+        Use this only for parts that were already extracted by
+        ``_split_schema_by_dot`` — do NOT call it on dotted strings because
+        it will not split them first.
+        """
+        ip = self.identifier_preparer
+        name = str(component)
+        if getattr(component, "quote", None):
+            return ip.quote_identifier(name)
+        return ip.quote_identifier(self.denormalize_name(name))
+
+    def always_quote_join(self, *idents) -> str:
+        """Build a dot-joined SQL identifier string that always quotes every part.
+
+        Each identifier in *idents is split on unquoted dots via
+        ``_split_schema_by_dot`` (so ``"db.schema"`` becomes two components),
+        then every component is unconditionally double-quoted via
+        ``_quote_component``.
+
+        Do NOT pass pre-split parts that may contain literal dots (e.g. a
+        component extracted from ``'"my.schema"'``).  Use ``_quote_component``
+        directly on each pre-split part instead.
+        """
+        split_idents = reduce(
+            operator.add,
+            [
+                self.identifier_preparer._split_schema_by_dot(ids)
+                for ids in idents
+                if ids is not None
+            ],
+        )
+        return ".".join(self._quote_component(i) for i in split_idents)

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -354,28 +354,11 @@ class SnowflakeDialect(default.DefaultDialect):
     def _always_quote_join(self, *idents):
         """Build a dot-joined identifier string that always quotes every part.
 
-        Unlike _denormalize_quote_join (which quotes only when _requires_quotes
-        demands it), this helper denormalizes each segment first and then
-        unconditionally wraps it in double-quotes.  This is safe because quoting
-        a denormalized Snowflake identifier is semantically equivalent to the
-        unquoted form for case-insensitive names, while also being correct for
-        case-sensitive ones.
-
-        IMPORTANT: denormalization must happen before quoting.  Quoting the
-        SA-normalized (lowercase) form would produce "my_table" which Snowflake
-        resolves as a case-sensitive reference to a table literally stored as
-        my_table — different from the stored MY_TABLE.
-
-        Only use this for new, single-table SQL helpers.  Existing callers of
-        _denormalize_quote_join must not be changed to avoid altering SQL output
-        for existing users (backward-compatibility constraint).
+        Delegates to ``_NameUtils.always_quote_join`` — see that method for
+        the full contract.  The dialect accessor exists for backward
+        compatibility with callers inside this class.
         """
-        ip = self.identifier_preparer
-        split_idents = reduce(
-            operator.add,
-            [ip._split_schema_by_dot(ids) for ids in idents if ids is not None],
-        )
-        return ".".join(ip.quote(self.denormalize_name(i)) for i in split_idents)
+        return self.name_utils.always_quote_join(*idents)
 
     def _get_full_schema_name(self, connection, schema=None, **kw):
         """
@@ -407,24 +390,10 @@ class SnowflakeDialect(default.DefaultDialect):
                     f"'database.schema', got {len(parts)} parts"
                 )
 
-        # Quote each part unconditionally and preserve explicit quoted-name
-        # boundaries from _split_schema_by_dot. Do NOT pass through
-        # _denormalize_quote_join, which would re-split parts containing
-        # literal dots (e.g. "schema.with.dots").
-        quoted_parts = []
-        for part in parts:
-            part_name = str(part)
-            if getattr(part, "quote", None):
-                quoted_parts.append(
-                    self.identifier_preparer.quote_identifier(part_name)
-                )
-            else:
-                quoted_parts.append(
-                    self.identifier_preparer.quote_identifier(
-                        self.denormalize_name(part_name)
-                    )
-                )
-        return ".".join(quoted_parts)
+        # Quote each pre-split part unconditionally, preserving explicit
+        # quoted-name boundaries.  Do NOT re-split via always_quote_join
+        # because parts may contain literal dots (e.g. "schema.with.dots").
+        return ".".join(self.name_utils._quote_component(p) for p in parts)
 
     @reflection.cache
     def _current_database_schema(self, connection, **kw):

--- a/src/snowflake/sqlalchemy/structured_type_info_manager.py
+++ b/src/snowflake/sqlalchemy/structured_type_info_manager.py
@@ -83,39 +83,13 @@ class _StructuredTypeInfoManager:
         """Get all columns in a table in a schema"""
         schema = schema if schema else self.default_schema
 
-        ip = self.name_utils.identifier_preparer
-
         if "." in str(table_name):
-            parts = ip._split_schema_by_dot(str(table_name))
-            table_name = str(parts[-1])
+            ip = self.name_utils.identifier_preparer
+            table_name = ip._split_schema_by_dot(str(table_name))[-1]
 
-        # Quote each component of a (possibly database-qualified) schema
-        # separately instead of quoting the whole dotted string as a single
-        # identifier. Quoting ``"MYDB"."MYSCHEMA"`` as one identifier double-
-        # escapes the existing quotes (``"""MYDB"".""MYSCHEMA"""``) and breaks
-        # the DESC TABLE fallback. Splitting on the dot — while preserving
-        # explicit quotes around a component (e.g. ``"my.schema"``) — keeps the
-        # injection guard (every component is still double-quoted) and mirrors
-        # the schema-wide reflection path's ``_always_quote_join`` behaviour.
-        components = [
-            self._quote_component(component)
-            for component in ip._split_schema_by_dot(schema)
-        ]
-        components.append(self._quote_component(table_name))
-        return self.get_table_columns_by_full_name(".".join(components))
-
-    def _quote_component(self, component) -> str:
-        """Unconditionally double-quote a single identifier component.
-
-        A component flagged as explicitly quoted (``quote=True``) is taken
-        verbatim; otherwise it is denormalized first so a plain lowercase name
-        matches how Snowflake stores it.
-        """
-        ip = self.name_utils.identifier_preparer
-        name = str(component)
-        if getattr(component, "quote", None):
-            return ip.quote_identifier(name)
-        return ip.quote_identifier(self.name_utils.denormalize_name(name))
+        return self.get_table_columns_by_full_name(
+            self.name_utils.always_quote_join(schema, table_name)
+        )
 
     def _parse_desc_result(self, result):
         """Parse DESC TABLE result into column information"""

--- a/tests/test_unit_name_utils.py
+++ b/tests/test_unit_name_utils.py
@@ -29,130 +29,116 @@ def nu():
 # ---------------------------------------------------------------------------
 
 
-class TestQuoteComponent:
-    def test_plain_lowercase_is_uppercased_and_quoted(self, nu):
-        assert nu._quote_component(quoted_name("myschema", None)) == '"MYSCHEMA"'
-
-    def test_plain_uppercase_is_quoted(self, nu):
-        assert nu._quote_component(quoted_name("MYSCHEMA", None)) == '"MYSCHEMA"'
-
-    def test_mixed_case_without_explicit_quote_is_quoted(self, nu):
-        assert nu._quote_component(quoted_name("MySchema", None)) == '"MySchema"'
-
-    def test_quote_true_preserves_lowercase_no_denormalization(self, nu):
-        # quote=True signals the identifier was double-quoted at the source and
-        # is case-sensitive.  denormalize_name must NOT uppercase it.
-        assert nu._quote_component(quoted_name("myschema", True)) == '"myschema"'
-
-    def test_quote_true_mixed_case_preserved(self, nu):
-        assert nu._quote_component(quoted_name("MySchema", True)) == '"MySchema"'
-
-    def test_internal_double_quote_is_escaped(self, nu):
-        result = nu._quote_component(quoted_name('my"schema', None))
-        assert result.startswith('"') and result.endswith('"')
-        assert '""' in result  # SQL double-quote escaping
-
-
-# ---------------------------------------------------------------------------
-# always_quote_join — normal identifiers
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "component, expected",
+    [
+        pytest.param(
+            quoted_name("myschema", None), '"MYSCHEMA"', id="lowercase→uppercase"
+        ),
+        pytest.param(quoted_name("MYSCHEMA", None), '"MYSCHEMA"', id="uppercase"),
+        pytest.param(quoted_name("MySchema", None), '"MySchema"', id="mixed-case"),
+        pytest.param(
+            quoted_name("myschema", True),
+            '"myschema"',
+            id="quote=True preserves lowercase",
+        ),
+        pytest.param(
+            quoted_name("MySchema", True),
+            '"MySchema"',
+            id="quote=True preserves mixed-case",
+        ),
+    ],
+)
+def test_quote_component(nu, component, expected):
+    assert nu._quote_component(component) == expected
 
 
-class TestAlwaysQuoteJoinNormal:
-    def test_plain_lowercase_schema_and_table(self, nu):
-        assert nu.always_quote_join("myschema", "mytable") == '"MYSCHEMA"."MYTABLE"'
-
-    def test_plain_uppercase_schema_and_table(self, nu):
-        assert nu.always_quote_join("MYSCHEMA", "MYTABLE") == '"MYSCHEMA"."MYTABLE"'
-
-    def test_mixed_case_schema_and_table(self, nu):
-        result = nu.always_quote_join("MySchema", "MyTable")
-        assert result == '"MySchema"."MyTable"'
-
-    def test_none_ident_is_skipped(self, nu):
-        assert (
-            nu.always_quote_join(None, "myschema", "mytable") == '"MYSCHEMA"."MYTABLE"'
-        )
-
-    def test_single_ident(self, nu):
-        assert nu.always_quote_join("myschema") == '"MYSCHEMA"'
+def test_quote_component_escapes_internal_double_quote(nu):
+    result = nu._quote_component(quoted_name('my"schema', None))
+    assert result.startswith('"') and result.endswith('"')
+    assert '""' in result  # SQL double-quote escaping
 
 
 # ---------------------------------------------------------------------------
-# always_quote_join — database-qualified schemas (1.10.1 regression guard)
+# always_quote_join
 # ---------------------------------------------------------------------------
 
 
-class TestAlwaysQuoteJoinDatabaseQualified:
-    def test_unquoted_db_qualified_schema_is_split(self, nu):
-        # Primary regression: MYDB.MYSCHEMA must become "MYDB"."MYSCHEMA",
-        # not "MYDB.MYSCHEMA" (a single identifier containing a literal dot).
-        result = nu.always_quote_join("MYDB.MYSCHEMA", "mytable")
-        assert result == '"MYDB"."MYSCHEMA"."MYTABLE"'
-
-    def test_lowercase_db_qualified_schema_is_split_and_uppercased(self, nu):
-        result = nu.always_quote_join("mydb.myschema", "mytable")
-        assert result == '"MYDB"."MYSCHEMA"."MYTABLE"'
-
-    def test_pre_quoted_db_qualified_schema_not_double_escaped(self, nu):
-        # If the schema string already contains SQL double-quotes around each
-        # component, the parser must strip and re-quote correctly.
-        result = nu.always_quote_join('"MYDB"."MYSCHEMA"', "mytable")
-        assert result == '"MYDB"."MYSCHEMA"."MYTABLE"'
-        assert '"""' not in result
-
-    def test_literal_dot_inside_quoted_component_not_split(self, nu):
-        # A quoted component containing a literal dot must not be re-split.
-        result = nu.always_quote_join('"my.schema"', "mytable")
-        assert result == '"my.schema"."MYTABLE"'
+@pytest.mark.parametrize(
+    "idents, expected",
+    [
+        # plain identifiers
+        pytest.param(
+            ("myschema", "mytable"), '"MYSCHEMA"."MYTABLE"', id="plain lowercase"
+        ),
+        pytest.param(
+            ("MYSCHEMA", "MYTABLE"), '"MYSCHEMA"."MYTABLE"', id="plain uppercase"
+        ),
+        pytest.param(("MySchema", "MyTable"), '"MySchema"."MyTable"', id="mixed case"),
+        pytest.param(
+            (None, "myschema", "mytable"), '"MYSCHEMA"."MYTABLE"', id="None skipped"
+        ),
+        pytest.param(("myschema",), '"MYSCHEMA"', id="single ident"),
+        # database-qualified schemas — 1.10.1 regression guard
+        pytest.param(
+            ("MYDB.MYSCHEMA", "mytable"),
+            '"MYDB"."MYSCHEMA"."MYTABLE"',
+            id="unquoted db-qualified schema",
+        ),
+        pytest.param(
+            ("mydb.myschema", "mytable"),
+            '"MYDB"."MYSCHEMA"."MYTABLE"',
+            id="lowercase db-qualified schema",
+        ),
+        pytest.param(
+            ('"MYDB"."MYSCHEMA"', "mytable"),
+            '"MYDB"."MYSCHEMA"."MYTABLE"',
+            id="pre-quoted db-qualified schema",
+        ),
+        pytest.param(
+            ('"my.schema"', "mytable"),
+            '"my.schema"."MYTABLE"',
+            id="literal dot in quoted component not split",
+        ),
+        pytest.param(
+            ("myschema", "foo.bar"),
+            '"MYSCHEMA"."FOO"."BAR"',
+            id="dot in table splits into components",
+        ),
+        # case-sensitivity signal (quote=True) preserved
+        pytest.param(
+            (quoted_name("myschema", True), "mytable"),
+            '"myschema"."MYTABLE"',
+            id="quote=True lowercase case preserved",
+        ),
+        pytest.param(
+            (quoted_name("MySchema", True), "mytable"),
+            '"MySchema"."MYTABLE"',
+            id="quote=True mixed-case preserved",
+        ),
+    ],
+)
+def test_always_quote_join(nu, idents, expected):
+    assert nu.always_quote_join(*idents) == expected
+    assert '"""' not in nu.always_quote_join(*idents)
 
 
 # ---------------------------------------------------------------------------
-# always_quote_join — case-sensitivity signal (quote=True) preserved
+# always_quote_join — identifier quoting correctness
 # ---------------------------------------------------------------------------
 
 
-class TestAlwaysQuoteJoinCaseSensitivity:
-    def test_quote_true_lowercase_schema_case_preserved(self, nu):
-        # Old _always_quote_join called str() before checking quote, so
-        # quoted_name("myschema", True) was uppercased to "MYSCHEMA".
-        # always_quote_join must preserve the case-sensitive lowercase form.
-        schema = quoted_name("myschema", True)
-        result = nu.always_quote_join(schema, "mytable")
-        assert '"myschema"' in result
-        assert '"MYSCHEMA"' not in result
-
-    def test_quote_true_mixed_case_schema_case_preserved(self, nu):
-        schema = quoted_name("MySchema", True)
-        result = nu.always_quote_join(schema, "mytable")
-        assert '"MySchema"' in result
-
-
-# ---------------------------------------------------------------------------
-# always_quote_join — SQL injection guard
-# ---------------------------------------------------------------------------
-
-
-class TestAlwaysQuoteJoinInjection:
-    def test_semicolon_in_schema_is_quoted(self, nu):
-        payload = "myschema; DROP TABLE users--"
-        result = nu.always_quote_join(payload, "mytable")
-        stripped = re.sub(r'"[^"]*"', "", result)
-        assert ";" not in stripped, f"Semicolon escaped quoting: {result!r}"
-
-    def test_semicolon_in_table_is_quoted(self, nu):
-        payload = "mytable; SELECT 1--"
-        result = nu.always_quote_join("myschema", payload)
-        stripped = re.sub(r'"[^"]*"', "", result)
-        assert ";" not in stripped, f"Semicolon escaped quoting: {result!r}"
-
-    def test_dot_in_table_splits_into_components(self, nu):
-        # A dot in table_name produces extra components, but all are quoted.
-        result = nu.always_quote_join("myschema", "foo.bar")
-        assert result == '"MYSCHEMA"."FOO"."BAR"'
-
-    def test_drop_injection_in_schema_is_neutralised(self, nu):
-        payload = "x'; DROP TABLE t--"
-        result = nu.always_quote_join(payload, "t")
-        stripped = re.sub(r'"[^"]*"', "", result)
-        assert "DROP" not in stripped, f"DROP keyword escaped quoting: {result!r}"
+@pytest.mark.parametrize(
+    "idents, blocked",
+    [
+        pytest.param(
+            ("myschema; DROP TABLE users--", "mytable"), ";", id="semicolon in schema"
+        ),
+        pytest.param(("myschema", "mytable; SELECT 1--"), ";", id="semicolon in table"),
+        pytest.param(("x'; DROP TABLE t--", "t"), "DROP", id="DROP in schema"),
+    ],
+)
+def test_always_quote_join_identifier_quoting(nu, idents, blocked):
+    result = nu.always_quote_join(*idents)
+    stripped = re.sub(r'"[^"]*"', "", result)
+    assert blocked not in stripped, f"Pattern {blocked!r} escaped quoting: {result!r}"

--- a/tests/test_unit_name_utils.py
+++ b/tests/test_unit_name_utils.py
@@ -1,0 +1,158 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+"""
+Unit tests for _NameUtils._quote_component and _NameUtils.always_quote_join.
+
+These methods are the canonical always-quote helpers shared by
+SnowflakeDialect._always_quote_join, _get_full_schema_name, and
+_StructuredTypeInfoManager.get_table_columns.  Correctness here guarantees
+all three callers stay consistent automatically.
+"""
+
+import re
+
+import pytest
+from sqlalchemy.sql.elements import quoted_name
+
+from snowflake.sqlalchemy.name_utils import _NameUtils
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+
+@pytest.fixture
+def nu():
+    return _NameUtils(SnowflakeDialect().identifier_preparer)
+
+
+# ---------------------------------------------------------------------------
+# _quote_component
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteComponent:
+    def test_plain_lowercase_is_uppercased_and_quoted(self, nu):
+        assert nu._quote_component(quoted_name("myschema", None)) == '"MYSCHEMA"'
+
+    def test_plain_uppercase_is_quoted(self, nu):
+        assert nu._quote_component(quoted_name("MYSCHEMA", None)) == '"MYSCHEMA"'
+
+    def test_mixed_case_without_explicit_quote_is_quoted(self, nu):
+        assert nu._quote_component(quoted_name("MySchema", None)) == '"MySchema"'
+
+    def test_quote_true_preserves_lowercase_no_denormalization(self, nu):
+        # quote=True signals the identifier was double-quoted at the source and
+        # is case-sensitive.  denormalize_name must NOT uppercase it.
+        assert nu._quote_component(quoted_name("myschema", True)) == '"myschema"'
+
+    def test_quote_true_mixed_case_preserved(self, nu):
+        assert nu._quote_component(quoted_name("MySchema", True)) == '"MySchema"'
+
+    def test_internal_double_quote_is_escaped(self, nu):
+        result = nu._quote_component(quoted_name('my"schema', None))
+        assert result.startswith('"') and result.endswith('"')
+        assert '""' in result  # SQL double-quote escaping
+
+
+# ---------------------------------------------------------------------------
+# always_quote_join — normal identifiers
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysQuoteJoinNormal:
+    def test_plain_lowercase_schema_and_table(self, nu):
+        assert nu.always_quote_join("myschema", "mytable") == '"MYSCHEMA"."MYTABLE"'
+
+    def test_plain_uppercase_schema_and_table(self, nu):
+        assert nu.always_quote_join("MYSCHEMA", "MYTABLE") == '"MYSCHEMA"."MYTABLE"'
+
+    def test_mixed_case_schema_and_table(self, nu):
+        result = nu.always_quote_join("MySchema", "MyTable")
+        assert result == '"MySchema"."MyTable"'
+
+    def test_none_ident_is_skipped(self, nu):
+        assert (
+            nu.always_quote_join(None, "myschema", "mytable") == '"MYSCHEMA"."MYTABLE"'
+        )
+
+    def test_single_ident(self, nu):
+        assert nu.always_quote_join("myschema") == '"MYSCHEMA"'
+
+
+# ---------------------------------------------------------------------------
+# always_quote_join — database-qualified schemas (1.10.1 regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysQuoteJoinDatabaseQualified:
+    def test_unquoted_db_qualified_schema_is_split(self, nu):
+        # Primary regression: MYDB.MYSCHEMA must become "MYDB"."MYSCHEMA",
+        # not "MYDB.MYSCHEMA" (a single identifier containing a literal dot).
+        result = nu.always_quote_join("MYDB.MYSCHEMA", "mytable")
+        assert result == '"MYDB"."MYSCHEMA"."MYTABLE"'
+
+    def test_lowercase_db_qualified_schema_is_split_and_uppercased(self, nu):
+        result = nu.always_quote_join("mydb.myschema", "mytable")
+        assert result == '"MYDB"."MYSCHEMA"."MYTABLE"'
+
+    def test_pre_quoted_db_qualified_schema_not_double_escaped(self, nu):
+        # If the schema string already contains SQL double-quotes around each
+        # component, the parser must strip and re-quote correctly.
+        result = nu.always_quote_join('"MYDB"."MYSCHEMA"', "mytable")
+        assert result == '"MYDB"."MYSCHEMA"."MYTABLE"'
+        assert '"""' not in result
+
+    def test_literal_dot_inside_quoted_component_not_split(self, nu):
+        # A quoted component containing a literal dot must not be re-split.
+        result = nu.always_quote_join('"my.schema"', "mytable")
+        assert result == '"my.schema"."MYTABLE"'
+
+
+# ---------------------------------------------------------------------------
+# always_quote_join — case-sensitivity signal (quote=True) preserved
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysQuoteJoinCaseSensitivity:
+    def test_quote_true_lowercase_schema_case_preserved(self, nu):
+        # Old _always_quote_join called str() before checking quote, so
+        # quoted_name("myschema", True) was uppercased to "MYSCHEMA".
+        # always_quote_join must preserve the case-sensitive lowercase form.
+        schema = quoted_name("myschema", True)
+        result = nu.always_quote_join(schema, "mytable")
+        assert '"myschema"' in result
+        assert '"MYSCHEMA"' not in result
+
+    def test_quote_true_mixed_case_schema_case_preserved(self, nu):
+        schema = quoted_name("MySchema", True)
+        result = nu.always_quote_join(schema, "mytable")
+        assert '"MySchema"' in result
+
+
+# ---------------------------------------------------------------------------
+# always_quote_join — SQL injection guard
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysQuoteJoinInjection:
+    def test_semicolon_in_schema_is_quoted(self, nu):
+        payload = "myschema; DROP TABLE users--"
+        result = nu.always_quote_join(payload, "mytable")
+        stripped = re.sub(r'"[^"]*"', "", result)
+        assert ";" not in stripped, f"Semicolon escaped quoting: {result!r}"
+
+    def test_semicolon_in_table_is_quoted(self, nu):
+        payload = "mytable; SELECT 1--"
+        result = nu.always_quote_join("myschema", payload)
+        stripped = re.sub(r'"[^"]*"', "", result)
+        assert ";" not in stripped, f"Semicolon escaped quoting: {result!r}"
+
+    def test_dot_in_table_splits_into_components(self, nu):
+        # A dot in table_name produces extra components, but all are quoted.
+        result = nu.always_quote_join("myschema", "foo.bar")
+        assert result == '"MYSCHEMA"."FOO"."BAR"'
+
+    def test_drop_injection_in_schema_is_neutralised(self, nu):
+        payload = "x'; DROP TABLE t--"
+        result = nu.always_quote_join(payload, "t")
+        stripped = re.sub(r'"[^"]*"', "", result)
+        assert "DROP" not in stripped, f"DROP keyword escaped quoting: {result!r}"

--- a/tests/test_unit_structured_type_info_manager.py
+++ b/tests/test_unit_structured_type_info_manager.py
@@ -231,7 +231,9 @@ def test_quoted_database_qualified_schema_is_not_double_escaped():
     assert (
         '"MYDB"."MYSCHEMA"."MYTABLE"' in sql
     ), f"Already-quoted qualified schema was double-escaped; got: {sql!r}"
-    assert '"""' not in sql, f"Found triple double-quote (double escaping); got: {sql!r}"
+    assert (
+        '"""' not in sql
+    ), f"Found triple double-quote (double escaping); got: {sql!r}"
 
 
 def test_quoted_component_with_literal_dot_is_preserved():


### PR DESCRIPTION
unify always-quote identifier logic into `_NameUtil`

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NO-SNOW

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

### Unify always-quote identifier logic into `_NameUtils`

The `_always_quote_join` pattern (split on dot → denormalize → unconditionally double-quote each component) existed in three independent copies across `SnowflakeDialect._always_quote_join`, `_get_full_schema_name`, and `_StructuredTypeInfoManager.get_table_columns`. This divergence is what caused the v1.10.1 regression: the `get_table_columns` copy called `ip.quote()` on the whole schema string without splitting first, breaking database-qualified schemas like `MYDB.MYSCHEMA`.

This PR moves the canonical implementation — `_quote_component` and `always_quote_join` — onto `_NameUtils`. All three callers now delegate to the same code, making a repeat of the same drift impossible.

As a side-effect, fixes a pre-existing bug in the old `_always_quote_join`: it `called str()` on each identifier before checking the quote attribute, so `quoted_name("myschema", True)` (an explicitly case-sensitive lowercase identifier) was silently uppercased to `"MYSCHEMA"`. The new `_quote_component` inspects `quote` on the original object and skips denormalization when it is `True`.

Adds `tests/test_unit_name_utils.py` (21 tests) covering normal identifiers, database-qualified schema splitting, case-sensitivity preservation, and identifier quoting correctness for both new methods directly.
