### PR TITLE
mraba/telemetry-structure-object: move toward queryable json

### DIFF
--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -2107,7 +2107,7 @@ class SnowflakeDialect(default.DefaultDialect):
         flags = {
             "case_sensitive_identifiers": self._case_sensitive_identifiers,
             "enable_decfloat": self._enable_decfloat,
-            "cache_column_metadata": self._cache_column_metadata,
+            "cache_column_metadata": getattr(self, "_cache_column_metadata", False),
             "force_div_is_floordiv": self.force_div_is_floordiv,
             "isolation_level": self._isolation_level,
         }

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -47,7 +47,13 @@ from sqlalchemy.sql import text
 from sqlalchemy.sql.sqltypes import NullType
 from sqlalchemy.types import FLOAT, Date, DateTime, Float, Time
 
-from ._constants import DIALECT_NAME, SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS
+from ._constants import (
+    DIALECT_NAME,
+    PARAM_APPLICATION,
+    PARAM_INTERNAL_APPLICATION_NAME,
+    PARAM_INTERNAL_APPLICATION_VERSION,
+    SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS,
+)
 from .base import (
     SnowflakeCompiler,
     SnowflakeDDLCompiler,
@@ -98,8 +104,121 @@ _ENABLE_SQLALCHEMY_AS_APPLICATION_NAME = True
 logger = getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Connection-parameter telemetry
+# ---------------------------------------------------------------------------
+# Connector connection kwargs whose *values* are safe (non-PII, low
+# cardinality) to record on the NEW_CONNECTION_PARAMETERS telemetry event.
+# Anything not listed here is recorded by key-presence only (see
+# ``SnowflakeDialect._build_connection_parameters_telemetry``); identifier-like
+# params (warehouse/role/database/schema) and every credential are deliberately
+# excluded so their values never leave the client.
+_TELEMETRY_SAFE_VALUE_PARAMS = frozenset(
+    {
+        "authenticator",  # normalised via _normalize_authenticator
+        "paramstyle",
+        "numpy",
+        "client_session_keep_alive",
+        "protocol",
+        "ocsp_fail_open",
+        "validate_default_parameters",
+        "client_prefetch_threads",
+        "login_timeout",
+        "network_timeout",
+        "autocommit",
+        "arrow_number_to_decimal",
+        "client_store_temporary_credential",
+        "disable_request_pooling",
+    }
+)
+
+# Connection kwargs the dialect injects itself (see
+# ``_update_connection_application_name``).  Excluded from the recorded key set
+# so telemetry reflects the customer's own choices, not our defaults.
+_TELEMETRY_INJECTED_PARAMS = frozenset(
+    {
+        PARAM_APPLICATION,
+        PARAM_INTERNAL_APPLICATION_NAME,
+        PARAM_INTERNAL_APPLICATION_VERSION,
+    }
+)
+
+try:  # Keep the known-authenticator set in sync with the connector.
+    from snowflake.connector.network import (
+        DEFAULT_AUTHENTICATOR,
+        EXTERNAL_BROWSER_AUTHENTICATOR,
+        ID_TOKEN_AUTHENTICATOR,
+        KEY_PAIR_AUTHENTICATOR,
+        OAUTH_AUTHENTICATOR,
+        OAUTH_AUTHORIZATION_CODE,
+        OAUTH_CLIENT_CREDENTIALS,
+        PROGRAMMATIC_ACCESS_TOKEN,
+        USR_PWD_MFA_AUTHENTICATOR,
+        WORKLOAD_IDENTITY_AUTHENTICATOR,
+    )
+
+    _TELEMETRY_KNOWN_AUTHENTICATORS = frozenset(
+        a.lower()
+        for a in (
+            DEFAULT_AUTHENTICATOR,
+            EXTERNAL_BROWSER_AUTHENTICATOR,
+            ID_TOKEN_AUTHENTICATOR,
+            KEY_PAIR_AUTHENTICATOR,
+            OAUTH_AUTHENTICATOR,
+            OAUTH_AUTHORIZATION_CODE,
+            OAUTH_CLIENT_CREDENTIALS,
+            PROGRAMMATIC_ACCESS_TOKEN,
+            USR_PWD_MFA_AUTHENTICATOR,
+            WORKLOAD_IDENTITY_AUTHENTICATOR,
+        )
+    )
+except Exception:  # pragma: no cover - defensive fallback
+    _TELEMETRY_KNOWN_AUTHENTICATORS = frozenset(
+        {
+            "snowflake",
+            "externalbrowser",
+            "snowflake_jwt",
+            "oauth",
+            "oauth_authorization_code",
+            "oauth_client_credentials",
+            "id_token",
+            "username_password_mfa",
+            "programmatic_access_token",
+            "workload_identity",
+        }
+    )
+
+
+def _normalize_authenticator(value: Any) -> str:
+    """Reduce an authenticator to a low-cardinality, non-identifying label.
+
+    Known connector authenticators are returned verbatim (lower-cased).  A
+    custom authenticator is usually an IdP URL (e.g. an Okta endpoint) which
+    identifies the customer, so anything unrecognised collapses to
+    ``"okta_url"`` (URL-shaped) or ``"other"``.
+    """
+    if not isinstance(value, str):
+        return "other"
+    v = value.strip().lower()
+    if v in _TELEMETRY_KNOWN_AUTHENTICATORS:
+        return v
+    if "okta" in v or "://" in v:
+        return "okta_url"
+    return "other"
+
+
+def _telemetry_safe_value(name: str, value: Any) -> Any:
+    """Coerce an allow-listed param value to a JSON-friendly primitive."""
+    if name == "authenticator":
+        return _normalize_authenticator(value)
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
 class TelemetryEvents(Enum):
     NEW_CONNECTION = "sqlalchemy_new_connection"
+    NEW_CONNECTION_PARAMETERS = "sqlalchemy_new_connection_parameters"
 
 
 class SnowflakeIsolationLevel(Enum):
@@ -245,7 +364,10 @@ class SnowflakeDialect(default.DefaultDialect):
         redact_log_secrets: bool = True,
         **kwargs: Any,
     ):
-        super().__init__(isolation_level=isolation_level, **kwargs)  # type: ignore[arg-type]
+        super().__init__(isolation_level=isolation_level, **kwargs)
+        # ``DefaultDialect`` does not reliably expose the configured isolation
+        # level as an attribute, so keep the constructor value for telemetry.
+        self._isolation_level = isolation_level
         self.force_div_is_floordiv = force_div_is_floordiv
         self.div_is_floordiv = force_div_is_floordiv
         self._case_sensitive_identifiers = case_sensitive_identifiers
@@ -1968,11 +2090,56 @@ class SnowflakeDialect(default.DefaultDialect):
             decimal.getcontext().prec = DECFLOAT_PRECISION
 
         connection = super().connect(*cargs, **cparams)
-        self._log_new_connection_event(connection)  # type: ignore[arg-type]
+        self._log_new_connection_event(connection, cparams)
 
         return connection  # type: ignore[return-value]
 
-    def _log_new_connection_event(self, connection: SnowflakeConnection) -> None:
+    def _build_connection_parameters_telemetry(self, cparams: dict) -> dict:
+        """Structured, queryable telemetry describing the dialect
+        configuration and the connection options the customer supplied.
+
+        PII-safe: credential and identifier *values* are never included.
+        Every supplied option is recorded by key-presence only
+        (``provided_keys``); values are copied solely for the curated
+        ``_TELEMETRY_SAFE_VALUE_PARAMS`` allow-list, with ``authenticator``
+        normalised to a non-identifying label.
+        """
+        flags = {
+            "case_sensitive_identifiers": self._case_sensitive_identifiers,
+            "enable_decfloat": self._enable_decfloat,
+            "cache_column_metadata": self._cache_column_metadata,
+            "force_div_is_floordiv": self.force_div_is_floordiv,
+            "isolation_level": self._isolation_level,
+        }
+
+        versions = {"sqlalchemy": SQLALCHEMY_VERSION}
+        try:
+            from pandas import __version__ as PANDAS_VERSION
+
+            versions["pandas"] = PANDAS_VERSION
+        except ImportError:
+            pass
+
+        cparams = cparams or {}
+        provided_keys = sorted(
+            k for k in cparams if k not in _TELEMETRY_INJECTED_PARAMS
+        )
+        values = {
+            name: _telemetry_safe_value(name, cparams[name])
+            for name in _TELEMETRY_SAFE_VALUE_PARAMS
+            if name in cparams
+        }
+
+        return {
+            "versions": versions,
+            "dialect_flags": flags,
+            "connection_parameters": {
+                "provided_keys": provided_keys,
+                "values": values,
+            },
+        }
+
+    def _log_new_connection_event(self, connection, cparams=None):
         try:
             snowflake_connection = cast(SnowflakeConnection, cast(object, connection))
             snowflake_telemetry_client = TelemetryClient(rest=snowflake_connection.rest)  # type: ignore[arg-type]
@@ -2004,16 +2171,39 @@ class SnowflakeDialect(default.DefaultDialect):
             telemetry_value["force_div_is_floordiv"] = self.force_div_is_floordiv
             telemetry_value["legacy_url_params"] = self._legacy_url_params
 
+            timestamp = int(time_in_seconds() * 1000)
+
             snowflake_telemetry_client.add_log_to_batch(
                 TelemetryData.from_telemetry_data_dict(
                     from_dict={
                         TelemetryField.KEY_TYPE.value: TelemetryEvents.NEW_CONNECTION.value,
                         TelemetryField.KEY_VALUE.value: str(telemetry_value),
                     },
-                    timestamp=int(time_in_seconds() * 1000),
+                    timestamp=timestamp,
                     connection=snowflake_connection,
                 )
             )
+
+            # Structured, queryable companion event.  Emitted alongside the
+            # legacy event (same batch) so downstream analysis can migrate to
+            # structured connection-option data — including which connection
+            # options customers actually set — without disturbing the existing
+            # event until the new one is validated against real data.  Unlike
+            # the legacy payload this is a nested dict rather than ``str(...)``
+            # so it lands as queryable JSON.
+            snowflake_telemetry_client.add_log_to_batch(
+                TelemetryData.from_telemetry_data_dict(
+                    from_dict={
+                        TelemetryField.KEY_TYPE.value: TelemetryEvents.NEW_CONNECTION_PARAMETERS.value,
+                        TelemetryField.KEY_VALUE.value: self._build_connection_parameters_telemetry(
+                            cparams
+                        ),
+                    },
+                    timestamp=timestamp,
+                    connection=snowflake_connection,
+                )
+            )
+
             snowflake_telemetry_client.send_batch()
         except Exception as e:
             logger.debug(

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -364,7 +364,7 @@ class SnowflakeDialect(default.DefaultDialect):
         redact_log_secrets: bool = True,
         **kwargs: Any,
     ):
-        super().__init__(isolation_level=isolation_level, **kwargs)
+        super().__init__(isolation_level=isolation_level, **kwargs)  # type: ignore[arg-type]
         # ``DefaultDialect`` does not reliably expose the configured isolation
         # level as an attribute, so keep the constructor value for telemetry.
         self._isolation_level = isolation_level

--- a/tests/test_dialect_connect.py
+++ b/tests/test_dialect_connect.py
@@ -51,10 +51,13 @@ def test_connect_sends_telemetry(mock_telemetry_client, mock_connect, fake_conne
 
     assert result is fake_connection
 
-    # Verify add_log_to_batch was called with correct payload
+    # Verify add_log_to_batch was called with correct payload.  The legacy
+    # ``sqlalchemy_new_connection`` event is the first log added to the batch
+    # (a second, structured event is added after it — see the structured-event
+    # tests below).
     telemetry_instance = mock_telemetry_client.return_value
 
-    payload = telemetry_instance.add_log_to_batch.call_args[0][0]
+    payload = telemetry_instance.add_log_to_batch.call_args_list[0].args[0]
     assert (
         payload.message[TelemetryField.KEY_TYPE.value]
         == TelemetryEvents.NEW_CONNECTION.value
@@ -86,7 +89,7 @@ def test_connect_telemetry_includes_pandas_when_available(
         dialect.connect()
 
     telemetry_instance = mock_telemetry_client.return_value
-    payload = telemetry_instance.add_log_to_batch.call_args[0][0]
+    payload = telemetry_instance.add_log_to_batch.call_args_list[0].args[0]
     telemetry_value = payload.message[TelemetryField.KEY_VALUE.value]
 
     assert telemetry_value == str(
@@ -113,7 +116,7 @@ def test_connect_telemetry_excludes_pandas_when_not_available(
         dialect.connect()
 
     telemetry_instance = mock_telemetry_client.return_value
-    payload = telemetry_instance.add_log_to_batch.call_args[0][0]
+    payload = telemetry_instance.add_log_to_batch.call_args_list[0].args[0]
     telemetry_value = payload.message[TelemetryField.KEY_VALUE.value]
 
     assert telemetry_value == str(
@@ -148,10 +151,16 @@ def test_connect_logs_when_telemetry_fails(
 
 
 def _telemetry_payload(dialect, telemetry_client_mock, fake_connection):
-    """Run ``dialect.connect()`` once and return the payload message dict."""
+    """Run ``dialect.connect()`` once and return the legacy payload message.
+
+    The legacy ``sqlalchemy_new_connection`` event is the first log added to
+    the batch; the structured event is second.
+    """
     fake_connection.rest = mock.MagicMock()
     dialect.connect()
-    payload = telemetry_client_mock.return_value.add_log_to_batch.call_args[0][0]
+    payload = telemetry_client_mock.return_value.add_log_to_batch.call_args_list[
+        0
+    ].args[0]
     return payload.message
 
 
@@ -249,3 +258,202 @@ def test_connect_telemetry_records_url_driven_flag(
     assert message[TelemetryField.KEY_VALUE.value] == str(
         {"SQLAlchemy": SQLALCHEMY_VERSION, **expected_flags}
     )
+
+
+# ---------------------------------------------------------------------------
+# Structured NEW_CONNECTION_PARAMETERS event
+# ---------------------------------------------------------------------------
+
+
+def _structured_message(telemetry_client_mock):
+    """Return the message dict of the structured connection-parameters event.
+
+    It is the *second* log added to the batch (after the legacy event).
+    """
+    payload = telemetry_client_mock.return_value.add_log_to_batch.call_args_list[
+        1
+    ].args[0]
+    return payload.message
+
+
+@mock.patch.object(sqla_default.DefaultDialect, "connect")
+@mock.patch("snowflake.sqlalchemy.snowdialect.TelemetryClient")
+def test_structured_event_is_emitted_alongside_legacy(
+    mock_telemetry_client, mock_connect, fake_connection
+):
+    """Both events are batched together and sent with a single send_batch."""
+    mock_connect.return_value = fake_connection
+
+    with mock.patch.dict(modules, {"pandas": None}):
+        fake_connection.rest = mock.MagicMock()
+        SnowflakeDialect().connect()
+
+    telemetry_instance = mock_telemetry_client.return_value
+    assert telemetry_instance.add_log_to_batch.call_count == 2
+    telemetry_instance.send_batch.assert_called_once()
+
+    legacy = telemetry_instance.add_log_to_batch.call_args_list[0].args[0]
+    structured = telemetry_instance.add_log_to_batch.call_args_list[1].args[0]
+    assert (
+        legacy.message[TelemetryField.KEY_TYPE.value]
+        == TelemetryEvents.NEW_CONNECTION.value
+    )
+    assert (
+        structured.message[TelemetryField.KEY_TYPE.value]
+        == TelemetryEvents.NEW_CONNECTION_PARAMETERS.value
+    )
+    # The structured value is a nested dict (queryable JSON), not str(dict).
+    assert isinstance(structured.message[TelemetryField.KEY_VALUE.value], dict)
+
+
+@mock.patch.object(sqla_default.DefaultDialect, "connect")
+@mock.patch("snowflake.sqlalchemy.snowdialect.TelemetryClient")
+def test_structured_event_records_keys_but_never_sensitive_values(
+    mock_telemetry_client, mock_connect, fake_connection
+):
+    """Every supplied option is recorded by key; only allow-listed, non-PII
+    values are copied.  Credentials/identifiers appear as keys only, and the
+    dialect's own injected application params are excluded entirely."""
+    mock_connect.return_value = fake_connection
+
+    with mock.patch.dict(modules, {"pandas": None}):
+        fake_connection.rest = mock.MagicMock()
+        SnowflakeDialect().connect(
+            user="ZZuserZZ",
+            password="ZZpasswordZZ",
+            token="ZZtokenvalueZZ",
+            private_key="ZZprivatekeyZZ",
+            account="ZZaccountZZ",
+            warehouse="ZZwarehouseZZ",
+            role="ZZroleZZ",
+            numpy=True,
+            paramstyle="qmark",
+            client_session_keep_alive=True,
+        )
+
+    value = _structured_message(mock_telemetry_client)[TelemetryField.KEY_VALUE.value]
+    conn = value["connection_parameters"]
+
+    # Presence: customer-supplied keys are all listed...
+    for key in (
+        "user",
+        "password",
+        "token",
+        "private_key",
+        "account",
+        "warehouse",
+        "role",
+        "numpy",
+        "paramstyle",
+        "client_session_keep_alive",
+    ):
+        assert key in conn["provided_keys"]
+    # ...but the dialect's injected application params are not.
+    for injected in (
+        "application",
+        "internal_application_name",
+        "internal_application_version",
+    ):
+        assert injected not in conn["provided_keys"]
+
+    # Values: only the non-PII allow-list is copied through.
+    assert conn["values"] == {
+        "numpy": True,
+        "paramstyle": "qmark",
+        "client_session_keep_alive": True,
+    }
+    # No credential/identifier value leaks anywhere in the serialized payload.
+    # (Sentinels are deliberately distinct from the key names so a match means
+    # a real value leak, not the key appearing in ``provided_keys``.)
+    serialized = str(value)
+    for secret in (
+        "ZZuserZZ",
+        "ZZpasswordZZ",
+        "ZZtokenvalueZZ",
+        "ZZprivatekeyZZ",
+        "ZZaccountZZ",
+        "ZZwarehouseZZ",
+        "ZZroleZZ",
+    ):
+        assert secret not in serialized
+
+
+@pytest.mark.parametrize(
+    "authenticator,expected",
+    [
+        ("externalbrowser", "externalbrowser"),
+        ("EXTERNALBROWSER", "externalbrowser"),
+        ("oauth", "oauth"),
+        ("https://acme.okta.com", "okta_url"),
+        ("something-custom", "other"),
+    ],
+)
+@mock.patch.object(sqla_default.DefaultDialect, "connect")
+@mock.patch("snowflake.sqlalchemy.snowdialect.TelemetryClient")
+def test_structured_event_normalizes_authenticator(
+    mock_telemetry_client, mock_connect, fake_connection, authenticator, expected
+):
+    """authenticator is normalized to a low-cardinality, non-identifying label."""
+    mock_connect.return_value = fake_connection
+
+    with mock.patch.dict(modules, {"pandas": None}):
+        fake_connection.rest = mock.MagicMock()
+        SnowflakeDialect().connect(authenticator=authenticator)
+
+    value = _structured_message(mock_telemetry_client)[TelemetryField.KEY_VALUE.value]
+    assert value["connection_parameters"]["values"]["authenticator"] == expected
+
+
+@mock.patch.object(sqla_default.DefaultDialect, "connect")
+@mock.patch("snowflake.sqlalchemy.snowdialect.TelemetryClient")
+def test_structured_event_records_flags_and_isolation_level(
+    mock_telemetry_client, mock_connect, fake_connection
+):
+    """dialect_flags carries the config booleans plus the isolation level."""
+    mock_connect.return_value = fake_connection
+
+    with mock.patch.dict(modules, {"pandas": None}):
+        fake_connection.rest = mock.MagicMock()
+        SnowflakeDialect(
+            isolation_level="AUTOCOMMIT",
+            enable_decfloat=True,
+        ).connect()
+
+    value = _structured_message(mock_telemetry_client)[TelemetryField.KEY_VALUE.value]
+    flags = value["dialect_flags"]
+    assert flags["isolation_level"] == "AUTOCOMMIT"
+    assert flags["enable_decfloat"] is True
+    assert flags["case_sensitive_identifiers"] is False
+    assert flags["cache_column_metadata"] is False
+    assert flags["force_div_is_floordiv"] is True
+
+
+@mock.patch.object(sqla_default.DefaultDialect, "connect")
+@mock.patch("snowflake.sqlalchemy.snowdialect.TelemetryClient")
+def test_structured_event_reflects_url_driven_params(
+    mock_telemetry_client, mock_connect, fake_connection
+):
+    """URL query params resolved by create_connect_args reach the structured
+    event's provided_keys/values (via the cparams passed to connect)."""
+    mock_connect.return_value = fake_connection
+
+    with mock.patch.dict(modules, {"pandas": None}):
+        fake_connection.rest = mock.MagicMock()
+        dialect = SnowflakeDialect()
+        url = SAUrl.create(
+            "snowflake",
+            username="u",
+            password="p",
+            host="testaccount",
+            query={"numpy": "True", "warehouse": "WH"},
+        )
+        _, cparams = dialect.create_connect_args(url)
+        dialect.connect(**cparams)
+
+    value = _structured_message(mock_telemetry_client)[TelemetryField.KEY_VALUE.value]
+    conn = value["connection_parameters"]
+    assert "numpy" in conn["provided_keys"]
+    assert "warehouse" in conn["provided_keys"]
+    assert conn["values"]["numpy"] is True
+    # warehouse is an identifier: recorded by presence only, never by value.
+    assert "warehouse" not in conn["values"]


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #chore

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR evolves the connection telemetry message structure: instead of a single flat event carrying an opaque str(dict) payload, it adds a nested, structured event (sqlalchemy_new_connection_parameters) emitted alongside the existing one, organizing the message into dedicated sections (versions, dialect_flags, connection_parameters) as queryable JSON. The legacy event continues emitting unchanged so nothing downstream breaks, while the new structure can be validated and iterated on independently before anything migrates to it.