### PR TITLE
Fix view show like single quote escaping

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,6 +20,7 @@ Source code is also available at:
   - `FILE_FORMAT` option string values (e.g. `CSVFormatter().date_format(...)`, `file_extension`, `timestamp_format`) are now escaped before being embedded in the compiled SQL, improving single-quote escaping (SNOW-3649888).
   - `repr()` of `AWSBucket`, `AzureContainer`, `GCSBucket` (and, transitively, `CopyIntoStorage`) now masks cloud secrets — `AWS_SECRET_KEY`, `AWS_KEY_ID`, `AWS_TOKEN`, `AZURE_SAS_TOKEN`, `MASTER_KEY` are rendered as `'***'` (SNOW-3649782). Compiled SQL is unchanged.
   - Added an opt-in logging redactor for engine logs that contain inline credentials: `SnowflakeSecretRedactionFilter`, `add_secret_redaction_filter()`, and `redact_secrets()`. Prefer `STORAGE_INTEGRATION` to avoid putting secrets in SQL at all (SNOW-3649850).
+- Fix `get_view_definition` silently truncating or failing for view names that contain a single quote or backslash (e.g. `o'brien`). The name is now SQL-escaped (`'` → `''`, `\` → `\\`) before being embedded in the `SHOW VIEWS LIKE '...'` literal, so such views are found correctly and no query manipulation is possible via a crafted view name.
 
 # Release Notes
 

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -56,6 +56,7 @@ from .sql.custom_schema.custom_table_prefix import CustomTablePrefix
 from .util import (
     _legacy_url_params_enabled,
     _update_connection_application_name,
+    escape_string_literal_interior,
     parse_url_boolean,
     parse_url_integer,
 )
@@ -1573,18 +1574,21 @@ class SnowflakeDialect(default.DefaultDialect):
         Gets the view definition
         """
         schema = schema or self.default_schema_name
+        # denormalize_name gives the stored form without identifier quoting;
+        # escape_string_literal_interior then doubles ' and \ for the LIKE string literal.
+        like_value = escape_string_literal_interior(self.denormalize_name(view_name))
         if schema:
             cursor = connection.execute(
                 text(
-                    f"SHOW /* sqlalchemy:get_view_definition */ VIEWS \
-                    LIKE '{self._denormalize_quote_join(view_name)}' IN {self._denormalize_quote_join(schema)}"
+                    f"SHOW /* sqlalchemy:get_view_definition */ VIEWS "
+                    f"LIKE '{like_value}' IN {self._denormalize_quote_join(schema)}"
                 )
             )
         else:
             cursor = connection.execute(
                 text(
-                    f"SHOW /* sqlalchemy:get_view_definition */ VIEWS \
-                    LIKE '{self._denormalize_quote_join(view_name)}'"
+                    f"SHOW /* sqlalchemy:get_view_definition */ VIEWS "
+                    f"LIKE '{like_value}'"
                 )
             )
 
@@ -1593,7 +1597,7 @@ class SnowflakeDialect(default.DefaultDialect):
             ret = cursor.fetchone()
             if ret:
                 return ret[name_to_index_map["text"]]
-        except Exception:
+        except (sa_exc.DBAPIError, sf_errors.ProgrammingError):
             pass
         return None
 

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -422,3 +422,49 @@ class TestSingleTableDispatchSA2:
         assert (
             '"MYSCHEMA"' not in full
         ), f"Schema component from table_name must be dropped; got {full!r}"
+
+
+def _capture_view_sql(dialect, view_name, schema="PUBLIC"):
+    """Call get_view_definition and return the SQL string passed to execute()."""
+    conn = mock.MagicMock()
+    cursor = mock.MagicMock()
+    cursor.keys.return_value = []
+    cursor.fetchone.return_value = None
+    conn.execute.return_value = cursor
+    try:
+        dialect.get_view_definition(conn, view_name, schema=schema)
+    except Exception:
+        pass
+    assert conn.execute.called
+    sql_arg = conn.execute.call_args[0][0]
+    return sql_arg.text if hasattr(sql_arg, "text") else str(sql_arg)
+
+
+class TestGetViewDefinitionLikeEscaping:
+    """get_view_definition must escape single quotes in the LIKE value."""
+
+    def test_plain_view_name_produces_valid_sql(self):
+        """A normal view name must appear correctly in the LIKE clause."""
+        d = _make_dialect()
+        sql = _capture_view_sql(d, "my_view")
+        assert "LIKE" in sql
+        assert "MY_VIEW" in sql or "my_view" in sql
+
+    @pytest.mark.parametrize(
+        "view_name, expected, not_expected",
+        [
+            pytest.param("o'brien", ["''"], ['"o'], id="simple_quote"),
+            pytest.param("a' b --", ["''"], [], id="quote_and_comment"),
+            pytest.param("back\\slash", ["\\\\"], [], id="backslash_doubled"),
+        ],
+    )
+    def test_special_chars_are_escaped(self, view_name, expected, not_expected):
+        sql = _capture_view_sql(_make_dialect(), view_name)
+        for fragment in expected:
+            assert (
+                fragment in sql
+            ), f"Expected {fragment!r} in SQL for {view_name!r}, got: {sql!r}"
+        for fragment in not_expected:
+            assert (
+                fragment not in sql
+            ), f"Unexpected {fragment!r} in SQL for {view_name!r}, got: {sql!r}"


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NO-SNOW

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

**Fix view-name escaping in `get_view_definition`**

- Fixes `get_view_definition` silently truncating or failing for view names that contain a
  single quote or backslash (e.g. `o'brien`). The name is now escaped (`'` → `''`, `\` → `\\`)
  before being embedded in the `SHOW VIEWS LIKE '...'` literal, so such views are found
  correctly and the name is always treated as data.

**Touches:** `snowdialect.py`, `DESCRIPTION.md`, `tests/test_unit_core.py`.

