### PR TITLE
SNOW-3655930: improve escaping and rendering

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,8 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- `ClusterByOption` now raises `TypeError` at DDL compile time when an expression element is neither a `str` nor a `sqlalchemy.sql.expression.TextClause`. Previously, such values were silently coerced via `str()`, which produced malformed DDL (e.g. bind-parameter placeholders like `:id_1`) for any expression beyond a bare column name. The accepted types match the documented constructor signature; code using only `str` or `text(...)` is unaffected.
+
 # Release Notes
 
 - v1.10.2 (June 18, 2026)

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -40,6 +40,8 @@ from .util import (
     _set_connection_interpolate_empty_sequences,
     _Snowflake_ORMJoin,
     _Snowflake_Selectable_Join,
+    escape_backslashes,
+    escape_string_literal_interior,
 )
 
 RESERVED_WORDS = frozenset(
@@ -901,7 +903,17 @@ class SnowflakeCompiler(compiler.SQLCompiler):
 
     def render_literal_value(self, value, type_):
         # escape backslash
-        return super().render_literal_value(value, type_).replace("\\", "\\\\")
+        return escape_backslashes(super().render_literal_value(value, type_))
+
+    def _escape_string_interior(self, value: str) -> str:
+        """Return ``value`` escaped for embedding inside a single-quoted literal.
+
+        Returns only the escaped interior (no surrounding quotes), so callers
+        that already supply the enclosing quotes can interpolate the result
+        directly.  Shares its escaping rules with the DDL compiler via
+        ``escape_string_literal_interior``.
+        """
+        return escape_string_literal_interior(value)
 
 
 class SnowflakeExecutionContext(default.DefaultExecutionContext):
@@ -964,6 +976,14 @@ _identity_pk_warned: set = set()
 
 
 class SnowflakeDDLCompiler(compiler.DDLCompiler):
+    def _escape_string_interior(self, value: str) -> str:
+        """Return ``value`` escaped for embedding inside a single-quoted literal.
+
+        DDL counterpart of ``SnowflakeCompiler._escape_string_interior``; both
+        share their escaping rules via ``escape_string_literal_interior``.
+        """
+        return escape_string_literal_interior(value)
+
     def denormalize_column_name(self, name):
         if name is None:
             return None

--- a/src/snowflake/sqlalchemy/sql/custom_schema/options/as_query_option.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/options/as_query_option.py
@@ -48,13 +48,17 @@ class AsQueryOption(TableOption):
     def priority(self) -> Priority:
         return Priority.LOWEST
 
-    def __get_expression(self):
+    def __get_expression(self, compiler=None):
         if isinstance(self.query, Selectable):
-            return self.query.compile(compile_kwargs={"literal_binds": True})
+            dialect = compiler.dialect if compiler is not None else None
+            return self.query.compile(
+                dialect=dialect,
+                compile_kwargs={"literal_binds": True},
+            )
         return self.query
 
     def _render(self, compiler) -> str:
-        return self.template() % (self.__get_expression())
+        return self.template() % (self.__get_expression(compiler))
 
     def __repr__(self) -> str:
         return "AsQueryOption(%s)" % self.__get_expression()

--- a/src/snowflake/sqlalchemy/sql/custom_schema/options/cluster_by_option.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/options/cluster_by_option.py
@@ -45,11 +45,22 @@ class ClusterByOption(TableOption):
     def priority(self) -> Priority:
         return Priority.HIGH
 
-    def __get_expression(self):
-        return ", ".join([str(expression) for expression in self.expressions])
+    def __get_expression(self, compiler=None):
+        parts = []
+        for expr in self.expressions:
+            if isinstance(expr, TextClause):
+                parts.append(str(expr))  # TextClause is trusted literal SQL
+            elif isinstance(expr, str):
+                parts.append(self._quote_identifier_value(expr, compiler))
+            else:
+                raise TypeError(
+                    "ClusterByOption expressions must be str or TextClause, "
+                    f"got {type(expr).__name__}"
+                )
+        return ", ".join(parts)
 
     def _render(self, compiler) -> str:
-        return self.template() % (self.__get_expression())
+        return self.template() % (self.__get_expression(compiler))
 
     def __repr__(self) -> str:
         return "ClusterByOption(%s)" % self.__get_expression()

--- a/src/snowflake/sqlalchemy/sql/custom_schema/options/identifier_option.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/options/identifier_option.py
@@ -11,6 +11,10 @@ from .table_option import Priority, TableOption, TableOptionKey
 class IdentifierOption(TableOption):
     """Class to represent an identifier option in Snowflake Tables.
 
+    Pass the bare identifier name — without surrounding double-quotes.
+    The dialect's identifier preparer applies quoting automatically when
+    the name contains characters that require it (spaces, mixed case, etc.).
+
     Example:
         warehouse = IdentifierOption('my_warehouse')
 
@@ -49,7 +53,7 @@ class IdentifierOption(TableOption):
         return f"{self.option_name.upper()} = %s"
 
     def _render(self, compiler) -> str:
-        return self.template() % self.value
+        return self.template() % self._quote_identifier_value(self.value, compiler)
 
     def __repr__(self) -> str:
         option_name = (

--- a/src/snowflake/sqlalchemy/sql/custom_schema/options/keyword_option.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/options/keyword_option.py
@@ -32,6 +32,7 @@ class KeywordOption(TableOption):
         return f"{self.option_name.upper()} = %s"
 
     def _render(self, compiler) -> str:
+        # This function renders only keywords, so no additional processing is needed.
         return self.template() % self.value.upper()
 
     @staticmethod

--- a/src/snowflake/sqlalchemy/sql/custom_schema/options/literal_option.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/options/literal_option.py
@@ -53,7 +53,10 @@ class LiteralOption(TableOption):
             return f"{self.option_name.upper()} = '%s'"
 
     def _render(self, compiler) -> str:
-        return self.template() % self.value
+        if isinstance(self.value, int):
+            return self.template() % self.value
+        escaped = self._escape_string_literal_value(str(self.value))
+        return self.template() % escaped
 
     def __repr__(self) -> str:
         option_name = (

--- a/src/snowflake/sqlalchemy/sql/custom_schema/options/table_option.py
+++ b/src/snowflake/sqlalchemy/sql/custom_schema/options/table_option.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from snowflake.sqlalchemy import exc
 from snowflake.sqlalchemy.custom_commands import NoneType
+from snowflake.sqlalchemy.util import escape_string_literal_interior
 
 
 class Priority(Enum):
@@ -59,6 +60,29 @@ class TableOption:
 
     def template(self) -> str:
         return f"{self.option_name.upper()} = %s"
+
+    @staticmethod
+    def _quote_identifier_value(value: str, compiler=None) -> str:
+        """Return the identifier quoted per the dialect's rules.
+
+        Uses ``compiler.preparer.quote()`` when a compiler is available so
+        that special characters are wrapped in double-quotes and any embedded
+        double-quotes are doubled.  Falls back to the bare value when no
+        compiler is present (e.g. in ``__repr__`` / test-only paths).
+        """
+        if compiler is not None:
+            return compiler.preparer.quote(value)
+        return value
+
+    @staticmethod
+    def _escape_string_literal_value(value: str) -> str:
+        """Return the escaped interior of a DDL string literal (no surrounding quotes).
+
+        Applies single-quote doubling and backslash doubling for Snowflake's
+        ESCAPE_STRING_LITERALS semantics.  Returns only the interior — no
+        surrounding quotes — ready to interpolate into a ``'%s'`` template.
+        """
+        return escape_string_literal_interior(value)
 
     def render_option(self, compiler) -> str:
         self._validate_option()

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -316,3 +316,25 @@ def create_snowflake_engine(
     else:
         url = base_url
     return _sa_create_engine(url, **kwargs)
+
+
+def escape_backslashes(value: str) -> str:
+    """Double backslashes so they survive Snowflake's ESCAPE_STRING_LITERALS.
+
+    Snowflake interprets backslash escape sequences inside string literals by
+    default, so any literal backslash in user data must be doubled.
+    """
+    return value.replace("\\", "\\\\")
+
+
+def escape_string_literal_interior(value: str) -> str:
+    """Escape the *interior* of a single-quoted Snowflake string literal.
+
+    Doubles single quotes (standard SQL ``''`` escaping) and backslashes
+    (Snowflake ``ESCAPE_STRING_LITERALS`` semantics).  The two replacements are
+    order-independent.  Returns only the interior — **no surrounding quotes** —
+    and deliberately does **not** double percent signs, so the result is safe to
+    interpolate into a Python ``%``-formatted DDL template (unlike SQLAlchemy's
+    ``String`` literal processor, which both wraps in quotes and doubles ``%``).
+    """
+    return value.replace("'", "''").replace("\\", "\\\\")

--- a/tests/test_table_option_quoting.py
+++ b/tests/test_table_option_quoting.py
@@ -1,0 +1,204 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+# Tests for DDL option identifier quoting and string-literal escaping.
+#
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, select
+from sqlalchemy.sql.ddl import CreateTable
+
+from snowflake.sqlalchemy import DynamicTable, IcebergTable, SnowflakeTable
+from snowflake.sqlalchemy.sql.custom_schema.options import (
+    ClusterByOption,
+    IdentifierOption,
+    KeywordOption,
+    LiteralOption,
+    SnowflakeKeyword,
+    TableOptionKey,
+    TimeUnit,
+)
+
+
+def test_identifier_option_quotes_special_chars(sql_compiler):
+    """IdentifierOption must identifier-quote values that contain SQL metacharacters."""
+    invalid_warehouse_name = "wh'; -- aaa"
+    metadata = MetaData()
+    table = DynamicTable(
+        "t",
+        metadata,
+        Column("id", Integer),
+        target_lag=(10, TimeUnit.SECONDS),
+        warehouse=invalid_warehouse_name,
+        as_query="SELECT 1",
+    )
+    sql = sql_compiler(CreateTable(table))
+    assert f'"{invalid_warehouse_name}"' in sql
+
+
+def test_identifier_option_doubles_embedded_quote(sql_compiler):
+    """IdentifierOption must double any double-quote inside the identifier."""
+    metadata = MetaData()
+    table = DynamicTable(
+        "t2",
+        metadata,
+        Column("id", Integer),
+        target_lag=(10, TimeUnit.SECONDS),
+        warehouse='my"warehouse',
+        as_query="SELECT 1",
+    )
+    sql = sql_compiler(CreateTable(table))
+    assert '"my""warehouse"' in sql
+
+
+def test_identifier_option_bare_name_not_pre_quoted(sql_compiler):
+    """IdentifierOption expects a bare name; the preparer quotes it when needed.
+
+    A pre-quoted value (e.g. '"my_warehouse"') is not supported — the embedded
+    quotes are treated as identifier characters and doubled.
+    """
+    metadata = MetaData()
+    table = DynamicTable(
+        "t_bare",
+        metadata,
+        Column("id", Integer),
+        target_lag=(10, TimeUnit.SECONDS),
+        warehouse="my_warehouse",
+        as_query="SELECT 1",
+    )
+    sql = sql_compiler(CreateTable(table))
+    assert "WAREHOUSE = my_warehouse" in sql
+
+
+def test_literal_option_escapes_single_quote(sql_compiler):
+    """LiteralOption must double single-quotes inside string literals."""
+    metadata = MetaData()
+    table = IcebergTable(
+        "t3",
+        metadata,
+        Column("id", Integer),
+        external_volume="vol",
+        base_location="loc'; -- aaa",
+    )
+    sql = sql_compiler(CreateTable(table))
+    assert "BASE_LOCATION = 'loc''; -- aaa'" in sql
+
+
+def test_literal_option_escapes_backslash_before_quote(sql_compiler):
+    r"""LiteralOption must double backslashes as well as single-quotes.
+
+    With ESCAPE_STRING_LITERALS=TRUE, Snowflake reads \' as an escaped quote;
+    doubling the backslash yields \\'' (literal backslash + escaped quote).
+    """
+    value_with_backslash_quote = "path\\' suffix"
+    metadata = MetaData()
+    table = IcebergTable(
+        "t4",
+        metadata,
+        Column("id", Integer),
+        external_volume="vol",
+        base_location=value_with_backslash_quote,
+    )
+    sql = sql_compiler(CreateTable(table))
+    assert "\\\\'' suffix" in sql
+
+
+def test_cluster_by_option_quotes_special_chars(sql_compiler):
+    """ClusterByOption must identifier-quote string column expressions."""
+    invalid_column_name = "col); -- aaa"
+    metadata = MetaData()
+    table = SnowflakeTable(
+        "t5",
+        metadata,
+        Column("id", Integer),
+        cluster_by=ClusterByOption(invalid_column_name),
+    )
+    sql = sql_compiler(CreateTable(table))
+    assert f'"{invalid_column_name}"' in sql
+
+
+def test_as_query_selectable_uses_snowflake_dialect(sql_compiler):
+    r"""AsQueryOption must compile Selectables with the active Snowflake dialect.
+
+    SQLAlchemy's default dialect only doubles single-quotes, leaving backslashes
+    raw, so a value containing \' could escape the literal. Compiling with
+    the Snowflake dialect also doubles backslashes, yielding \\''.
+    """
+    value_with_backslash_quote = "val\\' x"
+    src_meta = MetaData()
+    source = Table("src", src_meta, Column("name", String))
+    dynamic = DynamicTable(
+        "t6",
+        MetaData(),
+        Column("name", String),
+        target_lag=(10, TimeUnit.SECONDS),
+        warehouse="wh",
+        as_query=select(source).where(source.c.name == value_with_backslash_quote),
+    )
+    sql = sql_compiler(CreateTable(dynamic))
+    assert "\\\\'' x" in sql
+
+
+# Compiler-threading contract (SNOW-3649855): options handling user-controlled
+# strings must use the compiler they receive. The marker preparer makes this
+# checkable — QUOTED[…] appears only when compiler.preparer.quote() was called.
+# KeywordOption (closed enum) and LiteralOption (pure escaping) are marker-free
+# by design; AsQueryOption is covered separately above.
+
+
+class _MarkerPreparer:
+    """Preparer that wraps every quoted identifier in QUOTED[…] markers."""
+
+    def quote(self, value):
+        return f"QUOTED[{value}]"
+
+
+class _MarkerCompiler:
+    """Minimal compiler stub for verifying compiler-threading in _render."""
+
+    preparer = _MarkerPreparer()
+
+    class dialect:
+        name = "snowflake"
+
+
+_MARKER_COMPILER = _MarkerCompiler()
+
+
+@pytest.mark.parametrize(
+    "option, uses_compiler, expected_fragment",
+    [
+        pytest.param(
+            IdentifierOption.create(TableOptionKey.WAREHOUSE, "my_wh"),
+            True,
+            "QUOTED[my_wh]",
+            id="identifier_option_uses_preparer",
+        ),
+        pytest.param(
+            ClusterByOption("col_a"),
+            True,
+            "QUOTED[col_a]",
+            id="cluster_by_option_uses_preparer",
+        ),
+        pytest.param(
+            LiteralOption.create(TableOptionKey.BASE_LOCATION, "some/path"),
+            False,
+            "BASE_LOCATION = 'some/path'",
+            id="literal_option_no_compiler_dependency",
+        ),
+        pytest.param(
+            KeywordOption.create(TableOptionKey.REFRESH_MODE, SnowflakeKeyword.AUTO),
+            False,
+            "REFRESH_MODE = AUTO",
+            id="keyword_option_emits_bare_keyword",
+        ),
+    ],
+)
+def test_render_compiler_threading(option, uses_compiler, expected_fragment):
+    """_render uses the compiler for user-controlled values; not for closed enums."""
+    result = option._render(_MARKER_COMPILER)
+    assert expected_fragment in result
+    if uses_compiler:
+        assert "QUOTED[" in result, (
+            f"{type(option).__name__}._render did not use compiler.preparer.quote(); "
+            f"got: {result!r}"
+        )

--- a/tests/test_unit_escaping.py
+++ b/tests/test_unit_escaping.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+# Unit tests for the Snowflake string-escaping helpers in util.py.
+# See tests/test_table_option_quoting.py for end-to-end option rendering coverage.
+#
+import pytest
+from sqlalchemy.sql.sqltypes import String
+
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+from snowflake.sqlalchemy.util import escape_backslashes, escape_string_literal_interior
+
+# A single literal backslash. Spelled out to keep the parametrize tables
+# readable — "\\" in source is one backslash at runtime.
+BS = "\\"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param("", "", id="empty"),
+        pytest.param("plain", "plain", id="no_special_chars"),
+        pytest.param(BS, BS * 2, id="single_backslash"),
+        pytest.param(BS * 2, BS * 4, id="double_backslash"),
+        pytest.param("a" + BS + "b", "a" + BS * 2 + "b", id="embedded_backslash"),
+        pytest.param(BS + "'", BS * 2 + "'", id="backslash_before_quote_only_bs"),
+        pytest.param("100%", "100%", id="percent_untouched"),
+        pytest.param("'", "'", id="lone_quote_untouched"),
+        pytest.param("a" + BS + BS + "b", "a" + BS * 4 + "b", id="run_of_two"),
+    ],
+)
+def test_escape_backslashes(value, expected):
+    assert escape_backslashes(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param("", "", id="empty"),
+        pytest.param("plain", "plain", id="no_special_chars"),
+        pytest.param("'", "''", id="single_quote_doubled"),
+        pytest.param("''", "''''", id="two_quotes_doubled"),
+        pytest.param(BS, BS * 2, id="backslash_doubled"),
+        pytest.param("O'Brien", "O''Brien", id="apostrophe"),
+        pytest.param("loc'; -- aaa", "loc''; -- aaa", id="quote_in_value"),
+        # Combined backslash and quote: Snowflake (ESCAPE_STRING_LITERALS) reads
+        # \' as an escaped quote; doubling the backslash neutralises it -> \\''
+        pytest.param(
+            "path" + BS + "' suffix",
+            "path" + BS * 2 + "'' suffix",
+            id="backslash_quote_escaped",
+        ),
+        # Percent signs must NOT be doubled (unlike SA's literal processor),
+        # because the interior is interpolated into a %-formatted DDL template.
+        pytest.param("a%b", "a%b", id="percent_not_doubled"),
+        pytest.param("%s %d %%", "%s %d %%", id="format_specifiers_untouched"),
+        # No surrounding quotes are added.
+        pytest.param("x", "x", id="no_wrapping_quotes"),
+    ],
+)
+def test_escape_string_literal_interior(value, expected):
+    assert escape_string_literal_interior(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("a%b", id="percent"),
+        pytest.param("100%", id="trailing_percent"),
+        pytest.param("no percent here", id="no_percent"),
+    ],
+)
+def test_interior_escape_diverges_from_sa_processor_on_percent(value):
+    """Snowflake uses pyformat paramstyle, so the processor doubles '%' and
+    wraps the value in quotes. Our DDL-option helper must do neither — this
+    test fails loudly if anyone swaps the helper back to the processor.
+    """
+    dialect = SnowflakeDialect()
+    assert dialect.identifier_preparer._double_percents is True
+    processor = String()._cached_literal_processor(dialect)
+    processed = processor(value)
+
+    # Processor wraps in single-quotes; the helper does not.
+    assert processed.startswith("'") and processed.endswith("'")
+    helper = escape_string_literal_interior(value)
+    assert not helper.startswith("'")
+
+    if "%" in value:
+        assert "%%" in processed
+        assert "%%" not in helper
+    else:
+        # Absent percent signs, the processor interior matches the helper.
+        assert processed[1:-1] == helper
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("plain", id="plain"),
+        pytest.param("a'b", id="quote"),
+        pytest.param(BS, id="backslash"),
+        pytest.param("a%b'c" + BS + "d", id="mixed"),
+    ],
+)
+def test_compiler_escape_methods_delegate_to_helper(value):
+    dialect = SnowflakeDialect()
+    ddl_compiler = dialect.ddl_compiler(dialect, None)
+    sql_compiler = dialect.statement_compiler(dialect, None)
+    expected = escape_string_literal_interior(value)
+    assert ddl_compiler._escape_string_interior(value) == expected
+    assert sql_compiler._escape_string_interior(value) == expected


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-3655930

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

**Improve DDL option validation, escaping, and rendering**

Hardens how custom-schema table options render caller-supplied values in compiled DDL.

- `ClusterByOption` now raises `TypeError` at DDL compile time when an expression element is
  neither a `str` nor a `sqlalchemy.sql.expression.TextClause`. Previously such values were
  silently coerced via `str()`, which produced malformed DDL (e.g. bind-parameter placeholders
  like `:id_1`) for any expression beyond a bare column name. The accepted types match the
  documented constructor signature, so code using only `str` or `text(...)` is unaffected.
- Option identifier/literal rendering is routed through shared helpers for consistent quoting
  and escaping.
- Adds unit coverage for table-option quoting and the escaping helpers
  (`tests/test_table_option_quoting.py`, `tests/test_unit_escaping.py`).

**Touches:** `base.py`, `util.py`, `sql/custom_schema/options/*`, `DESCRIPTION.md`, tests.