### PR TITLE
Snow 3720548 optimize reflection cache

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -21,6 +21,7 @@ Source code is also available at:
   - `repr()` of `AWSBucket`, `AzureContainer`, `GCSBucket` (and, transitively, `CopyIntoStorage`) now masks cloud secrets — `AWS_SECRET_KEY`, `AWS_KEY_ID`, `AWS_TOKEN`, `AZURE_SAS_TOKEN`, `MASTER_KEY` are rendered as `'***'` (SNOW-3649782). Compiled SQL is unchanged.
   - Added an opt-in logging redactor for engine logs that contain inline credentials: `SnowflakeSecretRedactionFilter`, `add_secret_redaction_filter()`, and `redact_secrets()`. Prefer `STORAGE_INTEGRATION` to avoid putting secrets in SQL at all (SNOW-3649850).
 - Fix `get_view_definition` silently truncating or failing for view names that contain a single quote or backslash (e.g. `o'brien`). The name is now SQL-escaped (`'` → `''`, `\` → `\\`) before being embedded in the `SHOW VIEWS LIKE '...'` literal, so such views are found correctly and no query manipulation is possible via a crafted view name.
+- Optimise single-table reflection (SNOW-3720548): reflecting one table no longer scans the entire schema, reducing latency and Snowflake credit usage for targeted `Inspector` calls.
 
 # Release Notes
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Optimise single-table reflection (SNOW-3720548): reflecting one table no longer scans the entire schema, reducing latency and Snowflake credit usage for targeted `Inspector` calls.
 - Improve `_url()` helper and `create_connect_args` connection-parameter handling:
   - `account` and `region` values are now validated against an allowlist of DNS-safe characters (alphanumeric, `-`, `.`, `_`) before being interpolated into the connection URL, preventing URL-authority corruption from unexpected characters.
   - `user` values are percent-encoded before being placed in the URL userinfo component, preserving the original value delivered to the connector while preventing `@`, `?`, and `#` from being misinterpreted as URL delimiters.
@@ -21,7 +22,6 @@ Source code is also available at:
   - `repr()` of `AWSBucket`, `AzureContainer`, `GCSBucket` (and, transitively, `CopyIntoStorage`) now masks cloud secrets — `AWS_SECRET_KEY`, `AWS_KEY_ID`, `AWS_TOKEN`, `AZURE_SAS_TOKEN`, `MASTER_KEY` are rendered as `'***'` (SNOW-3649782). Compiled SQL is unchanged.
   - Added an opt-in logging redactor for engine logs that contain inline credentials: `SnowflakeSecretRedactionFilter`, `add_secret_redaction_filter()`, and `redact_secrets()`. Prefer `STORAGE_INTEGRATION` to avoid putting secrets in SQL at all (SNOW-3649850).
 - Fix `get_view_definition` silently truncating or failing for view names that contain a single quote or backslash (e.g. `o'brien`). The name is now SQL-escaped (`'` → `''`, `\` → `\\`) before being embedded in the `SHOW VIEWS LIKE '...'` literal, so such views are found correctly and no query manipulation is possible via a crafted view name.
-- Optimise single-table reflection (SNOW-3720548): reflecting one table no longer scans the entire schema, reducing latency and Snowflake credit usage for targeted `Inspector` calls.
 
 # Release Notes
 

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -1001,6 +1001,10 @@ class SnowflakeDialect(default.DefaultDialect):
         Falls back to DESC TABLE per-table for objects not in information_schema
         (temp tables, dynamic tables, etc.).
 
+        When filter_names is set and the full-schema cache is cold, issues a
+        targeted WHERE table_name IN (...) query so that both the SQL scan and
+        the DESC TABLE fan-out are limited to the requested tables only.
+
         Important: the return key must use the original ``schema`` value (which
         may be None), not a normalised substitute, so SA's _reflect_info lookup
         succeeds when schema was not explicitly provided.
@@ -1009,9 +1013,35 @@ class SnowflakeDialect(default.DefaultDialect):
         effective_schema = schema or self.default_schema_name
         if not effective_schema:
             _, effective_schema = self._current_database_schema(connection, **kw)
-        all_columns = self._get_schema_columns(connection, effective_schema, **kw)
-        if all_columns is None:
-            all_columns = {}
+
+        # If the full-schema result is already cached, use it as a superset for
+        # any filter_names request — no SQL needed.  The key format matches the
+        # @reflection.cache key produced by a plain _get_schema_columns call
+        # (positional schema arg, no extra kwargs).
+        info_cache = kw.get("info_cache")
+        full_schema_cache_key = ("_get_schema_columns", (effective_schema,), ())
+        if info_cache is not None and full_schema_cache_key in info_cache:
+            all_columns = info_cache[full_schema_cache_key] or {}
+        elif filter_names is not None:
+            # Cold cache, targeted request: pass filter_names as a tuple so
+            # @reflection.cache stores the result under a distinct key that
+            # does not pollute the full-schema entry.  _get_schema_columns will
+            # use _query_filtered_columns_info and only process the requested
+            # rows, which eliminates the DESC TABLE fan-out for other tables.
+            all_columns = (
+                self._get_schema_columns(
+                    connection,
+                    effective_schema,
+                    filter_names=tuple(filter_names),
+                    **kw,
+                )
+                or {}
+            )
+        else:
+            all_columns = (
+                self._get_schema_columns(connection, effective_schema, **kw) or {}
+            )
+
         tables = filter_names if filter_names is not None else list(all_columns.keys())
         mgr = _StructuredTypeInfoManager(
             connection, self.name_utils, self.default_schema_name
@@ -1242,25 +1272,40 @@ class SnowflakeDialect(default.DefaultDialect):
     @reflection.cache
     def _get_schema_columns(self, connection, schema, **kw):
         """
-        Get all columns in the schema with complete metadata.
+        Get columns for a schema (or a filtered subset) with complete metadata.
 
         Args:
             connection: Database connection
             schema: Schema name to reflect
-            **kw: Additional arguments including optional info_cache
+            **kw: Additional arguments including optional info_cache and
+                  filter_names (tuple of table names for a targeted query).
 
         Returns:
             Dictionary mapping table names to lists of column info dicts,
-            or None if information_schema query returned too much data
+            or None if information_schema query returned too much data.
 
         Note:
             Returns None (cacheable) when hitting Snowflake's information_schema
             result size limit, triggering fallback to per-table DESC queries.
+
+            When filter_names is present it is popped from **kw before calling
+            any sub-methods so that their @reflection.cache keys are not
+            contaminated by a kwarg they don't use.
         """
+        # Consume filter_names here so it does not propagate to sub-method
+        # calls (which are also @reflection.cache-decorated) and contaminate
+        # their cache keys.
+        filter_names = kw.pop("filter_names", None)
+
         # Get the fully-qualified database.schema name for SQL commands
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
 
-        result = self._query_all_columns_info(connection, full_schema_name, **kw)
+        if filter_names is not None:
+            result = self._query_filtered_columns_info(
+                connection, full_schema_name, filter_names
+            )
+        else:
+            result = self._query_all_columns_info(connection, full_schema_name, **kw)
         if result is None:
             return None
 
@@ -1470,6 +1515,77 @@ class SnowflakeDialect(default.DefaultDialect):
             if pe.orig.errno == 90030:
                 # This means that there are too many tables in the schema, we need to go more granular
                 return None  # None triggers get_table_columns while staying cacheable
+            raise
+
+    def _query_filtered_columns_info(self, connection, schema_name, filter_names):
+        """Targeted information_schema.columns query restricted to specific tables.
+
+        Adds ``AND ic.table_name IN (:t0, :t1, …)`` to the WHERE clause so
+        that only the requested rows are returned.  This eliminates both the
+        full-schema SQL scan and the DESC TABLE fan-out for other tables.
+
+        Not decorated with @reflection.cache — the caller (_get_schema_columns)
+        provides the caching boundary and stores the processed result under a
+        key that includes filter_names.
+
+        Args:
+            connection: Database connection.
+            schema_name: Fully-qualified ``"database"."schema"`` name produced
+                by _get_full_schema_name.
+            filter_names: Non-empty iterable of table names to query.
+
+        Returns:
+            Result set from information_schema.columns for the given tables,
+            or None on Snowflake result-size error 90030.
+        """
+        database_raw, schema_raw = self._db_plus_schema(schema_name)
+        if database_raw is None:
+            raise ValueError(
+                f"Expected fully-qualified schema name 'database.schema', got '{schema_name}'"
+            )
+
+        database_part = self.identifier_preparer.quote(database_raw)
+        schema_only = self.denormalize_name(schema_raw)
+        info_schema_table = f"{database_part}.information_schema.columns"
+
+        # Denormalize so names match information_schema casing (uppercase for
+        # case-insensitive identifiers, preserved for quoted ones).
+        table_names = [self.denormalize_name(t) for t in filter_names]
+        placeholders = ", ".join(f":t{i}" for i in range(len(table_names)))
+        params: dict = {"table_schema": schema_only}
+        params.update({f"t{i}": name for i, name in enumerate(table_names)})
+
+        try:
+            return connection.execute(
+                text(
+                    f"""
+            SELECT /* sqlalchemy:_get_schema_columns */
+                   ic.table_name,
+                   ic.column_name,
+                   ic.data_type,
+                   ic.character_maximum_length,
+                   ic.numeric_precision,
+                   ic.numeric_scale,
+                   ic.is_nullable,
+                   ic.column_default,
+                   ic.is_identity,
+                   ic.comment,
+                   ic.identity_start,
+                   ic.identity_increment,
+                   ic.identity_generation,
+                   ic.identity_cycle,
+                   ic.identity_ordered,
+                   ic.data_type_alias
+              FROM {info_schema_table} ic
+             WHERE ic.table_schema=:table_schema
+               AND ic.table_name IN ({placeholders})
+             ORDER BY ic.ordinal_position"""
+                ),
+                params,
+            )
+        except sa_exc.ProgrammingError as pe:
+            if pe.orig.errno == 90030:
+                return None
             raise
 
     @reflection.cache

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -1532,12 +1532,17 @@ class SnowflakeDialect(default.DefaultDialect):
             connection: Database connection.
             schema_name: Fully-qualified ``"database"."schema"`` name produced
                 by _get_full_schema_name.
-            filter_names: Non-empty iterable of table names to query.
+            filter_names: Iterable of table names to query.  An empty iterable
+                returns ``[]`` immediately without issuing SQL (``IN ()`` is
+                invalid in Snowflake).
 
         Returns:
             Result set from information_schema.columns for the given tables,
             or None on Snowflake result-size error 90030.
         """
+        if not filter_names:
+            return []
+
         database_raw, schema_raw = self._db_plus_schema(schema_name)
         if database_raw is None:
             raise ValueError(

--- a/tests/test_reflection_cache.py
+++ b/tests/test_reflection_cache.py
@@ -1,0 +1,196 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+"""
+Integration tests for the targeted-query cache optimisation (SNOW-3720548 / GH-701).
+
+These tests require a live Snowflake account.  They verify end-to-end behaviour:
+
+  - filter_names with a cold cache issues a targeted WHERE table_name IN (...)
+    query and returns only the requested tables' columns.
+  - The targeted and full-schema paths return identical column data for the
+    same tables.
+  - A warm full-schema cache is used as a superset for filter_names requests,
+    returning correct results without issuing a second SQL statement.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+
+class TestReflectionCacheIntegration:
+    """Integration tests — requires a live Snowflake account."""
+
+    @pytest.fixture()
+    def isolated_schema(self, engine_testaccount):
+        """Create a schema with three plain tables; drop it on teardown.
+
+        Uses three tables (table_a, table_b, table_c) so tests can assert
+        that filter_names restricts results to only the requested subset.
+        """
+        suffix = uuid.uuid4().hex[:8]
+        schema = f"sqlalchemy_cache_test_{suffix}"
+
+        with engine_testaccount.connect() as conn:
+            conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
+            conn.execute(
+                text(
+                    f"CREATE OR REPLACE TABLE {schema}.table_a "
+                    "(id INTEGER, name VARCHAR(100))"
+                )
+            )
+            conn.execute(
+                text(
+                    f"CREATE OR REPLACE TABLE {schema}.table_b "
+                    "(id INTEGER, value FLOAT)"
+                )
+            )
+            conn.execute(
+                text(
+                    f"CREATE OR REPLACE TABLE {schema}.table_c "
+                    "(id INTEGER, flag BOOLEAN)"
+                )
+            )
+            conn.commit()
+
+        yield schema
+
+        with engine_testaccount.connect() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+            conn.commit()
+
+    def test_targeted_path_returns_only_requested_table(
+        self, engine_testaccount, isolated_schema
+    ):
+        """filter_names=[table_a] must not include table_b or table_c in the result."""
+        with engine_testaccount.connect() as conn:
+            result = engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a"],
+                info_cache={},
+            )
+
+        assert len(result) == 1
+        (_, tname), _ = result[0]
+        assert tname.lower() == "table_a"
+
+    def test_targeted_path_returns_correct_columns(
+        self, engine_testaccount, isolated_schema
+    ):
+        """filter_names=[table_a] must return the exact columns defined for that table."""
+        with engine_testaccount.connect() as conn:
+            result = engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a"],
+                info_cache={},
+            )
+
+        (_, _), cols = result[0]
+        assert {c["name"].lower() for c in cols} == {"id", "name"}
+
+    def test_targeted_sql_contains_in_clause(
+        self, engine_testaccount, isolated_schema, assert_text_in_buf
+    ):
+        """Targeted path must issue SQL with AND ic.table_name IN (...)."""
+        with engine_testaccount.connect() as conn:
+            engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a"],
+                info_cache={},
+            )
+
+        assert_text_in_buf("AND ic.table_name IN")
+
+    def test_targeted_and_full_paths_return_same_column_data(
+        self, engine_testaccount, isolated_schema
+    ):
+        """Targeted and full-schema paths must return identical column sets."""
+        with engine_testaccount.connect() as conn:
+            full_result = engine_testaccount.dialect.get_multi_columns(
+                conn, schema=isolated_schema, info_cache={}
+            )
+            targeted_result = engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a", "table_b"],
+                info_cache={},
+            )
+
+        full_cols = {
+            k[1].lower(): {c["name"].lower() for c in cols} for k, cols in full_result
+        }
+        targeted_cols = {
+            k[1].lower(): {c["name"].lower() for c in cols}
+            for k, cols in targeted_result
+        }
+
+        for tname in targeted_cols:
+            assert targeted_cols[tname] == full_cols[tname], (
+                f"Column mismatch for {tname}: "
+                f"targeted={targeted_cols[tname]}, full={full_cols[tname]}"
+            )
+
+    def test_warm_cache_returns_correct_columns_for_requested_table(
+        self, engine_testaccount, isolated_schema
+    ):
+        """Warm full-schema cache must serve correct column data for filter_names requests."""
+        info_cache: dict = {}
+
+        with engine_testaccount.connect() as conn:
+            engine_testaccount.dialect.get_multi_columns(
+                conn, schema=isolated_schema, info_cache=info_cache
+            )
+            result = engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a"],
+                info_cache=info_cache,
+            )
+
+        assert len(result) == 1
+        (_, tname), cols = result[0]
+        assert tname.lower() == "table_a"
+        assert {c["name"].lower() for c in cols} == {"id", "name"}
+
+    def test_cold_and_warm_paths_return_identical_results(
+        self, engine_testaccount, isolated_schema
+    ):
+        """Cold targeted path and warm-cache path must return the same column data.
+
+        This is the core correctness invariant: regardless of which path
+        populates the result, the caller sees the same columns.
+        """
+        with engine_testaccount.connect() as conn:
+            cold_result = engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a", "table_b"],
+                info_cache={},
+            )
+
+            warm_cache: dict = {}
+            engine_testaccount.dialect.get_multi_columns(
+                conn, schema=isolated_schema, info_cache=warm_cache
+            )
+            warm_result = engine_testaccount.dialect.get_multi_columns(
+                conn,
+                schema=isolated_schema,
+                filter_names=["table_a", "table_b"],
+                info_cache=warm_cache,
+            )
+
+        cold_by_table = {
+            k[1].lower(): {c["name"].lower() for c in cols} for k, cols in cold_result
+        }
+        warm_by_table = {
+            k[1].lower(): {c["name"].lower() for c in cols} for k, cols in warm_result
+        }
+
+        assert cold_by_table == warm_by_table

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -454,7 +454,6 @@ class TestGetViewDefinitionLikeEscaping:
         "view_name, expected, not_expected",
         [
             pytest.param("o'brien", ["''"], ['"o'], id="simple_quote"),
-
             pytest.param("back\\slash", ["\\\\"], [], id="backslash_doubled"),
         ],
     )
@@ -506,7 +505,6 @@ class TestReflectionCommentLikeEscaping:
         "table_name, expected, not_expected",
         [
             pytest.param("o'brien", ["''"], ['"o'], id="simple_quote"),
-
             pytest.param("back\\slash", ["\\\\"], [], id="backslash_doubled"),
         ],
     )

--- a/tests/test_unit_reflection_cache.py
+++ b/tests/test_unit_reflection_cache.py
@@ -99,6 +99,16 @@ def patch_column_query_methods(dialect, filtered_rows=(), all_rows=()):
         yield mock_all_columns_query, mock_targeted_query, mock_primary_keys
 
 
+def test_targeted_query_empty_filter_names_returns_empty_without_sql(dialect_no_db):
+    """Empty filter_names must short-circuit before SQL — AND ic.table_name IN () is invalid."""
+    conn, sql_log = _make_mock_conn()
+
+    result = dialect_no_db._query_filtered_columns_info(conn, _FULL_SCHEMA, ())
+
+    assert list(result) == []
+    assert sql_log == [], "no SQL should be issued for empty filter_names"
+
+
 def test_targeted_query_contains_table_name_in_clause(dialect_no_db):
     """Targeted query must have AND ic.table_name IN (...) in its WHERE clause."""
     conn, sql_log = _make_mock_conn()
@@ -292,29 +302,24 @@ def test_multi_columns_warm_cache_skips_sql(dialect_no_db):
     conn.execute.assert_not_called()
 
 
-def test_multi_columns_warm_cache_returns_requested_columns(dialect_no_db):
-    """Warm cache: result contains exactly the columns for the requested table."""
-    conn = MagicMock()
-    cols_a = [{"name": "id"}]
-    cols_b = [{"name": "name"}]
-    info_cache = {_FULL_SCHEMA_CACHE_KEY: {"table_a": cols_a, "table_b": cols_b}}
-
-    result = dialect_no_db.get_multi_columns(
-        conn,
-        schema=_SCHEMA,
-        filter_names=["table_a"],
-        info_cache=info_cache,
-    )
-
-    assert len(result) == 1
-    assert result[0] == ((_SCHEMA, "table_a"), cols_a)
-
-
-def test_multi_columns_warm_cache_serves_multiple_filter_names(dialect_no_db):
-    """Warm cache: all requested tables are served from cache without SQL."""
+@pytest.mark.parametrize(
+    "filter_names, expected_keys",
+    [
+        pytest.param(["table_a"], {(_SCHEMA, "table_a")}, id="single_table"),
+        pytest.param(
+            ["t1", "t3"], {(_SCHEMA, "t1"), (_SCHEMA, "t3")}, id="multi_table"
+        ),
+    ],
+)
+def test_multi_columns_warm_cache_serves_correct_subset(
+    dialect_no_db, filter_names, expected_keys
+):
+    """Warm cache: only the requested tables are returned, no SQL issued."""
     conn = MagicMock()
     info_cache = {
         _FULL_SCHEMA_CACHE_KEY: {
+            "table_a": [{"name": "id"}],
+            "table_b": [{"name": "name"}],
             "t1": [{"name": "a"}],
             "t2": [{"name": "b"}],
             "t3": [{"name": "c"}],
@@ -322,14 +327,10 @@ def test_multi_columns_warm_cache_serves_multiple_filter_names(dialect_no_db):
     }
 
     result = dialect_no_db.get_multi_columns(
-        conn,
-        schema=_SCHEMA,
-        filter_names=["t1", "t3"],
-        info_cache=info_cache,
+        conn, schema=_SCHEMA, filter_names=filter_names, info_cache=info_cache
     )
 
-    assert len(result) == 2
-    assert {r[0] for r in result} == {(_SCHEMA, "t1"), (_SCHEMA, "t3")}
+    assert {r[0] for r in result} == expected_keys
     conn.execute.assert_not_called()
 
 

--- a/tests/test_unit_reflection_cache.py
+++ b/tests/test_unit_reflection_cache.py
@@ -1,0 +1,445 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+"""
+Unit tests for the targeted-query cache optimisation (SNOW-3720548 / GH-701).
+
+Before the fix, reflecting a single table caused:
+  - a full information_schema.columns scan across the entire schema, and
+  - a DESC TABLE call for every structured-type table in the schema.
+
+After the fix:
+  - get_multi_columns with filter_names + cold cache issues a narrow
+    WHERE table_name IN (...) query instead of a full schema scan.
+  - get_multi_columns with filter_names + warm full-schema cache skips SQL
+    entirely, reading from the cached result.
+  - A filtered result is stored under a distinct cache key and never pollutes
+    the full-schema cache entry.
+  - _get_schema_columns dispatches to the right underlying query method based
+    on whether filter_names is present in **kw.
+  - DESC TABLE fan-out is eliminated implicitly: the targeted SQL only returns
+    rows for the requested tables, so _build_column_info (which triggers DESC
+    TABLE for structured-type columns) only processes those rows.
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+_DB = "MYDB"
+_SCHEMA = "myschema"
+_FULL_SCHEMA = '"MYDB"."MYSCHEMA"'
+
+# @reflection.cache key format: (fn_name, positional_str_args_tuple, sorted_kw_items_tuple)
+# info_cache and unreflectable are excluded by the decorator.
+_FULL_SCHEMA_CACHE_KEY = ("_get_schema_columns", (_SCHEMA,), ())
+
+
+@pytest.fixture
+def dialect_no_db():
+    """SnowflakeDialect without a live database connection."""
+    return SnowflakeDialect()
+
+
+def _make_mock_conn():
+    """Return (conn, sql_log) where sql_log records information_schema queries.
+
+    The mock connection returns plausible stubs for housekeeping queries
+    (CURRENT_DATABASE, PRIMARY KEYS) and logs every other query for assertions.
+    """
+    conn = MagicMock()
+    sql_log: list[dict] = []
+
+    def _execute(stmt, params=None):
+        sql = stmt.text if hasattr(stmt, "text") else str(stmt)
+        r = MagicMock()
+        if "current_database" in sql.lower():
+            r.fetchone.return_value = (_DB, "MYSCHEMA")
+        elif "PRIMARY KEYS" in sql:
+            r.__iter__ = lambda s: iter([])
+        else:
+            sql_log.append({"sql": sql, "params": dict(params or {})})
+            r.__iter__ = lambda s: iter([])
+        return r
+
+    conn.execute.side_effect = _execute
+    return conn, sql_log
+
+
+@contextmanager
+def patch_column_query_methods(dialect, filtered_rows=(), all_rows=()):
+    """Patch the query methods that _get_schema_columns dispatches to.
+
+    Stubs out schema-resolution helpers and replaces the two column-query
+    methods with MagicMocks so tests can assert on dispatch logic without
+    hitting a real database.
+
+    Yields (mock_all_columns_query, mock_targeted_query, mock_primary_keys).
+    """
+    mock_all_columns_query = MagicMock(return_value=iter(all_rows))
+    mock_targeted_query = MagicMock(return_value=iter(filtered_rows))
+    mock_primary_keys = MagicMock(return_value={})
+    with patch.object(
+        dialect, "_get_full_schema_name", return_value=_FULL_SCHEMA
+    ), patch.object(
+        dialect, "_current_database_schema", return_value=(_DB, "MYSCHEMA")
+    ), patch.object(
+        dialect, "_get_schema_primary_keys", mock_primary_keys
+    ), patch.object(
+        dialect, "_query_all_columns_info", mock_all_columns_query
+    ), patch.object(
+        dialect, "_query_filtered_columns_info", mock_targeted_query
+    ):
+        yield mock_all_columns_query, mock_targeted_query, mock_primary_keys
+
+
+def test_targeted_query_contains_table_name_in_clause(dialect_no_db):
+    """Targeted query must have AND ic.table_name IN (...) in its WHERE clause."""
+    conn, sql_log = _make_mock_conn()
+
+    dialect_no_db._query_filtered_columns_info(
+        conn, _FULL_SCHEMA, ("TABLE_A", "TABLE_B")
+    )
+
+    assert len(sql_log) == 1, "expected exactly one SQL statement"
+    assert "AND ic.table_name IN" in sql_log[0]["sql"]
+
+
+@pytest.mark.parametrize(
+    "filter_names, expected_table_params",
+    [
+        pytest.param(("ONLY_TABLE",), {"t0": "ONLY_TABLE"}, id="single_table"),
+        pytest.param(
+            ("A", "B", "C"), {"t0": "A", "t1": "B", "t2": "C"}, id="three_tables"
+        ),
+    ],
+)
+def test_targeted_query_placeholder_count(
+    dialect_no_db, filter_names, expected_table_params
+):
+    """Each table in filter_names gets its own numbered bind-parameter placeholder."""
+    conn, sql_log = _make_mock_conn()
+
+    dialect_no_db._query_filtered_columns_info(conn, _FULL_SCHEMA, filter_names)
+
+    params = sql_log[0]["params"]
+    table_params = {
+        k: v for k, v in params.items() if k.startswith("t") and k[1:].isdigit()
+    }
+    assert table_params == expected_table_params
+    assert len(re.findall(r":t\d+", sql_log[0]["sql"])) == len(expected_table_params)
+
+
+def test_targeted_query_params_contain_denormalized_table_names(dialect_no_db):
+    """Table names are denormalized (uppercased) before binding to params."""
+    conn, sql_log = _make_mock_conn()
+
+    dialect_no_db._query_filtered_columns_info(conn, _FULL_SCHEMA, ("my_table",))
+
+    params = sql_log[0]["params"]
+    table_values = {v for k, v in params.items() if k.startswith("t")}
+    assert "MY_TABLE" in table_values
+
+
+def test_targeted_query_table_schema_param_is_present(dialect_no_db):
+    """table_schema bind param must be set for the WHERE table_schema filter."""
+    conn, sql_log = _make_mock_conn()
+
+    dialect_no_db._query_filtered_columns_info(conn, _FULL_SCHEMA, ("TABLE_A",))
+
+    assert "table_schema" in sql_log[0]["params"]
+
+
+def test_targeted_query_selects_same_columns_as_full_query(dialect_no_db):
+    """The SELECT column list must be identical to _query_all_columns_info."""
+    conn, sql_log = _make_mock_conn()
+
+    dialect_no_db._query_filtered_columns_info(conn, _FULL_SCHEMA, ("TABLE_A",))
+
+    sql = sql_log[0]["sql"]
+    for col in (
+        "ic.table_name",
+        "ic.column_name",
+        "ic.data_type",
+        "ic.character_maximum_length",
+        "ic.numeric_precision",
+        "ic.numeric_scale",
+        "ic.is_nullable",
+        "ic.column_default",
+        "ic.is_identity",
+        "ic.comment",
+        "ic.identity_start",
+        "ic.identity_increment",
+        "ic.identity_generation",
+        "ic.identity_cycle",
+        "ic.identity_ordered",
+        "ic.data_type_alias",
+    ):
+        assert col in sql, f"expected column {col!r} in SELECT list; got:\n{sql}"
+
+
+def test_schema_columns_without_filter_names_calls_all_columns_query(dialect_no_db):
+    """No filter_names → _query_all_columns_info is called, not the targeted variant."""
+    conn = MagicMock()
+
+    with patch_column_query_methods(dialect_no_db) as (
+        mock_all_columns_query,
+        mock_targeted_query,
+        _,
+    ):
+        dialect_no_db._get_schema_columns(conn, _SCHEMA, info_cache={})
+
+    mock_all_columns_query.assert_called_once()
+    mock_targeted_query.assert_not_called()
+
+
+def test_schema_columns_with_filter_names_calls_targeted_query(dialect_no_db):
+    """filter_names kwarg → _query_filtered_columns_info is called, not the full variant."""
+    conn = MagicMock()
+
+    with patch_column_query_methods(dialect_no_db) as (
+        mock_all_columns_query,
+        mock_targeted_query,
+        _,
+    ):
+        dialect_no_db._get_schema_columns(
+            conn, _SCHEMA, filter_names=("TABLE_A",), info_cache={}
+        )
+
+    mock_targeted_query.assert_called_once_with(conn, _FULL_SCHEMA, ("TABLE_A",))
+    mock_all_columns_query.assert_not_called()
+
+
+def test_schema_columns_filter_names_not_forwarded_to_all_columns_query(dialect_no_db):
+    """filter_names must be consumed and not bleed into _query_all_columns_info's
+    call — that would contaminate its @reflection.cache key."""
+    conn = MagicMock()
+
+    with patch_column_query_methods(dialect_no_db) as (mock_all_columns_query, _, _):
+        dialect_no_db._get_schema_columns(conn, _SCHEMA, info_cache={})
+
+    _, call_kw = mock_all_columns_query.call_args
+    assert "filter_names" not in call_kw
+
+
+def test_schema_columns_filter_names_not_forwarded_to_primary_keys_query(dialect_no_db):
+    """filter_names must not appear in the _get_schema_primary_keys call so that
+    PK results are shared across full-schema and targeted reflection paths."""
+    conn = MagicMock()
+
+    with patch_column_query_methods(dialect_no_db) as (_, _, mock_primary_keys):
+        dialect_no_db._get_schema_columns(
+            conn, _SCHEMA, filter_names=("TABLE_A",), info_cache={}
+        )
+
+    _, pk_kw = mock_primary_keys.call_args
+    assert "filter_names" not in pk_kw
+
+
+def test_schema_columns_filter_names_creates_distinct_cache_entry(dialect_no_db):
+    """A targeted call must be stored under a key that includes filter_names,
+    separate from the full-schema key, so they can coexist in info_cache."""
+    conn = MagicMock()
+    info_cache: dict = {}
+
+    with patch_column_query_methods(dialect_no_db):
+        dialect_no_db._get_schema_columns(
+            conn, _SCHEMA, filter_names=("TABLE_A",), info_cache=info_cache
+        )
+
+    filtered_key = (
+        "_get_schema_columns",
+        (_SCHEMA,),
+        (("filter_names", ("TABLE_A",)),),
+    )
+    assert (
+        filtered_key in info_cache
+    ), "filtered result should be cached under its own key"
+    assert (
+        _FULL_SCHEMA_CACHE_KEY not in info_cache
+    ), "filtered result must not be stored under the full-schema key"
+
+
+def test_schema_columns_full_schema_result_cached_under_schema_only_key(dialect_no_db):
+    """Full-schema call must be stored under the plain (schema,) key."""
+    conn = MagicMock()
+    info_cache: dict = {}
+
+    with patch_column_query_methods(dialect_no_db):
+        dialect_no_db._get_schema_columns(conn, _SCHEMA, info_cache=info_cache)
+
+    assert _FULL_SCHEMA_CACHE_KEY in info_cache
+
+
+def test_multi_columns_warm_cache_skips_sql(dialect_no_db):
+    """Warm full-schema cache: connection.execute must never be called."""
+    conn = MagicMock()
+    info_cache = {_FULL_SCHEMA_CACHE_KEY: {"mytable": [{"name": "col1"}]}}
+
+    dialect_no_db.get_multi_columns(
+        conn,
+        schema=_SCHEMA,
+        filter_names=["mytable"],
+        info_cache=info_cache,
+    )
+
+    conn.execute.assert_not_called()
+
+
+def test_multi_columns_warm_cache_returns_requested_columns(dialect_no_db):
+    """Warm cache: result contains exactly the columns for the requested table."""
+    conn = MagicMock()
+    cols_a = [{"name": "id"}]
+    cols_b = [{"name": "name"}]
+    info_cache = {_FULL_SCHEMA_CACHE_KEY: {"table_a": cols_a, "table_b": cols_b}}
+
+    result = dialect_no_db.get_multi_columns(
+        conn,
+        schema=_SCHEMA,
+        filter_names=["table_a"],
+        info_cache=info_cache,
+    )
+
+    assert len(result) == 1
+    assert result[0] == ((_SCHEMA, "table_a"), cols_a)
+
+
+def test_multi_columns_warm_cache_serves_multiple_filter_names(dialect_no_db):
+    """Warm cache: all requested tables are served from cache without SQL."""
+    conn = MagicMock()
+    info_cache = {
+        _FULL_SCHEMA_CACHE_KEY: {
+            "t1": [{"name": "a"}],
+            "t2": [{"name": "b"}],
+            "t3": [{"name": "c"}],
+        },
+    }
+
+    result = dialect_no_db.get_multi_columns(
+        conn,
+        schema=_SCHEMA,
+        filter_names=["t1", "t3"],
+        info_cache=info_cache,
+    )
+
+    assert len(result) == 2
+    assert {r[0] for r in result} == {(_SCHEMA, "t1"), (_SCHEMA, "t3")}
+    conn.execute.assert_not_called()
+
+
+def test_multi_columns_cold_cache_passes_filter_names_to_schema_columns(dialect_no_db):
+    """Cold cache + filter_names → _get_schema_columns is called with filter_names kwarg."""
+    conn = MagicMock()
+    info_cache: dict = {}
+    captured: list[dict] = []
+
+    def fake_schema_columns(connection, schema, **kw):
+        captured.append({"schema": schema, "kw": dict(kw)})
+        fn = kw.get("filter_names")
+        return {n: [] for n in fn} if fn else {}
+
+    with patch.object(dialect_no_db, "_get_schema_columns", fake_schema_columns):
+        dialect_no_db.get_multi_columns(
+            conn,
+            schema=_SCHEMA,
+            filter_names=["mytable"],
+            info_cache=info_cache,
+        )
+
+    assert len(captured) == 1
+    assert captured[0]["kw"].get("filter_names") == ("mytable",)
+
+
+def test_multi_columns_cold_cache_filter_names_normalised_to_tuple(dialect_no_db):
+    """filter_names is converted to a tuple before passing to _get_schema_columns
+    so the @reflection.cache key is stable regardless of the input container type."""
+    conn = MagicMock()
+    captured: list = []
+
+    def fake_schema_columns(connection, schema, **kw):
+        captured.append(kw.get("filter_names"))
+        return {}
+
+    with patch.object(dialect_no_db, "_get_schema_columns", fake_schema_columns):
+        dialect_no_db.get_multi_columns(
+            conn,
+            schema=_SCHEMA,
+            filter_names=["a", "b"],
+            info_cache={},
+        )
+
+    assert isinstance(
+        captured[0], tuple
+    ), "filter_names must be a tuple for stable cache keys"
+
+
+def test_multi_columns_cold_cache_no_filter_names_calls_full_schema_path(dialect_no_db):
+    """Cold cache + no filter_names → _get_schema_columns called without filter_names."""
+    conn = MagicMock()
+    captured: list[dict] = []
+
+    def fake_schema_columns(connection, schema, **kw):
+        captured.append(dict(kw))
+        return {}
+
+    with patch.object(dialect_no_db, "_get_schema_columns", fake_schema_columns):
+        dialect_no_db.get_multi_columns(conn, schema=_SCHEMA, info_cache={})
+
+    assert len(captured) == 1
+    assert "filter_names" not in captured[0]
+
+
+def test_multi_columns_filtered_result_not_stored_under_full_schema_key(dialect_no_db):
+    """Targeted result must never populate the full-schema cache key.
+
+    If it did, a later MetaData.reflect() (no filter_names) would get a cache
+    hit and silently return only the subset that was previously reflected.
+    """
+    conn = MagicMock()
+    info_cache: dict = {}
+
+    def fake_schema_columns(connection, schema, **kw):
+        return {"mytable": []}
+
+    with patch.object(dialect_no_db, "_get_schema_columns", fake_schema_columns):
+        dialect_no_db.get_multi_columns(
+            conn,
+            schema=_SCHEMA,
+            filter_names=["mytable"],
+            info_cache=info_cache,
+        )
+
+    assert _FULL_SCHEMA_CACHE_KEY not in info_cache, (
+        "Filtered result was written to the full-schema cache key — "
+        "a later MetaData.reflect() would get a stale partial result."
+    )
+
+
+def test_multi_columns_warm_cache_takes_priority_over_targeted_path(dialect_no_db):
+    """Warm full-schema cache must be used even when filter_names is set, and
+    _get_schema_columns must not be called at all."""
+    conn = MagicMock()
+    info_cache = {_FULL_SCHEMA_CACHE_KEY: {"mytable": [{"name": "id"}]}}
+    schema_columns_calls: list = []
+
+    def fake_schema_columns(connection, schema, **kw):
+        schema_columns_calls.append(kw)
+        return {}
+
+    with patch.object(dialect_no_db, "_get_schema_columns", fake_schema_columns):
+        dialect_no_db.get_multi_columns(
+            conn,
+            schema=_SCHEMA,
+            filter_names=["mytable"],
+            info_cache=info_cache,
+        )
+
+    assert (
+        schema_columns_calls == []
+    ), "_get_schema_columns was called despite a warm full-schema cache entry"

--- a/tests/test_unit_structured_types.py
+++ b/tests/test_unit_structured_types.py
@@ -242,9 +242,7 @@ class TestVisitObjectKeyQuoting:
         obj.items_types = {'"a"."b"': (VARCHAR(10), False)}
         result = self._type_compiler().process(obj)
         # The dot and the inner quotes must not appear unescaped in the output
-        assert (
-            '"a"."b"' not in result
-        ), f"Value was emitted verbatim in DDL: {result!r}"
+        assert '"a"."b"' not in result, f"Value was emitted verbatim in DDL: {result!r}"
 
 
 class TestObjectRepr:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-3720548 / #701 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

## Optimise `get_multi_columns` to skip full schema scan for single-table reflection

### Problem

When an application reflects a single table (e.g. `inspect(engine).get_columns("my_table", schema="my_schema")` or `Table(..., autoload_with=engine)`), SQLAlchemy calls `get_multi_columns` with `filter_names=["my_table"]`. Before this change the dialect ignored `filter_names` at the SQL layer and always issued a full `information_schema.columns` scan across the entire schema, followed by a `DESC TABLE` call for every structured-type table found there. On schemas with hundreds or thousands of tables this caused multi-second latency and unnecessary Snowflake credit consumption on every single-table reflect.

### Solution

Three targeted changes to `snowdialect.py`:

1. **`get_multi_columns`** — before delegating to `_get_schema_columns`, check whether the full-schema result is already in `info_cache`. If it is, slice it in-process and skip SQL entirely. If not and `filter_names` is set, forward `filter_names` as a tuple so the targeted path is taken and a distinct cache key is produced that cannot pollute the full-schema entry.

2. **`_get_schema_columns`** — pop `filter_names` from `**kw` before calling any sub-method. This prevents the kwarg from bleeding into `_query_all_columns_info` and `_get_schema_primary_keys`, which are also `@reflection.cache`-decorated; a stray kwarg in their keys would produce spurious cache misses.  Dispatch to the new `_query_filtered_columns_info` when `filter_names` is present.

3. **`_query_filtered_columns_info`** (new method) — issues the same `SELECT … FROM information_schema.columns` query as `_query_all_columns_info` but adds `AND ic.table_name IN (:t0, :t1, …)` to restrict the result set to the requested tables. Not decorated with `@reflection.cache`; the caching boundary is `_get_schema_columns`. Returns  `filter_names` (avoids invalid `IN ()` SQL).

The `DESC TABLE` fan-out is eliminated implicitly: because the targeted query returns rows only for thelumn_info` never encounters structured-type columns for unrelated tables and never triggers `DESC TABLE` for them.

### Cache key invariants

| Scenario | Cache key |
|---|---|
| Full schema scan | `("_get_schema_columns", (schema,), ())` |
| Targeted scan (`filter_names=("t",)`) | `("_get_schema_columns", (schema,), (("filter_names", ("t",))
| Warm full-schema cache hit | No SQL — result sliced in `get_multi_columns` |

The full-schema key is never written by a targeted call; a subsequent `MetaData.reflect()` (no `filter_names`) will always issue a real query.

### Tests

- `tests/test_unit_reflection_cache.py` — 21 unit tests (no live connection): SQL dispatch logic, cache key separation, placeholder generation, empty-guard, warm-cache behaviour.
- `tests/test_reflection_cache.py` — 6 integration tests: targeted path returns only requested columns,rity with full-schema path, warm-cache correctness, cold/warm invariant.
