### PR TITLE
Fix object type handling and repr object representation

### DIFF
--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -1424,8 +1424,14 @@ class SnowflakeTypeCompiler(compiler.GenericTypeCompiler):
             return "OBJECT"
         else:
             contents = []
+            ip = self.dialect.identifier_preparer
             for key in type_.items_types:
-                row_text = f"{key} {type_.items_types[key][0].compile()}"
+                if len(key) >= 2 and key[0] == '"' and key[-1] == '"':
+                    inner = key[1:-1].replace('""', '"')
+                else:
+                    inner = key
+                quoted_key = ip.quote(inner)
+                row_text = f"{quoted_key} {type_.items_types[key][0].compile()}"
                 # Type and not null is specified
                 if len(type_.items_types[key]) > 1:
                     row_text += f"{' NOT NULL' if type_.items_types[key][1] else ''}"

--- a/src/snowflake/sqlalchemy/custom_types.py
+++ b/src/snowflake/sqlalchemy/custom_types.py
@@ -146,10 +146,10 @@ class OBJECT(StructuredType):
         super().__init__()
 
     def __repr__(self):
-        quote_char = "'"
+        dq = '"'
         return "OBJECT(%s)" % ", ".join(
             [
-                f"{repr(key).strip(quote_char)}={repr(value)}"
+                f"{key.strip(dq)}={repr(value)}"
                 for key, value in self.items_types.items()
             ]
         )

--- a/src/snowflake/sqlalchemy/parser/custom_type_parser.py
+++ b/src/snowflake/sqlalchemy/parser/custom_type_parser.py
@@ -108,14 +108,17 @@ def tokenize_parameters(text: str, character_for_strip=",") -> list:
     output_parameters = []
     parameter = ""
     open_parenthesis = 0
+    in_double_quote = False
     for c in text:
+        if c == '"':
+            in_double_quote = not in_double_quote
 
         if c == "(":
             open_parenthesis += 1
         elif c == ")":
             open_parenthesis -= 1
 
-        if open_parenthesis > 0 or c != character_for_strip:
+        if open_parenthesis > 0 or in_double_quote or c != character_for_strip:
             parameter += c
         elif c == character_for_strip:
             output_parameters.append(parameter.strip(" "))

--- a/tests/test_unit_structured_types.py
+++ b/tests/test_unit_structured_types.py
@@ -1,11 +1,13 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
+import ast
+
 import pytest
-from sqlalchemy.sql.sqltypes import Float, Integer, Text
+from sqlalchemy.sql.sqltypes import VARCHAR, Float, Integer, Text
 
 from snowflake.sqlalchemy import NUMBER
-from snowflake.sqlalchemy.custom_types import MAP, TEXT, VECTOR
+from snowflake.sqlalchemy.custom_types import MAP, OBJECT, TEXT, VECTOR
 from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 from src.snowflake.sqlalchemy.parser.custom_type_parser import (
     ischema_names,
@@ -160,3 +162,121 @@ def test_resolve_column_type_uuid_produces_string_uuid():
     )
     assert isinstance(col_type, UUID)
     assert col_type.as_uuid is False
+
+
+class TestTokenizeParametersQuoteAware:
+    """tokenize_parameters must not split on delimiters inside double-quoted identifiers."""
+
+    @pytest.mark.parametrize(
+        "input_str, delimiter, expected",
+        [
+            pytest.param(
+                '"foo,bar" TEXT', ",", ['"foo,bar" TEXT'], id="comma_in_quotes"
+            ),
+            pytest.param(
+                '"field1" TEXT,"field2" NUMBER',
+                ",",
+                ['"field1" TEXT', '"field2" NUMBER'],
+                id="comma_outside_quotes",
+            ),
+            pytest.param("a, b, c", ",", ["a", "b", "c"], id="plain_tokens"),
+        ],
+    )
+    def test_tokenize(self, input_str, delimiter, expected):
+        assert tokenize_parameters(input_str, delimiter) == expected
+
+
+class TestObjectTypeParsing:
+    """parse_type correctly handles OBJECT fields with special characters in names."""
+
+    def test_object_with_comma_in_field_name_parses_cleanly(self):
+        """OBJECT("foo,bar" TEXT) must yield exactly one field with the full name."""
+        obj = parse_type('OBJECT("foo,bar" TEXT)')
+        assert (
+            len(obj.items_types) == 1
+        ), f"Expected 1 field, got {list(obj.items_types.keys())!r}"
+        assert (
+            '"foo,bar"' in obj.items_types
+        ), f"Expected key '\"foo,bar\"', got {list(obj.items_types.keys())!r}"
+
+    def test_object_with_normal_fields_parses_correctly(self):
+        """Baseline: OBJECT with normal field names still parses correctly."""
+        obj = parse_type("OBJECT(name TEXT, age NUMBER)")
+        assert set(obj.items_types.keys()) == {"name", "age"}
+
+
+class TestVisitObjectKeyQuoting:
+    """visit_OBJECT must wrap every key in double-quotes in the DDL output."""
+
+    def _type_compiler(self):
+        return SnowflakeDialect().type_compiler
+
+    def test_special_char_in_key_is_quoted(self):
+        """A key with ')' must be surrounded by double-quotes in DDL output."""
+        obj = OBJECT(normal_field=VARCHAR(10))
+        obj.items_types = {"field)injected": (VARCHAR(10), False)}
+        result = self._type_compiler().process(obj)
+        assert (
+            '"field)injected"' in result
+        ), f"Expected quoted key in DDL, got {result!r}"
+
+    def test_already_quoted_key_is_not_double_quoted(self):
+        """A key already stored with double-quotes (from parse_type) must not be re-quoted."""
+        obj = parse_type('OBJECT("WeirdField" TEXT)')
+        result = self._type_compiler().process(obj)
+        assert '"WeirdField"' in result
+        assert '""WeirdField""' not in result, f"Key was double-quoted: {result!r}"
+
+    def test_normal_key_is_preserved(self):
+        """A plain identifier key must appear in DDL (quoted only if required by dialect rules)."""
+        obj = OBJECT(my_field=VARCHAR(10))
+        result = self._type_compiler().process(obj)
+        assert (
+            "my_field" in result
+        ), f"Expected key 'my_field' in DDL output, got {result!r}"
+
+    def test_fake_quoted_key_is_re_quoted(self):
+        """A key that starts and ends with '"' but contains structure must be re-quoted, not passed verbatim."""
+        obj = OBJECT()
+        # Simulate a key that the old startswith/endswith guard let through verbatim
+        obj.items_types = {'"a"."b"': (VARCHAR(10), False)}
+        result = self._type_compiler().process(obj)
+        # The dot and the inner quotes must not appear unescaped in the output
+        assert (
+            '"a"."b"' not in result
+        ), f"Value was emitted verbatim in DDL: {result!r}"
+
+
+class TestObjectRepr:
+    """OBJECT.__repr__ must produce valid Python for all field name forms."""
+
+    @staticmethod
+    def _try_parse_python(source: str):
+        try:
+            ast.parse(source)
+            return True, None
+        except SyntaxError as exc:
+            return False, str(exc)
+
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            pytest.param(OBJECT(my_field=VARCHAR(10)), id="plain_field"),
+            pytest.param(
+                parse_type('OBJECT("WeirdField" VARCHAR(10))'), id="double_quoted_field"
+            ),
+        ],
+    )
+    def test_repr_is_valid_python(self, obj):
+        ok, err = self._try_parse_python(repr(obj))
+        assert ok, f"repr is not valid Python: {err}\n  repr: {repr(obj)!r}"
+
+    def test_double_quoted_field_name_stripped_in_repr(self):
+        """The surrounding double-quotes are stripped so the kwarg is a valid identifier."""
+        obj = parse_type('OBJECT("WeirdField" VARCHAR(10))')
+        assert "WeirdField=" in repr(
+            obj
+        ), f"Expected 'WeirdField=' in repr, got: {repr(obj)!r}"
+        assert '"WeirdField"=' not in repr(
+            obj
+        ), f"Double-quotes must be stripped from repr kwarg: {repr(obj)!r}"


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NO-SNOW

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

**Fix OBJECT type key handling and repr rendering**

- Fixes `OBJECT` structured-type field-key rendering: a key that looks pre-quoted but contains
  additional structure is now re-quoted rather than passed through verbatim, so the emitted DDL
  is always well-formed.
- Ensures `OBJECT.__repr__` produces valid Python for all field-name forms.

**Touches:** `base.py`, `custom_types.py`, `parser/custom_type_parser.py`,
`tests/test_unit_structured_types.py`.

