### PR TITLE
Reflection name handling improvements

### DIFF
--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -583,6 +583,8 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
                     ret.append((schema[pre_idx:idx], False))
                     pre_idx = idx + 1
                 elif schema[idx] == '"':
+                    if pre_idx < idx:
+                        ret.append((schema[pre_idx:idx], False))
                     in_quote = True
                     pre_idx = idx + 1
             else:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -434,9 +434,7 @@ class SnowflakeDialect(default.DefaultDialect):
         return self._has_object(connection, "SEQUENCE", sequence_name, schema)
 
     def _has_object(self, connection, object_type, object_name, schema=None):
-        full_name = self._denormalize_quote_join(
-            self.denormalize_name(schema), self.denormalize_name(object_name)
-        )
+        full_name = self._qualify_object_name(object_name, schema)
         try:
             results = connection.execute(
                 text(f"DESC {object_type} /* sqlalchemy:_has_object */ {full_name}")
@@ -471,6 +469,16 @@ class SnowflakeDialect(default.DefaultDialect):
         compatibility with callers inside this class.
         """
         return self.name_utils.always_quote_join(*idents)
+
+    def _qualify_object_name(self, object_name, schema=None):
+        """Return schema.object fully quoted, treating object_name as a single atomic identifier."""
+        ip = self.identifier_preparer
+        parts = []
+        if schema is not None:
+            schema_parts = ip._split_schema_by_dot(self.denormalize_name(schema))
+            parts.extend(ip._quote_free_identifiers(*schema_parts))
+        parts.append(ip._safe_quote(self.denormalize_name(object_name)))
+        return ".".join(parts)
 
     def _get_full_schema_name(self, connection, schema=None, **kw):
         """
@@ -1434,14 +1442,11 @@ class SnowflakeDialect(default.DefaultDialect):
             IS_VERSION_20 or self._is_single_table_reflection(schema, **kw)
         ) and table_name:
             single_table_name = table_name
-            if "." in str(table_name):
-                # table_name may arrive as "schema.table" or even
-                # "database.schema.table" when callers pass a qualified
-                # name.  Take the last component so _always_quote_join
-                # does not double-qualify the identifier.
+            if "." in str(table_name) and not getattr(table_name, "quote", False):
+                # Strip any schema prefix — _qualify_object_name adds it from `schema`.
                 parts = self.identifier_preparer._split_schema_by_dot(str(table_name))
                 single_table_name = str(parts[-1])
-            full_table_name = self._always_quote_join(schema, single_table_name)
+            full_table_name = self._qualify_object_name(single_table_name, schema)
             column_info_manager = _StructuredTypeInfoManager(
                 connection, self.name_utils, self.default_schema_name
             )

--- a/tests/test_unit_case_sensitivity.py
+++ b/tests/test_unit_case_sensitivity.py
@@ -366,6 +366,65 @@ class TestNormalizeName:
                 assert str(result) == upper.lower()
 
 
+class TestSplitSchemaByDotPrefixDrop:
+    """Regression tests for the prefix-drop bug: unquoted prefix before a quoted segment."""
+
+    @pytest.fixture
+    def ip(self):
+        return SnowflakeDialect().identifier_preparer
+
+    @pytest.mark.parametrize(
+        "schema_str, expected_parts",
+        [
+            ('prefix"QUOTED"', ["prefix", "QUOTED"]),
+            ('tenantA_"TENANT_B"', ["tenantA_", "TENANT_B"]),
+            ('"myschema"', ["myschema"]),
+            ("mydb.myschema", ["mydb", "myschema"]),
+            ('a"B"', ["a", "B"]),
+        ],
+    )
+    def test_split_parts(self, ip, schema_str, expected_parts):
+        parts = ip._split_schema_by_dot(schema_str)
+        assert [str(p) for p in parts] == expected_parts
+
+
+class TestQualifyObjectName:
+    """_qualify_object_name must treat object_name atomically, never re-splitting on dots."""
+
+    @pytest.fixture
+    def dialect(self):
+        d = SnowflakeDialect()
+        d.default_schema_name = "PUBLIC"
+        return d
+
+    def _count_parts(self, qualified: str) -> int:
+        parts = 0
+        in_quote = False
+        for ch in qualified:
+            if ch == '"':
+                in_quote = not in_quote
+            elif ch == "." and not in_quote:
+                parts += 1
+        return parts + 1 if qualified else 0
+
+    @pytest.mark.parametrize(
+        "object_name, schema, expected_parts",
+        [
+            ("my_table", None, 1),
+            ("my_table", "PUBLIC", 2),
+            ("other.table", "PUBLIC", 2),
+            ("my_table", "OTHER_DB.OTHER_SCHEMA", 3),
+            ("OTHER_DB.OTHER_SCHEMA.SECRETS", None, 1),
+        ],
+    )
+    def test_part_count(self, dialect, object_name, schema, expected_parts):
+        result = dialect._qualify_object_name(object_name, schema=schema)
+        assert self._count_parts(result) == expected_parts, f"got {result!r}"
+
+    def test_no_schema_exact_output(self, dialect):
+        assert dialect._qualify_object_name("my_table") == '"MY_TABLE"'
+
+
 # ---------------------------------------------------------------------------
 # _has_object denormalizes object_name before building SQL
 # ---------------------------------------------------------------------------
@@ -383,53 +442,24 @@ class TestHasObjectNormalization:
         conn.execute.return_value = result_mock
         return d, conn
 
-    def test_plain_lowercase_generates_quoted_uppercase(self):
-        """_has_object('mytable') should generate DESC TABLE \"MYTABLE\" (quoted uppercase)."""
+    @pytest.mark.parametrize(
+        "object_name, schema, expected_fragments",
+        [
+            ("mytable", None, ['"MYTABLE"']),
+            (quoted_name("mytable", True), None, ['"mytable"']),
+            ("MyTable", None, ['"MyTable"']),
+            ("mytable", "myschema", ['"MYTABLE"', '"MYSCHEMA"']),
+        ],
+        ids=["lowercase", "quoted_name", "mixed_case", "with_schema"],
+    )
+    def test_desc_sql_fragments(self, object_name, schema, expected_fragments):
         d, conn = self._dialect_with_mock_connection()
-        d._has_object(conn, "TABLE", "mytable")
-        call_args = conn.execute.call_args
-        sql_text = str(call_args[0][0])
-        # denormalize_name('mytable') -> 'MYTABLE'
-        # _denormalize_quote_join('MYTABLE') -> '"MYTABLE"'
-        assert (
-            '"MYTABLE"' in sql_text
-        ), f"Expected '\"MYTABLE\"' in DESC SQL, got: {sql_text!r}"
-
-    def test_quoted_name_generates_quoted_lowercase(self):
-        """_has_object(quoted_name('mytable', True)) should generate DESC TABLE \"mytable\"."""
-        d, conn = self._dialect_with_mock_connection()
-        d._has_object(conn, "TABLE", quoted_name("mytable", True))
-        call_args = conn.execute.call_args
-        sql_text = str(call_args[0][0])
-        assert (
-            '"mytable"' in sql_text
-        ), f"Expected '\"mytable\"' in DESC SQL, got: {sql_text!r}"
-
-    def test_mixed_case_generates_quoted_mixed(self):
-        """_has_object('MyTable') should generate DESC TABLE \"MyTable\" (case-sensitive)."""
-        d, conn = self._dialect_with_mock_connection()
-        d._has_object(conn, "TABLE", "MyTable")
-        call_args = conn.execute.call_args
-        sql_text = str(call_args[0][0])
-        # denormalize_name('MyTable') -> 'MyTable' (mixed case passes through)
-        # _denormalize_quote_join('MyTable') -> '"MyTable"' (quoted because mixed case)
-        assert (
-            '"MyTable"' in sql_text
-        ), f"Expected '\"MyTable\"' in DESC SQL, got: {sql_text!r}"
-
-    def test_with_schema_plain_lowercase(self):
-        """_has_object with schema denormalizes both schema and object_name."""
-        d, conn = self._dialect_with_mock_connection()
-        d._has_object(conn, "TABLE", "mytable", schema="myschema")
-        call_args = conn.execute.call_args
-        sql_text = str(call_args[0][0])
-        # Both schema and object_name are denormalized: lowercase → UPPERCASE then quoted.
-        assert (
-            '"MYTABLE"' in sql_text
-        ), f"Expected '\"MYTABLE\"' in DESC SQL, got: {sql_text!r}"
-        assert (
-            '"MYSCHEMA"' in sql_text
-        ), f"Expected '\"MYSCHEMA\"' in DESC SQL, got: {sql_text!r}"
+        d._has_object(conn, "TABLE", object_name, schema=schema)
+        sql_text = str(conn.execute.call_args[0][0])
+        for fragment in expected_fragments:
+            assert (
+                fragment in sql_text
+            ), f"Expected {fragment!r} in DESC SQL, got: {sql_text!r}"
 
     def test_programming_error_returns_false(self):
         """_has_object returns False when DESC raises ProgrammingError."""

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -6,8 +6,10 @@ from unittest import mock
 
 import pytest
 from sqlalchemy.engine.url import URL
+from sqlalchemy.sql.elements import quoted_name
 
 from snowflake.sqlalchemy import base
+from snowflake.sqlalchemy import snowdialect as sd_module
 from snowflake.sqlalchemy.compat import IS_VERSION_20
 from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 
@@ -362,3 +364,61 @@ class TestSingleTableDispatchSA2:
         # uppercase it correctly inside _always_quote_join.
         assert received["table_name"] == "my_table"
         assert type(received["table_name"]) is str
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_columns_quoted_name_with_embedded_dot_is_atomic(self):
+        """quoted_name with embedded dot must not be re-split into extra schema parts."""
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        received = {}
+
+        with mock.patch.object(sd_module, "_StructuredTypeInfoManager") as MockMgr:
+            mock_instance = mock.Mock()
+            mock_instance.get_table_columns_by_full_name.return_value = {}
+            MockMgr.return_value = mock_instance
+
+            dialect.get_columns(
+                connection,
+                quoted_name("weird.name", True),
+                schema="PUBLIC",
+            )
+
+            call_args = mock_instance.get_table_columns_by_full_name.call_args
+            received["full"] = call_args[0][0]
+
+        full = received["full"]
+        in_quote, parts = False, 0
+        for ch in full:
+            if ch == '"':
+                in_quote = not in_quote
+            elif ch == "." and not in_quote:
+                parts += 1
+        assert (
+            parts == 1
+        ), f"Expected 2-part reference (schema.table), got {parts + 1} parts: {full!r}"
+        assert (
+            '"weird.name"' in full
+        ), f"Expected quoted atomic identifier '\"weird.name\"' in {full!r}"
+
+    @pytest.mark.skipif(not IS_VERSION_20, reason="SA 2.x only")
+    def test_get_columns_dotted_plain_string_uses_last_component(self):
+        """A plain 'schema.table' string takes the last component as the table name."""
+        dialect = _make_dialect()
+        connection = mock.Mock()
+        received = {}
+
+        with mock.patch.object(sd_module, "_StructuredTypeInfoManager") as MockMgr:
+            mock_instance = mock.Mock()
+            mock_instance.get_table_columns_by_full_name.return_value = {}
+            MockMgr.return_value = mock_instance
+
+            dialect.get_columns(connection, "myschema.mytable", schema="PUBLIC")
+
+            call_args = mock_instance.get_table_columns_by_full_name.call_args
+            received["full"] = call_args[0][0]
+
+        full = received["full"]
+        assert '"MYTABLE"' in full, f"Expected last component 'MYTABLE' in {full!r}"
+        assert (
+            '"MYSCHEMA"' not in full
+        ), f"Schema component from table_name must be dropped; got {full!r}"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Improve reflection name handling**

Refines how identifiers are normalized and quoted during reflection, and tightens
case-sensitivity handling.

- Reflected identifier name handling in `base.py` / `snowdialect.py` is made consistent with the
  dialect's quoting rules.
- Expands unit coverage for case-sensitivity and core reflection behaviour
  (`tests/test_unit_case_sensitivity.py`, `tests/test_unit_core.py`).

**Touches:** `base.py`, `snowdialect.py`, tests.

