### PR TITLE
SNOW-3656026 identifiers and literal quoting

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at:
 # Unreleased Notes
 
 - `ClusterByOption` now raises `TypeError` at DDL compile time when an expression element is neither a `str` nor a `sqlalchemy.sql.expression.TextClause`. Previously, such values were silently coerced via `str()`, which produced malformed DDL (e.g. bind-parameter placeholders like `:id_1`) for any expression beyond a bare column name. The accepted types match the documented constructor signature; code using only `str` or `text(...)` is unaffected.
+- Improve identifier quoting and string-literal escaping for caller-supplied values across the DDL compiler so they are rendered consistently with the rest of the dialect. Column keys in `MERGE INTO` (both the `WHEN NOT MATCHED … INSERT` list and `WHEN MATCHED … SET` targets), stage namespaces/names, `format_name`, and `file_format` are now routed through the identifier preparer, and a `quote=False` schema or column label is quoted when it contains characters that would otherwise require quoting instead of being emitted verbatim. Cloud-storage URIs, `CREDENTIALS`, and `ENCRYPTION` clauses (shared by `COPY INTO` and `CREATE STAGE`) and `FILES=(…)` entries now apply the dialect's standard literal escaping (`'`→`''`, `\`→`\\`); `CREATE STAGE` builds its SQL from the container's fields rather than `repr(container)`. Legal identifiers — including upper-case names that Snowflake folds — still render bare, so existing DDL is unchanged.
 
 # Release Notes
 

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -24,7 +24,13 @@ from sqlalchemy.sql.selectable import Lateral, SelectState
 
 from snowflake.sqlalchemy._constants import DIALECT_NAME
 from snowflake.sqlalchemy.compat import IS_VERSION_20, args_reducer, string_types
-from snowflake.sqlalchemy.custom_commands import CloudStorageLocation, ExternalStage
+from snowflake.sqlalchemy.custom_commands import (
+    AWSBucket,
+    AzureContainer,
+    CloudStorageLocation,
+    ExternalStage,
+    GCSBucket,
+)
 
 from ._constants import NOT_NULL
 from .exc import (
@@ -463,16 +469,78 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
 
         super().__init__(dialect, initial_quote=quote, escape_quote=quote)
 
+    def _safe_quote(self, ident):
+        """Quote ``ident`` per dialect rules, but never emit an unsafe value raw.
+
+        ``IdentifierPreparer.quote`` honours ``quoted_name(..., quote=False)``
+        by returning the value verbatim.  In an identifier/schema position that
+        is a quoting concern (SNOW-3649808): an application that wraps a
+        user-derived identifier in ``quote=False`` would splat it unquoted into
+        the compiled statement.  We override only that case — when quote=False
+        but the value is *structurally* unsafe — while leaving legal bare
+        identifiers (the documented quote=False idiom, including upper-case
+        ones Snowflake folds) untouched.
+        """
+        if getattr(ident, "quote", None) is False and self._is_unsafe_unquoted(ident):
+            return self.quote_identifier(ident)
+        return self.quote(ident)
+
+    def _is_unsafe_unquoted(self, value: str) -> bool:
+        """Return True if emitting ``value`` unquoted could alter SQL structure.
+
+        Mirrors :meth:`_requires_quotes` but omits the case-only clause: an
+        upper/mixed-case identifier is harmless emitted bare (Snowflake folds
+        it), whereas whitespace, quotes, dots, parentheses, semicolons, etc. are
+        what require quoting.  Used to neutralise risky values while still
+        preserving the historical bare rendering of legal identifiers.
+        """
+        if not value:
+            return False
+        lc_value = value.lower()
+        return (
+            lc_value in self.reserved_words
+            or lc_value in self.illegal_identifiers
+            or value[0] in self.illegal_initial_characters
+            or not self.legal_characters.match(str(value))
+        )
+
+    def quote_identifier_if_unsafe(self, value: str) -> str:
+        """Quote each dot-separated part of ``value`` only when it is unsafe.
+
+        Used for custom-command identifiers (stage name/namespace, format_name,
+        file_format) that historically render bare and must keep doing so for
+        legal identifiers — including upper-case ones — while neutralising any
+        part that contains SQL metacharacters (SNOW-3649881 / SNOW-3649858).
+        """
+        return ".".join(
+            self.quote_identifier(p) if self._is_unsafe_unquoted(p) else str(p)
+            for p in self._split_schema_by_dot(value)
+            if p is not None
+        )
+
     def _quote_free_identifiers(self, *ids):
         """
-        Unilaterally identifier-quote any number of strings.
+        Identifier-quote any number of strings, quoting whenever the value
+        requires it.  Unlike a bare ``quote()`` this refuses to emit an unsafe
+        ``quote=False`` identifier verbatim (see :meth:`_safe_quote`).
         """
-        return tuple(self.quote(i) for i in ids if i is not None)
+        return tuple(self._safe_quote(i) for i in ids if i is not None)
 
     def quote_schema(self, schema, force=None):
         """
         Split schema by a dot and merge with required quotes
         """
+        # SA 2.0 schema-translate tokens arrive as
+        # ``quoted_name("__[SCHEMA_<key>]", quote=False)``.  _safe_quote
+        # (used inside _quote_free_identifiers) overrides quote=False when
+        # the value contains unsafe characters — but the bracket characters
+        # in SA's internal token are safe as-is; quoting them
+        # destroys the token and breaks SA's post-compile substitution.
+        # Return the token string as-is so SA can resolve it normally.
+        if getattr(schema, "quote", None) is False and str(schema).startswith(
+            "__[SCHEMA_"
+        ):
+            return str(schema)
         idents = self._split_schema_by_dot(schema)
         return ".".join(self._quote_free_identifiers(*idents))
 
@@ -482,8 +550,14 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
 
         if not isinstance(n, quoted_name) or n.quote is None:
             return self.quote(s)
-
-        return self.quote_identifier(s) if n.quote else s
+        if n.quote:
+            return self.quote_identifier(s)
+        # n.quote is False: previously returned ``s`` verbatim, which let an
+        # application that wrapped a user-supplied alias in
+        # ``quoted_name(alias, quote=False)`` could emit arbitrary SQL into the
+        # projection list (SNOW-3649824).  _safe_quote encodes the rule:
+        # honour quote=False for legal bare identifiers, force-quote if unsafe.
+        return self._safe_quote(s)
 
     def _requires_quotes(self, value: str) -> bool:
         """Return True if the given identifier requires quoting."""
@@ -546,6 +620,68 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
         ]
 
 
+def _render_storage_credentials(credentials_used, deterministic: bool = False) -> str:
+    """Render a ``CREDENTIALS=(...)`` clause with escaped literal values.
+
+    Credential values (SAS tokens, secret keys, KMS ids, ...) are
+    caller-supplied and embedded in single-quoted literals, so each is escaped
+    to neutralise single-quote / backslash sequences (SNOW-3649816).  Keys come
+    from the closed set defined by the bucket helpers and are emitted as-is.
+    """
+    items = list(credentials_used.items())
+    if deterministic:
+        items.sort(key=operator.itemgetter(0))
+    return "CREDENTIALS=({})".format(
+        " ".join(f"{n}='{escape_string_literal_interior(str(v))}'" for n, v in items)
+    )
+
+
+def _render_storage_encryption(encryption_used, deterministic: bool = False) -> str:
+    """Render an ``ENCRYPTION=(...)`` clause with escaped literal values."""
+    items = list(encryption_used.items())
+    if deterministic:
+        items.sort(key=operator.itemgetter(0))
+    return "ENCRYPTION=({})".format(
+        " ".join(
+            (
+                f"{n}='{escape_string_literal_interior(str(v))}'"
+                if isinstance(v, string_types)
+                else f"{n}={v}"
+            )
+            for n, v in items
+        )
+    )
+
+
+def _render_storage_uri(container) -> str:
+    """Return the escaped, single-quoted storage location literal for a container.
+
+    The bucket/path/account components originate from caller-supplied URIs
+    (``*.from_uri``), so the assembled body is escaped before being wrapped in
+    quotes — a single-quote in any component would otherwise escape the
+    location literal (SNOW-3649816 / SNOW-3649858).
+    """
+    if isinstance(container, AWSBucket):
+        body = "s3://{}{}".format(
+            container.bucket, f"/{container.path}" if container.path else ""
+        )
+    elif isinstance(container, AzureContainer):
+        body = "azure://{}.blob.core.windows.net/{}{}".format(
+            container.account,
+            container.container,
+            f"/{container.path}" if container.path else "",
+        )
+    elif isinstance(container, GCSBucket):
+        body = "gcs://{}{}".format(
+            container.bucket, f"/{container.path}" if container.path else ""
+        )
+    else:
+        raise TypeError(
+            f"Unsupported cloud storage location: {type(container).__name__}"
+        )
+    return f"'{escape_string_literal_interior(body)}'"
+
+
 class SnowflakeCompiler(compiler.SQLCompiler):
     def visit_sequence(self, sequence, **kw):
         return self.dialect.identifier_preparer.format_sequence(sequence) + ".nextval"
@@ -583,7 +719,11 @@ class SnowflakeCompiler(compiler.SQLCompiler):
             return "WHEN NOT MATCHED{} THEN {} ({}) VALUES ({})".format(
                 case_predicate,
                 merge_into_clause.command,
-                ", ".join(sets),
+                # Column keys come straight from clause.values(**kwargs) with no
+                # resolution against the target table, so an application driving
+                # the column set from external input could emit unintended SQL here
+                # (SNOW-3649763).  Identifier-quote each key.
+                ", ".join(self.preparer.quote(s) for s in sets),
                 ", ".join(map(lambda e: e._compiler_dispatch(self, **kw), sets_tos)),
             )
         else:
@@ -593,7 +733,10 @@ class SnowflakeCompiler(compiler.SQLCompiler):
             sets = (
                 ", ".join(
                     [
-                        f"{set[0]} = {set[1]._compiler_dispatch(self, **kw)}"
+                        # Same untrusted-key source as the INSERT branch above
+                        # (SNOW-3649763); quote the assignment target.
+                        f"{self.preparer.quote(set[0])} = "
+                        f"{set[1]._compiler_dispatch(self, **kw)}"
                         for set in set_list
                     ]
                 )
@@ -673,7 +816,13 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         if kw.get("deterministic", False):
             options_list.sort(key=operator.itemgetter(0))
         if "format_name" in formatter.options:
-            return f"FILE_FORMAT=(format_name = {formatter.options['format_name']})"
+            # format_name is a (possibly schema-qualified) identifier supplied
+            # by the caller; quote any unsafe part so it cannot alter the COPY
+            # options / SQL while keeping normal names bare (SNOW-3649881).
+            format_name = self.preparer.quote_identifier_if_unsafe(
+                formatter.options["format_name"]
+            )
+            return f"FILE_FORMAT=(format_name = {format_name})"
         return "FILE_FORMAT=(TYPE={}{})".format(
             formatter.file_format,
             (
@@ -697,74 +846,51 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         )
 
     def visit_aws_bucket(self, aws_bucket, **kw):
-        credentials_list = list(aws_bucket.credentials_used.items())
-        if kw.get("deterministic", False):
-            credentials_list.sort(key=operator.itemgetter(0))
-        credentials = "CREDENTIALS=({})".format(
-            " ".join(f"{n}='{v}'" for n, v in credentials_list)
-        )
-        encryption_list = list(aws_bucket.encryption_used.items())
-        if kw.get("deterministic", False):
-            encryption_list.sort(key=operator.itemgetter(0))
-        encryption = "ENCRYPTION=({})".format(
-            " ".join(
-                ("{}='{}'" if isinstance(v, string_types) else "{}={}").format(n, v)
-                for n, v in encryption_list
-            )
-        )
-        uri = "'s3://{}{}'".format(
-            aws_bucket.bucket, f"/{aws_bucket.path}" if aws_bucket.path else ""
-        )
+        deterministic = kw.get("deterministic", False)
         return (
-            uri,
-            credentials if aws_bucket.credentials_used else "",
-            encryption if aws_bucket.encryption_used else "",
+            _render_storage_uri(aws_bucket),
+            (
+                _render_storage_credentials(aws_bucket.credentials_used, deterministic)
+                if aws_bucket.credentials_used
+                else ""
+            ),
+            (
+                _render_storage_encryption(aws_bucket.encryption_used, deterministic)
+                if aws_bucket.encryption_used
+                else ""
+            ),
         )
 
     def visit_azure_container(self, azure_container, **kw):
-        credentials_list = list(azure_container.credentials_used.items())
-        if kw.get("deterministic", False):
-            credentials_list.sort(key=operator.itemgetter(0))
-        credentials = "CREDENTIALS=({})".format(
-            " ".join(f"{n}='{v}'" for n, v in credentials_list)
-        )
-        encryption_list = list(azure_container.encryption_used.items())
-        if kw.get("deterministic", False):
-            encryption_list.sort(key=operator.itemgetter(0))
-        encryption = "ENCRYPTION=({})".format(
-            " ".join(
-                f"{n}='{v}'" if isinstance(v, string_types) else f"{n}={v}"
-                for n, v in encryption_list
-            )
-        )
-        uri = "'azure://{}.blob.core.windows.net/{}{}'".format(
-            azure_container.account,
-            azure_container.container,
-            f"/{azure_container.path}" if azure_container.path else "",
-        )
+        deterministic = kw.get("deterministic", False)
         return (
-            uri,
-            credentials if azure_container.credentials_used else "",
-            encryption if azure_container.encryption_used else "",
+            _render_storage_uri(azure_container),
+            (
+                _render_storage_credentials(
+                    azure_container.credentials_used, deterministic
+                )
+                if azure_container.credentials_used
+                else ""
+            ),
+            (
+                _render_storage_encryption(
+                    azure_container.encryption_used, deterministic
+                )
+                if azure_container.encryption_used
+                else ""
+            ),
         )
 
     def visit_gcs_bucket(self, gcs_bucket, **kw):
-        encryption_list = list(gcs_bucket.encryption_used.items())
-        if kw.get("deterministic", False):
-            encryption_list.sort(key=operator.itemgetter(0))
-        encryption = "ENCRYPTION=({})".format(
-            " ".join(
-                f"{n}='{v}'" if isinstance(v, string_types) else f"{n}={v}"
-                for n, v in encryption_list
-            )
-        )
-        uri = "'gcs://{}{}'".format(
-            gcs_bucket.bucket, f"/{gcs_bucket.path}" if gcs_bucket.path else ""
-        )
+        deterministic = kw.get("deterministic", False)
         return (
-            uri,
+            _render_storage_uri(gcs_bucket),
             "",
-            encryption if gcs_bucket.encryption_used else "",
+            (
+                _render_storage_encryption(gcs_bucket.encryption_used, deterministic)
+                if gcs_bucket.encryption_used
+                else ""
+            ),
         )
 
     def visit_external_stage(self, external_stage, **kw):
@@ -772,7 +898,16 @@ class SnowflakeCompiler(compiler.SQLCompiler):
             return (
                 f"@{external_stage.namespace}{external_stage.name}{external_stage.path}"
             )
-        return f"@{external_stage.namespace}{external_stage.name}{external_stage.path} (file_format => {external_stage.file_format})"
+        # file_format names a (possibly schema-qualified) file format object;
+        # quote any unsafe part so it cannot alter SQL in the stage
+        # reference (SNOW-3649881).
+        file_format = self.preparer.quote_identifier_if_unsafe(
+            external_stage.file_format
+        )
+        return (
+            f"@{external_stage.namespace}{external_stage.name}{external_stage.path}"
+            f" (file_format => {file_format})"
+        )
 
     def delete_extra_from_clause(
         self, delete_stmt, from_table, extra_froms, from_hints, **kw
@@ -1117,16 +1252,52 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
 
         return text
 
+    def _format_stage_prefix(self, stage) -> str:
+        """Identifier-quote a stage's ``<namespace>.<name>`` prefix.
+
+        ``ExternalStage.prepare_namespace`` stores the namespace with a trailing
+        dot (or ``""``), so ``f"{stage.namespace}{stage.name}"`` always yields a
+        clean dotted identifier (``"DB.SCH.S"`` or ``"S"``).
+        ``quote_identifier_if_unsafe`` splits on dots internally, so the combined
+        string can be passed directly — no manual strip/rejoin needed.
+        Legal identifiers stay bare (no BCR).  (SNOW-3649858)
+        """
+        return self.preparer.quote_identifier_if_unsafe(
+            f"{stage.namespace}{stage.name}"
+        )
+
     def visit_create_stage(self, create_stage, **kw):
         """
         This visitor will create the SQL representation for a CREATE STAGE command.
         """
-        return "CREATE {or_replace}{temporary}STAGE {}{} URL={}".format(
-            create_stage.stage.namespace,
-            create_stage.stage.name,
-            repr(create_stage.container),
+        # Render the storage URL/credentials/encryption through the shared,
+        # escaped helpers rather than repr(container): repr() is a debug
+        # representation (and is redacted separately to hide secrets),
+        # and using it as a SQL serialiser left single-quote escaping incomplete
+        # (SNOW-3649858).
+        container = create_stage.container
+        deterministic = kw.get("deterministic", False)
+        uri = _render_storage_uri(container)
+        credentials = (
+            _render_storage_credentials(container.credentials_used, deterministic)
+            if getattr(container, "credentials_used", None)
+            else ""
+        )
+        encryption = (
+            _render_storage_encryption(container.encryption_used, deterministic)
+            if getattr(container, "encryption_used", None)
+            else ""
+        )
+        storage = "URL={}{}{}".format(
+            uri,
+            f" {credentials}" if credentials else "",
+            f" {encryption}" if encryption else "",
+        )
+        return "CREATE {or_replace}{temporary}STAGE {prefix} {storage}".format(
             or_replace="OR REPLACE " if create_stage.replace_if_exists else "",
             temporary="TEMPORARY " if create_stage.temporary else "",
+            prefix=self._format_stage_prefix(create_stage.stage),
+            storage=storage,
         )
 
     def visit_create_file_format(self, file_format, **kw):
@@ -1136,7 +1307,9 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
         """
         return "CREATE {}FILE FORMAT {} TYPE='{}' {}".format(
             "OR REPLACE " if file_format.replace_if_exists else "",
-            file_format.format_name,
+            # format_name is a (possibly schema-qualified) identifier; quote any
+            # unsafe part to prevent unintended DDL (SNOW-3649881).
+            self.preparer.quote_identifier_if_unsafe(file_format.format_name),
             file_format.formatter.file_format,
             " ".join(
                 [

--- a/src/snowflake/sqlalchemy/custom_commands.py
+++ b/src/snowflake/sqlalchemy/custom_commands.py
@@ -12,6 +12,7 @@ from sqlalchemy.sql.elements import ClauseElement
 from sqlalchemy.sql.roles import FromClauseRole
 
 from .compat import string_types
+from .util import escape_string_literal_interior
 
 NoneType = type(None)
 
@@ -104,7 +105,14 @@ class FilesOption:
         self.file_names = file_names
 
     def __str__(self):
-        the_files = ["'" + f.replace("'", "\\'") + "'" for f in self.file_names]
+        # File names are frequently externally-influenced (uploads, object-store
+        # listings, webhook bodies).  Use the shared Snowflake literal escaping
+        # (doubles ' and \) instead of the old \' convention, which left a
+        # backslash-before-quote escaping under ESCAPE_STRING_LITERALS
+        # (SNOW-3649871).
+        the_files = [
+            "'" + escape_string_literal_interior(f) + "'" for f in self.file_names
+        ]
         return f"({','.join(the_files)})"
 
 

--- a/tests/test_base_quoting.py
+++ b/tests/test_base_quoting.py
@@ -1,0 +1,393 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+# Regression tests for SNOW-3656026 (base.py identifier and literal
+# quoting).  Anchored by SNOW-3649763 and bundling SNOW-3649858,
+# SNOW-3649881, SNOW-3649816, SNOW-3649808, SNOW-3649824.
+#
+# These are pure-compilation tests (no live connection): each builds a
+# construct and asserts on the SQL emitted by the Snowflake dialect.  Tests
+# named ``*_quoting`` / ``*_escaping`` encode the expected behaviour and are
+# expected to FAIL until the base.py fixes land (TDD red state).  Tests named
+# ``*_bcr`` / ``*_preserved`` lock down behaviour that must NOT change and are
+# expected to pass both before and after the fix.
+#
+# Companion to tests/test_table_option_quoting.py
+# (options compiler-threading) and tests/test_unit_escaping.py (util helpers).
+#
+import pytest
+from sqlalchemy import Boolean, Column, Integer, MetaData, Sequence, String, Table
+from sqlalchemy.sql import select
+from sqlalchemy.sql.elements import quoted_name
+
+from snowflake.sqlalchemy import (
+    AWSBucket,
+    AzureContainer,
+    CopyFormatter,
+    CopyIntoStorage,
+    CreateFileFormat,
+    CreateStage,
+    CSVFormatter,
+    ExternalStage,
+    GCSBucket,
+    MergeInto,
+)
+
+# A single literal backslash.  "\\" in source is one backslash at runtime.
+BS = "\\"
+
+
+def _merge_tables():
+    meta = MetaData()
+    users = Table(
+        "users",
+        meta,
+        Column("id", Integer, Sequence("user_id_seq"), primary_key=True),
+        Column("name", String),
+        Column("fullname", String),
+    )
+    staging = Table(
+        "staging_users",
+        meta,
+        Column("id", Integer, Sequence("staging_id_seq"), primary_key=True),
+        Column("name", String),
+        Column("fullname", String),
+        Column("delete", Boolean),
+    )
+    return users, staging
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649763 — MergeInto: unquoted column keys in WHEN NOT MATCHED
+#   THEN INSERT (...) and in WHEN MATCHED THEN UPDATE SET allow identifier
+#   quoting.  base.py:584 (INSERT column list) and base.py:594 (UPDATE SET).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "apply_op,value",
+    [
+        pytest.param(
+            lambda m, s, p: m.when_not_matched_then_insert().values(**{p: s.c.name}),
+            "name) -- x",
+            id="insert_column_key",
+        ),
+        pytest.param(
+            lambda m, s, p: m.when_matched_then_update().values(**{p: s.c.name}),
+            "name = 1 -- x",
+            id="update_set_key",
+        ),
+    ],
+)
+def test_snow_3656026_merge_key_quoting(sql_compiler, apply_op, value):
+    """Column keys must be identifier-quoted in both INSERT and UPDATE SET sinks."""
+    users, staging = _merge_tables()
+    merge = MergeInto(users, staging, users.c.id == staging.c.id)
+    apply_op(merge, staging, value)
+    sql = sql_compiler(merge)
+    assert f'"{value}"' in sql
+
+
+def test_snow_3656026_merge_plain_keys_bcr(sql_compiler):
+    """BCR: ordinary column keys stay bare (no regression vs. current output)."""
+    users, staging = _merge_tables()
+    merge = MergeInto(users, staging, users.c.id == staging.c.id)
+    merge.when_not_matched_then_insert().values(
+        id=staging.c.id, name=staging.c.name, fullname=staging.c.fullname
+    )
+    sql = sql_compiler(merge)
+    assert "INSERT (fullname, id, name) VALUES" in sql
+    assert '"name"' not in sql  # legal identifiers are not force-quoted
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649808 — quote_schema()/_quote_free_identifiers emit raw
+#   schema when an application passes quoted_name(<value>, quote=False).
+#   base.py:468.
+# ---------------------------------------------------------------------------
+
+
+def test_snow_3656026_quote_schema_quote_false_quoting(sql_compiler):
+    """A quote=False schema that is unsafe must still be quoted, not emitted raw."""
+    value = "PUB; -- x"
+    meta = MetaData()
+    table = Table(
+        "t",
+        meta,
+        Column("c", Integer),
+        schema=quoted_name(value, quote=False),
+    )
+    sql = sql_compiler(select(table))
+    # After fix: schema is wrapped as a single quoted identifier (inert),
+    # rather than splat verbatim into the FROM clause.
+    assert f'"{value}"' in sql
+    assert f"FROM {value}" not in sql
+
+
+def test_snow_3656026_quote_schema_dotted_value_is_split_not_raw(sql_compiler):
+    """A dotted quote=False value is parsed as db.schema, not parsed raw.
+
+    Deliberate non-goal: ``quoted_name("OTHER_DB.OTHER_SCHEMA", quote=False)`` is
+    split on the dot and each (legal) part is emitted bare, which is the correct
+    interpretation of a qualified schema — indistinguishable from a genuine
+    ``db.schema`` reference, so preventing cross-tenant *redirection* is an
+    application-level validation concern.  The fix only guarantees no SQL
+    *syntax* is emitted: the output stays a well-formed dotted identifier.
+    """
+    value = "OTHER_DB.OTHER_SCHEMA"
+    meta = MetaData()
+    table = Table(
+        "t",
+        meta,
+        Column("c", Integer),
+        schema=quoted_name(value, quote=False),
+    )
+    sql = sql_compiler(select(table))
+    assert "FROM OTHER_DB.OTHER_SCHEMA.t" in sql
+    assert ";" not in sql and "--" not in sql
+
+
+def test_snow_3656026_quote_schema_safe_value_bcr(sql_compiler):
+    """BCR: a legal bare schema with quote=False stays unquoted (documented idiom)."""
+    meta = MetaData()
+    table = Table(
+        "report",
+        meta,
+        Column("c", Integer),
+        schema=quoted_name("TENANT1", quote=False),
+    )
+    sql = sql_compiler(select(table))
+    assert "TENANT1.report" in sql
+    assert '"TENANT1"' not in sql
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649824 — format_label returns the raw label when it is a
+#   quoted_name with quote=False, enabling single-statement projection-list
+#   quoting.  base.py:484.
+# ---------------------------------------------------------------------------
+
+
+def test_snow_3656026_format_label_quote_false_quoting(sql_compiler):
+    """An unsafe quote=False column alias must be quoted, not emitted raw."""
+    value = "x, y -- z"
+    meta = MetaData()
+    table = Table("t", meta, Column("c", Integer))
+    sql = sql_compiler(select(table.c.c.label(quoted_name(value, quote=False))))
+    # After the fix the alias is a single quoted identifier, so a comma in the
+    # value cannot split it into multiple projection items.  Assert the unquoted
+    # comma form does not appear.
+    assert f'"{value}"' in sql
+    assert "AS x, y" not in sql
+
+
+def test_snow_3656026_format_label_safe_alias_bcr(sql_compiler):
+    """BCR: a legal bare alias with quote=False stays unquoted."""
+    meta = MetaData()
+    table = Table("t", meta, Column("c", Integer))
+    sql = sql_compiler(select(table.c.c.label(quoted_name("myalias", quote=False))))
+    assert "AS myalias" in sql
+    assert '"myalias"' not in sql
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649881 — format_name interpolated raw at three sinks:
+#   visit_copy_formatter (base.py:674), visit_create_file_format (base.py:1119),
+#   visit_external_stage (base.py:773).  format_name is a (possibly
+#   schema-qualified) identifier and must be routed through the preparer.
+# ---------------------------------------------------------------------------
+
+
+def test_snow_3656026_copy_formatter_format_name_quoting(sql_compiler):
+    """visit_copy_formatter: format_name must be identifier-quoted."""
+    value = "fmt) opt --"
+    meta = MetaData()
+    target = Table("t", meta, Column("c", Integer))
+    stage = ExternalStage(name="S", namespace="DB.SCH")
+    copy_into = CopyIntoStorage(
+        from_=stage, into=target, formatter=CopyFormatter(format_name=value)
+    )
+    sql = sql_compiler(copy_into)
+    assert f'"{value}"' in sql
+
+
+def test_snow_3656026_create_file_format_name_quoting(sql_compiler):
+    """visit_create_file_format: format_name must be identifier-quoted."""
+    value = "fmt TYPE='csv' -- x"
+    create_format = CreateFileFormat(
+        format_name=value, formatter=CSVFormatter().field_delimiter(",")
+    )
+    sql = sql_compiler(create_format)
+    assert f'"{value}"' in sql
+
+
+def test_snow_3656026_external_stage_file_format_quoting(sql_compiler):
+    """visit_external_stage: file_format must be identifier-quoted."""
+    value = "fmt) x --"
+    stage = ExternalStage(name="S", namespace="DB.SCH", file_format=value)
+    sql = sql_compiler(stage)
+    assert f'"{value}"' in sql
+
+
+def test_snow_3656026_format_name_qualified_bcr(sql_compiler):
+    """BCR: a legal (schema-qualified) format name stays bare."""
+    create_format = CreateFileFormat(
+        format_name="ML_POC.PUBLIC.CSV_FILE_FORMAT",
+        formatter=CSVFormatter().field_delimiter(","),
+    )
+    sql = sql_compiler(create_format)
+    assert "ML_POC.PUBLIC.CSV_FILE_FORMAT" in sql
+    assert '"ML_POC"' not in sql
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649816 — AWS/Azure/GCS bucket path & credential single-quote
+#   escaping in COPY INTO string literals.  base.py:702/707/713 (AWS),
+#   727/732/738 (Azure), 753/759 (GCS).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bucket_cls", [AWSBucket, GCSBucket], ids=["aws", "gcs"])
+def test_snow_3656026_bucket_path_quote_escaping(sql_compiler, bucket_cls):
+    """Bucket path: an embedded single-quote must be doubled (AWS and GCS)."""
+    meta = MetaData()
+    src = Table("t", meta, Column("c", Integer))
+    bucket = bucket_cls("corp-bucket", "x' STORAGE_INTEGRATION=other_int --")
+    copy_into = CopyIntoStorage(from_=src, into=bucket)
+    sql = sql_compiler(copy_into)
+    assert "x'' STORAGE_INTEGRATION=other_int --" in sql
+
+
+def test_snow_3656026_aws_bucket_credential_quote_escaping(sql_compiler):
+    """AWS CREDENTIALS value: an embedded single-quote must be doubled."""
+    meta = MetaData()
+    src = Table("t", meta, Column("c", Integer))
+    bucket = AWSBucket("corp-bucket", "p").credentials(aws_role="r' XX --")
+    copy_into = CopyIntoStorage(from_=src, into=bucket)
+    sql = sql_compiler(copy_into)
+    assert "AWS_ROLE='r'' XX --'" in sql
+
+
+def test_snow_3656026_aws_bucket_path_backslash_escaping(sql_compiler):
+    r"""AWS bucket path: a backslash before a quote (\') must be neutralised.
+
+    With ESCAPE_STRING_LITERALS=TRUE Snowflake reads \' as an escaped quote;
+    the fix doubles the backslash so it sees \\ then ''.
+    """
+    meta = MetaData()
+    src = Table("t", meta, Column("c", Integer))
+    bucket = AWSBucket("corp-bucket", "p" + BS + "' escaping --")
+    copy_into = CopyIntoStorage(from_=src, into=bucket)
+    sql = sql_compiler(copy_into)
+    # Python "\\\\'' escaping" represents the SQL text: \\'' escaping
+    assert "\\\\'' escaping --" in sql
+
+
+def test_snow_3656026_azure_sas_token_quote_escaping(sql_compiler):
+    """Azure SAS token: an embedded single-quote must be doubled."""
+    meta = MetaData()
+    src = Table("t", meta, Column("c", Integer))
+    container = AzureContainer("acct", "cont").credentials(
+        "?sv=2020' ) STORAGE_INTEGRATION=other_int --"
+    )
+    copy_into = CopyIntoStorage(from_=src, into=container)
+    sql = sql_compiler(copy_into)
+    assert "AZURE_SAS_TOKEN='?sv=2020'' ) STORAGE_INTEGRATION=other_int --'" in sql
+
+
+def test_snow_3656026_aws_bucket_plain_value_bcr(sql_compiler):
+    """BCR: a bucket path without special characters is emitted unchanged."""
+    meta = MetaData()
+    src = Table("t", meta, Column("c", Integer))
+    bucket = AWSBucket("backup", "subdir/path")
+    copy_into = CopyIntoStorage(from_=src, into=bucket)
+    sql = sql_compiler(copy_into)
+    assert "'s3://backup/subdir/path'" in sql
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649858 — CreateStage: stage namespace/name interpolated
+#   without identifier quoting and container rendered via repr() without
+#   single-quote escaping.  base.py:1104.
+# ---------------------------------------------------------------------------
+
+
+def test_snow_3656026_create_stage_name_quoting(sql_compiler):
+    """CreateStage: an unsafe stage name must be identifier-quoted."""
+    value = "S URL='s3://b/' -- x"
+    stage = ExternalStage(name=value, namespace="DB.SCH")
+    container = AzureContainer("acct", "cont").credentials("tok")
+    create_stage = CreateStage(stage=stage, container=container)
+    sql = sql_compiler(create_stage)
+    assert f'"{value}"' in sql
+
+
+def test_snow_3656026_create_stage_container_quote_escaping(sql_compiler):
+    """CreateStage: a single-quote in the container URL must be doubled.
+
+    visit_create_stage currently renders the URL via repr(container); the fix
+    must escape the literal regardless of how the URL is produced.
+    """
+    stage = ExternalStage(name="S", namespace="DB.SCH")
+    container = AzureContainer("acct", "cont", "p' -- x")
+    create_stage = CreateStage(stage=stage, container=container)
+    sql = sql_compiler(create_stage)
+    assert "p'' -- x" in sql
+
+
+def test_snow_3656026_create_stage_plain_bcr(sql_compiler):
+    """BCR: a well-formed CreateStage compiles exactly as it does today."""
+    stage = ExternalStage(name="AZURE_STAGE", namespace="MY_DB.MY_SCHEMA")
+    container = AzureContainer("myaccount", "my-container").credentials("saas_token")
+    create_stage = CreateStage(stage=stage, container=container)
+    sql = sql_compiler(create_stage)
+    expected = (
+        "CREATE STAGE MY_DB.MY_SCHEMA.AZURE_STAGE "
+        "URL='azure://myaccount.blob.core.windows.net/my-container' "
+        "CREDENTIALS=(AZURE_SAS_TOKEN='saas_token')"
+    )
+    assert sql == expected
+
+
+# ---------------------------------------------------------------------------
+# SNOW-3649871 — FilesOption.__str__ used \' escaping (no
+#   backslash doubling), allowing a backslash-before-quote escaping from
+#   FILES=('...').  custom_commands.py:106.
+# ---------------------------------------------------------------------------
+
+
+def _copy_with_files(file_names):
+    meta = MetaData()
+    src = Table("t", meta, Column("c", Integer))
+    bucket = AWSBucket("backup")
+    copy_into = CopyIntoStorage(from_=src, into=bucket)
+    copy_into.files(file_names)
+    return copy_into
+
+
+def test_snow_3656026_files_single_quote_quoting(sql_compiler):
+    """FILES: an embedded single-quote must be doubled, not backslash-escaped."""
+    copy_into = _copy_with_files(["x') PURGE = TRUE FORCE = TRUE --"])
+    sql = sql_compiler(copy_into)
+    assert "'x'') PURGE = TRUE FORCE = TRUE --'" in sql
+    assert "\\'" not in sql  # old \' convention must be gone
+
+
+def test_snow_3656026_files_backslash_escaping(sql_compiler):
+    r"""FILES: a backslash before a quote (\') must be neutralised.
+
+    Old output for ``x\') ... `` was ``'x\\') ...'`` — Snowflake reads ``\\`` as
+    one literal backslash, leaving ``'`` to terminate the literal early.  The
+    fix doubles both: ``\`` -> ``\\`` and ``'`` -> ``''``.
+    """
+    copy_into = _copy_with_files(["x" + BS + "') PURGE = TRUE --"])
+    sql = sql_compiler(copy_into)
+    # Python "x\\\\'') ..." represents the SQL text: x\\'') ...
+    assert "'x\\\\'') PURGE = TRUE --'" in sql
+
+
+def test_snow_3656026_files_plain_value_bcr(sql_compiler):
+    """BCR: ordinary file names are emitted unchanged inside FILES=(...)."""
+    copy_into = _copy_with_files(["data1.csv", "data2.csv"])
+    sql = sql_compiler(copy_into)
+    assert "FILES = ('data1.csv','data2.csv')" in sql


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-3656026

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

**Improve identifier quoting and literal escaping in the DDL compiler**

Renders caller-supplied identifiers and string literals consistently with the rest of the dialect.

- Column keys in `MERGE INTO` (both the `WHEN NOT MATCHED … INSERT` list and the
  `WHEN MATCHED … SET` targets), stage namespaces/names, `format_name`, and `file_format` are
  now routed through the identifier preparer.
- A `quote=False` schema or column label is quoted when it contains characters that would
  otherwise require quoting, instead of being emitted verbatim.
- Cloud-storage URIs, `CREDENTIALS`, and `ENCRYPTION` clauses (shared by `COPY INTO` and
  `CREATE STAGE`) and `FILES=(…)` entries now apply the dialect's standard literal escaping
  (`'` → `''`, `\` → `\\`). `CREATE STAGE` builds its SQL from the container's fields rather
  than `repr(container)`.
- Legal identifiers — including upper-case names that Snowflake folds — still render bare, so
  existing DDL is unchanged.

**Touches:** `base.py`, `custom_commands.py`, `DESCRIPTION.md`, tests.