### PR TITLE
Post-refactor cleanup: name utilities, quoting internals, and identif…

### DIFF
--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -7,6 +7,7 @@ import operator
 import re
 import string
 import warnings
+from functools import reduce
 from typing import Any, List
 
 from sqlalchemy import exc as sa_exc
@@ -48,6 +49,8 @@ from .util import (
     _Snowflake_Selectable_Join,
     escape_backslashes,
     escape_string_literal_interior,
+    requires_quotes,
+    split_identifier_parts,
 )
 
 RESERVED_WORDS = frozenset(
@@ -485,6 +488,20 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
             return self.quote_identifier(ident)
         return self.quote(ident)
 
+    @property
+    def _identifier_cfg(self) -> dict:
+        """Config bundle passed to the pure identifier predicates in util.py.
+
+        Bundles the dialect-specific data the predicates need (reserved words,
+        illegal-identifier sets, legal-character regex) so call sites stay terse.
+        """
+        return {
+            "reserved_words": self.reserved_words,
+            "illegal_identifiers": self.illegal_identifiers,
+            "illegal_initial_characters": self.illegal_initial_characters,
+            "legal_characters": self.legal_characters,
+        }
+
     def _is_unsafe_unquoted(self, value: str) -> bool:
         """Return True if emitting ``value`` unquoted could alter SQL structure.
 
@@ -493,16 +510,11 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
         it), whereas whitespace, quotes, dots, parentheses, semicolons, etc. are
         what require quoting.  Used to neutralise risky values while still
         preserving the historical bare rendering of legal identifiers.
+
+        Structural-only form of ``util.requires_quotes`` (``include_case=False``);
+        the dialect config is supplied via ``_identifier_cfg``.
         """
-        if not value:
-            return False
-        lc_value = value.lower()
-        return (
-            lc_value in self.reserved_words
-            or lc_value in self.illegal_identifiers
-            or value[0] in self.illegal_initial_characters
-            or not self.legal_characters.match(str(value))
-        )
+        return requires_quotes(value, include_case=False, **self._identifier_cfg)
 
     def quote_identifier_if_unsafe(self, value: str) -> str:
         """Quote each dot-separated part of ``value`` only when it is unsafe.
@@ -560,49 +572,18 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
         return self._safe_quote(s)
 
     def _requires_quotes(self, value: str) -> bool:
-        """Return True if the given identifier requires quoting."""
-        lc_value = value.lower()
-        return (
-            lc_value in self.reserved_words
-            or lc_value in self.illegal_identifiers
-            or value[0] in self.illegal_initial_characters
-            or not self.legal_characters.match(str(value))
-            or (lc_value != value)
-        )
+        """Return True if the given identifier requires quoting.
+
+        Thin wrapper over ``util.requires_quotes`` (structural triggers plus the
+        case-only clause).
+        """
+        return requires_quotes(value, **self._identifier_cfg)
 
     def _split_schema_by_dot(self, schema):
-        # Each entry is (value, was_quoted) where was_quoted=True means the
-        # value was enclosed in double-quotes in the original string.
-        ret = []
-        idx = 0
-        pre_idx = 0
-        in_quote = False
-        while idx < len(schema):
-            if not in_quote:
-                if schema[idx] == "." and pre_idx < idx:
-                    ret.append((schema[pre_idx:idx], False))
-                    pre_idx = idx + 1
-                elif schema[idx] == '"':
-                    if pre_idx < idx:
-                        ret.append((schema[pre_idx:idx], False))
-                    in_quote = True
-                    pre_idx = idx + 1
-            else:
-                if schema[idx] == '"':
-                    # SQL double-quote escape: "" inside a quoted identifier is a
-                    # literal " character (e.g. "my""schema" → my"schema).
-                    if idx + 1 < len(schema) and schema[idx + 1] == '"':
-                        idx += 1  # skip the second quote; keep accumulating
-                    elif pre_idx < idx:
-                        value = schema[pre_idx:idx].replace('""', '"')
-                        ret.append((value, True))
-                        in_quote = False
-                        pre_idx = idx + 1
-            idx += 1
-            if pre_idx < len(schema) and schema[pre_idx] == ".":
-                pre_idx += 1
-        if pre_idx < idx:
-            ret.append((schema[pre_idx:idx], False))
+        # Scan the raw string into ``(value, was_quoted)`` parts; the pure
+        # scanner lives in util.split_identifier_parts so it can be unit-tested
+        # without a preparer.
+        ret = split_identifier_parts(schema)
 
         # Parts found inside "..." get ``quote=True`` only when the dialect
         # was constructed with ``case_sensitive_identifiers=True``.  Without
@@ -620,6 +601,15 @@ class SnowflakeIdentifierPreparer(compiler.IdentifierPreparer):
             )
             for value, was_quoted in ret
         ]
+
+    def _split_idents(self, *idents) -> list:
+        """Split each non-None identifier on its unquoted dots and concatenate
+        the parts; the all-None / empty case yields ``[]``."""
+        return reduce(
+            operator.add,
+            [self._split_schema_by_dot(i) for i in idents if i is not None],
+            [],
+        )
 
 
 def _render_storage_credentials(credentials_used, deterministic: bool = False) -> str:
@@ -896,20 +886,21 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         )
 
     def visit_external_stage(self, external_stage, **kw):
+        # Quote the stage's <namespace>.<name> prefix when required, consistently
+        # with CREATE STAGE, so the stage reference is always a well-formed
+        # identifier; the trailing path is a stage path, not an identifier.
+        prefix = self.preparer.quote_identifier_if_unsafe(
+            f"{external_stage.namespace}{external_stage.name}"
+        )
         if external_stage.file_format is None:
-            return (
-                f"@{external_stage.namespace}{external_stage.name}{external_stage.path}"
-            )
+            return f"@{prefix}{external_stage.path}"
         # file_format names a (possibly schema-qualified) file format object;
-        # quote any unsafe part so it cannot alter SQL in the stage
-        # reference (SNOW-3649881).
+        # quote any part that requires it so the stage reference stays
+        # well-formed.
         file_format = self.preparer.quote_identifier_if_unsafe(
             external_stage.file_format
         )
-        return (
-            f"@{external_stage.namespace}{external_stage.name}{external_stage.path}"
-            f" (file_format => {file_format})"
-        )
+        return f"@{prefix}{external_stage.path} (file_format => {file_format})"
 
     def delete_extra_from_clause(
         self, delete_stmt, from_table, extra_froms, from_hints, **kw
@@ -1042,16 +1033,6 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         # escape backslash
         return escape_backslashes(super().render_literal_value(value, type_))
 
-    def _escape_string_interior(self, value: str) -> str:
-        """Return ``value`` escaped for embedding inside a single-quoted literal.
-
-        Returns only the escaped interior (no surrounding quotes), so callers
-        that already supply the enclosing quotes can interpolate the result
-        directly.  Shares its escaping rules with the DDL compiler via
-        ``escape_string_literal_interior``.
-        """
-        return escape_string_literal_interior(value)
-
 
 class SnowflakeExecutionContext(default.DefaultExecutionContext):
     INSERT_SQL_RE = re.compile(r"^insert\s+into", flags=re.IGNORECASE)
@@ -1113,14 +1094,6 @@ _identity_pk_warned: set = set()
 
 
 class SnowflakeDDLCompiler(compiler.DDLCompiler):
-    def _escape_string_interior(self, value: str) -> str:
-        """Return ``value`` escaped for embedding inside a single-quoted literal.
-
-        DDL counterpart of ``SnowflakeCompiler._escape_string_interior``; both
-        share their escaping rules via ``escape_string_literal_interior``.
-        """
-        return escape_string_literal_interior(value)
-
     def denormalize_column_name(self, name):
         if name is None:
             return None

--- a/src/snowflake/sqlalchemy/custom_commands.py
+++ b/src/snowflake/sqlalchemy/custom_commands.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql.elements import ClauseElement
 from sqlalchemy.sql.roles import FromClauseRole
 
 from .compat import string_types
-from .util import escape_string_literal_interior
+from .util import escape_single_quotes, escape_string_literal_interior
 
 NoneType = type(None)
 
@@ -237,7 +237,7 @@ class CopyFormatter(ClauseElement):
         """
         if name in _FULL_ESCAPE_OPTION_KEYS:
             return escape_string_literal_interior(value)
-        return value.replace("'", "''")
+        return escape_single_quotes(value)
 
     @staticmethod
     def value_repr(name, value):

--- a/src/snowflake/sqlalchemy/custom_types.py
+++ b/src/snowflake/sqlalchemy/custom_types.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 import decimal
+import keyword
 import warnings
 from typing import Optional, Tuple, Union
 
@@ -147,12 +148,18 @@ class OBJECT(StructuredType):
 
     def __repr__(self):
         dq = '"'
-        return "OBJECT(%s)" % ", ".join(
-            [
-                f"{key.strip(dq)}={repr(value)}"
-                for key, value in self.items_types.items()
-            ]
-        )
+        parts = []
+        for key, value in self.items_types.items():
+            bare = key.strip(dq)
+            if bare.isidentifier() and not keyword.iskeyword(bare):
+                parts.append(f"{bare}={repr(value)}")
+            else:
+                # Field names that are not valid Python identifiers (e.g. a
+                # quoted identifier containing a space) cannot be keyword
+                # arguments; render them as a dict entry so the representation
+                # stays valid Python and round-trips through Alembic autogenerate.
+                parts.append(f"**{{{bare!r}: {repr(value)}}}")
+        return "OBJECT(%s)" % ", ".join(parts)
 
 
 class ARRAY(StructuredType):

--- a/src/snowflake/sqlalchemy/name_utils.py
+++ b/src/snowflake/sqlalchemy/name_utils.py
@@ -1,22 +1,26 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 
-import operator
-from functools import reduce
-
 from sqlalchemy.sql.compiler import IdentifierPreparer
 from sqlalchemy.sql.elements import quoted_name
 
 
 class _NameUtils:
 
-    def __init__(
-        self,
-        identifier_preparer: IdentifierPreparer,
-        case_sensitive_identifiers: bool = False,
-    ) -> None:
+    def __init__(self, identifier_preparer: IdentifierPreparer) -> None:
         self.identifier_preparer = identifier_preparer
-        self.case_sensitive_identifiers = case_sensitive_identifiers
+
+    @property
+    def case_sensitive_identifiers(self) -> bool:
+        """Read the flag live from the dialect — the single source of truth.
+
+        ``_NameUtils`` keeps no copy of its own: the dialect owns
+        ``_case_sensitive_identifiers`` (and the preparer reads it live too), so
+        a URL-driven flip is reflected here without rebuilding this object.
+        """
+        return getattr(
+            self.identifier_preparer.dialect, "_case_sensitive_identifiers", False
+        )
 
     def normalize_name(self, name):
         if name is None:
@@ -82,24 +86,25 @@ class _NameUtils:
             return ip.quote_identifier(name)
         return ip.quote_identifier(self.denormalize_name(name))
 
+    def quote_components(self, parts) -> str:
+        """Unconditionally double-quote each pre-split component and dot-join them.
+
+        For parts already extracted by ``_split_schema_by_dot`` (which may
+        themselves contain literal dots) — unlike :meth:`always_quote_join`, this
+        does **not** split.  Public so the dialect can quote pre-split parts
+        without reaching into ``_quote_component``.
+        """
+        return ".".join(self._quote_component(p) for p in parts)
+
     def always_quote_join(self, *idents) -> str:
         """Build a dot-joined SQL identifier string that always quotes every part.
 
         Each identifier in *idents is split on unquoted dots via
         ``_split_schema_by_dot`` (so ``"db.schema"`` becomes two components),
-        then every component is unconditionally double-quoted via
-        ``_quote_component``.
+        then every component is unconditionally double-quoted.
 
         Do NOT pass pre-split parts that may contain literal dots (e.g. a
-        component extracted from ``'"my.schema"'``).  Use ``_quote_component``
-        directly on each pre-split part instead.
+        component extracted from ``'"my.schema"'``).  Use :meth:`quote_components`
+        on the pre-split parts instead.
         """
-        split_idents = reduce(
-            operator.add,
-            [
-                self.identifier_preparer._split_schema_by_dot(ids)
-                for ids in idents
-                if ids is not None
-            ],
-        )
-        return ".".join(self._quote_component(i) for i in split_idents)
+        return self.quote_components(self.identifier_preparer._split_idents(*idents))

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -3,11 +3,8 @@
 #
 import decimal
 import logging
-import operator
-import warnings
 from collections import defaultdict
 from enum import Enum
-from functools import reduce
 from logging import getLogger
 from time import time as time_in_seconds
 from typing import Any, Collection, NamedTuple, Optional, cast
@@ -54,7 +51,9 @@ from .parser.custom_type_parser import _CUSTOM_DECIMAL  # noqa
 from .parser.custom_type_parser import ischema_names, parse_index_columns, parse_type
 from .sql.custom_schema.custom_table_prefix import CustomTablePrefix
 from .util import (
+    _URL_QUERY_BLOCKED_KWARGS,
     _legacy_url_params_enabled,
+    _reject_or_warn,
     _update_connection_application_name,
     escape_string_literal_interior,
     parse_url_boolean,
@@ -71,38 +70,6 @@ colspecs = {
 _ENABLE_SQLALCHEMY_AS_APPLICATION_NAME = True
 
 logger = getLogger(__name__)
-
-# Query parameters that are not forwarded to snowflake.connector.connect()
-# when they arrive via the URL query string.  Each entry is a connector kwarg
-# that changes the connection target, reads a local file, writes to a local
-# path, or relaxes a connector-internal safety check.
-#
-# Callers who legitimately need one of these parameters should pass it via
-# connect_args= in create_engine() — that path skips URL parsing entirely
-# and is under the application's explicit control.
-_URL_QUERY_BLOCKED_KWARGS: frozenset = frozenset(
-    {
-        # Overrides the host derived from the URL authority; redirects the
-        # login request to a different server.
-        "host",
-        # Selects the transport; plain HTTP would expose credentials in transit.
-        "protocol",
-        # Connector reads the named file and sends its contents as an OAuth
-        # token — local file read.
-        "token_file_path",
-        # Connector opens the named file to load a private key — local file read.
-        "private_key_file",
-        # Connector writes OCSP / CRL / diagnostic artefacts to the given
-        # path — local file write.
-        "ocsp_response_cache_filename",
-        "connection_diag_log_path",
-        "crl_cache_dir",
-        # Connector-internal safety flags; relaxing them changes the safety
-        # posture of every subsequent file operation.
-        "unsafe_file_write",
-        "unsafe_skip_file_permissions_check",
-    }
-)
 
 
 class TelemetryEvents(Enum):
@@ -255,10 +222,7 @@ class SnowflakeDialect(default.DefaultDialect):
         self.force_div_is_floordiv = force_div_is_floordiv
         self.div_is_floordiv = force_div_is_floordiv
         self._case_sensitive_identifiers = case_sensitive_identifiers
-        self.name_utils = _NameUtils(
-            self.identifier_preparer,
-            case_sensitive_identifiers=case_sensitive_identifiers,
-        )
+        self.name_utils = _NameUtils(self.identifier_preparer)
         self._enable_decfloat = enable_decfloat
         # Initialised here so ``_log_new_connection_event`` and any other
         # pre-connect code path can read the attribute unconditionally.
@@ -342,31 +306,24 @@ class SnowflakeDialect(default.DefaultDialect):
 
         query = dict(**url.query)  # make mutable
         cache_column_metadata = query.pop("cache_column_metadata", None)
-        self._cache_column_metadata = (
-            parse_url_boolean(cache_column_metadata) if cache_column_metadata else False
-        )
+        if cache_column_metadata is not None:
+            # Preserve the constructor kwarg when the URL omits the param —
+            # matches enable_decfloat / case_sensitive_identifiers below.
+            self._cache_column_metadata = parse_url_boolean(cache_column_metadata)
 
         # Handle enable_decfloat URL parameter
         enable_decfloat = query.pop("enable_decfloat", None)
         if enable_decfloat is not None:
             self._enable_decfloat = parse_url_boolean(enable_decfloat)
 
-        # Handle case_sensitive_identifiers URL parameter
+        # Handle case_sensitive_identifiers URL parameter.  The dialect attribute
+        # is the single source of truth: the preparer and name_utils both read it
+        # live, so flipping it here takes effect everywhere with no rebuild.
         case_sensitive_identifiers = query.pop("case_sensitive_identifiers", None)
         if case_sensitive_identifiers is not None:
-            flag = parse_url_boolean(case_sensitive_identifiers)
-            if flag != self._case_sensitive_identifiers:
-                # Replace ``name_utils`` atomically rather than mutating the
-                # live instance's attribute.  Python attribute assignment is
-                # atomic at the bytecode level, so concurrent readers on
-                # other threads observe either the old ``_NameUtils`` or the
-                # new one — never a torn update where the flag and the
-                # cached preparer are briefly inconsistent.
-                self._case_sensitive_identifiers = flag
-                self.name_utils = _NameUtils(
-                    self.identifier_preparer,
-                    case_sensitive_identifiers=flag,
-                )
+            self._case_sensitive_identifiers = parse_url_boolean(
+                case_sensitive_identifiers
+            )
 
         # URL sets the query parameter values as strings, we need to cast to expected types when necessary
         #
@@ -378,23 +335,16 @@ class SnowflakeDialect(default.DefaultDialect):
         legacy = self._legacy_url_params
         for name, value in query.items():
             if name in _URL_QUERY_BLOCKED_KWARGS:
-                if legacy:
-                    warnings.warn(
-                        f"Connection parameter {name!r} is set via the URL query string. "
-                        "This is a deprecated practice that will stop working in a future release. "
-                        "Pass the parameter via connect_args= in create_engine() instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                else:
-                    raise sa_exc.ArgumentError(
-                        f"Connection parameter {name!r} cannot be set via the URL "
-                        "query string for safety reasons. "
-                        "Pass it via connect_args= in create_engine() instead. "
-                        "To restore the previous behaviour temporarily, pass "
-                        "legacy_url_params=True to create_engine() or set the "
-                        f"{SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS} environment variable."
-                    )
+                _reject_or_warn(
+                    f"Connection parameter {name!r} cannot be set via the URL "
+                    "query string for safety reasons. "
+                    "Pass it via connect_args= in create_engine() instead. "
+                    "To restore the previous behaviour temporarily, pass "
+                    "legacy_url_params=True to create_engine() or set the "
+                    f"{SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS} environment variable.",
+                    legacy=legacy,
+                    stacklevel=2,
+                )
             opts[name] = self.parse_query_param_type(name, value)
 
         return ([], opts)
@@ -456,10 +406,7 @@ class SnowflakeDialect(default.DefaultDialect):
 
     def _denormalize_quote_join(self, *idents):
         ip = self.identifier_preparer
-        split_idents = reduce(
-            operator.add,
-            [ip._split_schema_by_dot(ids) for ids in idents if ids is not None],
-        )
+        split_idents = ip._split_idents(*idents)
         return ".".join(ip._quote_free_identifiers(*split_idents))
 
     def _always_quote_join(self, *idents):
@@ -514,7 +461,7 @@ class SnowflakeDialect(default.DefaultDialect):
         # Quote each pre-split part unconditionally, preserving explicit
         # quoted-name boundaries.  Do NOT re-split via always_quote_join
         # because parts may contain literal dots (e.g. "schema.with.dots").
-        return ".".join(self.name_utils._quote_component(p) for p in parts)
+        return self.name_utils.quote_components(parts)
 
     @reflection.cache
     def _current_database_schema(self, connection, **kw):
@@ -1644,9 +1591,12 @@ class SnowflakeDialect(default.DefaultDialect):
         Returns comment of table in a dictionary as described by SQLAlchemy spec.
         """
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
+        # table_name is embedded in a single-quoted SHOW ... LIKE literal, so escape
+        # its interior (double ' and \) just like get_view_definition. SNOW-3649853.
+        like_value = escape_string_literal_interior(table_name)
         sql_command = (
             "SHOW /* sqlalchemy:_get_table_comment */ "
-            f"TABLES LIKE '{table_name}' IN SCHEMA {full_schema_name}"
+            f"TABLES LIKE '{like_value}' IN SCHEMA {full_schema_name}"
         )
         cursor = connection.execute(text(sql_command))
         return cursor.fetchone()
@@ -1656,9 +1606,12 @@ class SnowflakeDialect(default.DefaultDialect):
         Returns comment of view in a dictionary as described by SQLAlchemy spec.
         """
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
+        # table_name is embedded in a single-quoted SHOW ... LIKE literal, so escape
+        # its interior (double ' and \) just like get_view_definition. SNOW-3649853.
+        like_value = escape_string_literal_interior(table_name)
         sql_command = (
             "SHOW /* sqlalchemy:_get_view_comment */ "
-            f"VIEWS LIKE '{table_name}' IN SCHEMA {full_schema_name}"
+            f"VIEWS LIKE '{like_value}' IN SCHEMA {full_schema_name}"
         )
         cursor = connection.execute(text(sql_command))
         return cursor.fetchone()

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -35,27 +35,56 @@ def _rfc_1738_quote(text):
     return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
 
 
-# Characters valid in the URL authority fields we interpolate (account, region —
-# both DNS labels).  Rejects URL metacharacters (?  & @ : / # …) that would otherwise
-# be misinterpreted as URL delimiters when the value is placed in the URL authority
-# component, introducing unintended query parameters.
+# --- connection-input handling --------------------------------------------
+# Rules for caller-controlled connection inputs: the URL-authority allowlist
+# (account/region), the denylist of connector kwargs that must not arrive via
+# the URL query string, and the shared reject-or-warn gate.
+
+# account/region are DNS labels; reject characters that would act as URL
+# delimiters in the authority component.
 _SAFE_URL_FIELD_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Connector kwargs that must travel via connect_args= rather than the URL query
+# string (they change the connection target, read/write local files, or relax a
+# connector safety check). Re-exported from snowdialect for backwards compat.
+_URL_QUERY_BLOCKED_KWARGS: frozenset = frozenset(
+    {
+        "host",
+        "protocol",
+        "token_file_path",
+        "private_key_file",
+        "ocsp_response_cache_filename",
+        "connection_diag_log_path",
+        "crl_cache_dir",
+        "unsafe_file_write",
+        "unsafe_skip_file_permissions_check",
+    }
+)
+
+
+def _reject_or_warn(message: str, *, legacy: bool, stacklevel: int = 2) -> None:
+    """Raise ``ArgumentError``, or warn under the legacy shim. ``stacklevel`` is
+    relative to this helper's caller."""
+    if legacy:
+        # +1 skips this helper's own frame so the warning is attributed to the
+        # caller that supplied ``stacklevel``.
+        warnings.warn(message, DeprecationWarning, stacklevel=stacklevel + 1)
+    else:
+        raise exc.ArgumentError(message)
 
 
 def _validate_url_field(field: str, value: str) -> None:
     if not _SAFE_URL_FIELD_RE.fullmatch(value):
-        msg = (
+        # The builder has no engine, so only the env var can relax this.
+        _reject_or_warn(
             f"'{field}' contains characters that cannot be safely placed in the "
             f"connection URL: {value!r}. "
-            "Only alphanumeric characters, hyphens, dots, and underscores are allowed."
+            "Only alphanumeric characters, hyphens, dots, and underscores are allowed. "
+            "To restore the previous behaviour temporarily, set the "
+            f"{SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS} environment variable.",
+            legacy=_legacy_url_params_enabled(),
+            stacklevel=3,  # caller's URL(...) site
         )
-        if _legacy_url_params_enabled():
-            # stacklevel=3 points the warning at the caller's ``URL(...)`` site:
-            # URL is an alias of _url (frame 2), which calls this function
-            # (frame 1); frame 3 is the user's call.
-            warnings.warn(msg, DeprecationWarning, stacklevel=3)
-        else:
-            raise exc.ArgumentError(msg)
 
 
 def _url(**db_parameters):
@@ -379,13 +408,125 @@ def escape_backslashes(value: str) -> str:
 
 
 def escape_string_literal_interior(value: str) -> str:
-    """Escape the *interior* of a single-quoted Snowflake string literal.
-
-    Doubles single quotes (standard SQL ``''`` escaping) and backslashes
-    (Snowflake ``ESCAPE_STRING_LITERALS`` semantics).  The two replacements are
-    order-independent.  Returns only the interior — **no surrounding quotes** —
-    and deliberately does **not** double percent signs, so the result is safe to
-    interpolate into a Python ``%``-formatted DDL template (unlike SQLAlchemy's
-    ``String`` literal processor, which both wraps in quotes and doubles ``%``).
+    """Escape the interior of a single-quoted Snowflake string literal: double
+    single quotes (standard SQL ``''``) and backslashes (Snowflake
+    ``ESCAPE_STRING_LITERALS``). Returns the interior only — no surrounding
+    quotes — and does not double percent signs, so it is safe to interpolate
+    into a ``%``-formatted DDL template.
     """
-    return value.replace("'", "''").replace("\\", "\\\\")
+    return escape_single_quotes(value).replace("\\", "\\\\")
+
+
+def escape_single_quotes(value: str) -> str:
+    """Double single quotes only, leaving backslashes untouched.
+
+    For single-quoted string-literal options where Snowflake backslash
+    sequences (``\\n``, ``\\134``, ``\\N``) must be preserved verbatim — unlike
+    ``escape_string_literal_interior``, which also doubles backslashes.
+    """
+    return value.replace("'", "''")
+
+
+# --- identifier quoting primitives -----------------------------------------
+#
+# Pure, config-free helpers shared by ``SnowflakeIdentifierPreparer`` (base.py)
+# and ``_NameUtils`` (name_utils.py).  Kept here, decoupled from the preparer,
+# so they can be unit-tested directly without constructing a dialect.  The
+# Snowflake-specific config (reserved words, illegal-identifier sets, the
+# legal-character regex, the case-sensitivity flag) stays on the preparer /
+# dialect and is passed in by the callers.
+
+
+def split_identifier_parts(text: str):
+    """Split a dotted identifier string into ``(value, was_quoted)`` parts.
+
+    Splits on unquoted dots while honouring double-quoted segments, so
+    ``"db.schema"`` -> ``[("db", False), ("schema", False)]`` and the quoted
+    ``'"my.schema"'`` -> ``[("my.schema", True)]``.  A doubled quote inside a
+    quoted segment (``"a""b"``) is unescaped to a single ``"`` (-> ``a"b``).
+
+    ``was_quoted`` records whether the part was enclosed in double quotes in the
+    source string; the caller decides what quoting that implies.  Returns only
+    the raw parts — **no** ``quoted_name`` wrapping and **no** case-sensitivity
+    policy (that lives in the preparer, which knows the dialect flag).
+
+    Parts must be dot-separated.  A quoted segment adjacent to other text without
+    a separating dot (``prefix"X"`` / ``"X"suffix``) or an unterminated quote is
+    malformed and raises ``ValueError`` rather than being parsed into an
+    arbitrary multi-part reference.
+    """
+    ret = []
+    idx = 0
+    pre_idx = 0
+    in_quote = False
+    while idx < len(text):
+        if not in_quote:
+            if text[idx] == "." and pre_idx < idx:
+                ret.append((text[pre_idx:idx], False))
+                pre_idx = idx + 1
+            elif text[idx] == '"':
+                # A quoted segment starts a part: unquoted text right before it
+                # (no separating dot) is malformed.
+                if pre_idx < idx:
+                    raise ValueError(
+                        f"invalid identifier {text!r}: unquoted text is adjacent "
+                        'to a quoted segment without a separating "."'
+                    )
+                in_quote = True
+                pre_idx = idx + 1
+        else:
+            if text[idx] == '"':
+                # "" inside a quoted segment is an escaped literal " character
+                # (e.g. "my""schema" -> my"schema).
+                if idx + 1 < len(text) and text[idx + 1] == '"':
+                    idx += 1  # skip the second quote; keep accumulating
+                else:
+                    value = text[pre_idx:idx].replace('""', '"')
+                    ret.append((value, True))
+                    in_quote = False
+                    pre_idx = idx + 1
+                    # A quoted segment ends a part: text other than a dot right
+                    # after the closing quote (no separating dot) is malformed.
+                    if idx + 1 < len(text) and text[idx + 1] != ".":
+                        raise ValueError(
+                            f"invalid identifier {text!r}: a quoted segment is "
+                            'adjacent to further text without a separating "."'
+                        )
+        idx += 1
+        if pre_idx < len(text) and text[pre_idx] == ".":
+            pre_idx += 1
+    if in_quote:
+        raise ValueError(f"invalid identifier {text!r}: unterminated quoted segment")
+    if pre_idx < idx:
+        ret.append((text[pre_idx:idx], False))
+    return ret
+
+
+def requires_quotes(
+    value: str,
+    *,
+    include_case: bool = True,
+    reserved_words,
+    illegal_identifiers,
+    illegal_initial_characters,
+    legal_characters,
+) -> bool:
+    """Return True if ``value`` requires double-quoting.
+
+    Structural triggers (reserved word, illegal identifier, illegal initial
+    character, or any character outside ``legal_characters``) always apply. With
+    ``include_case`` (the default) an upper/mixed-case identifier also requires
+    quotes to preserve its case against Snowflake's folding. Pass
+    ``include_case=False`` for the structural-only check, where a bare uppercase
+    name is fine because Snowflake folds it.
+    """
+    if not value:
+        return False
+    lc_value = value.lower()
+    structural = (
+        lc_value in reserved_words
+        or lc_value in illegal_identifiers
+        or value[0] in illegal_initial_characters
+        or not legal_characters.match(str(value))
+    )
+    return structural or (include_case and lc_value != value)

--- a/tests/test_unit_case_sensitivity.py
+++ b/tests/test_unit_case_sensitivity.py
@@ -367,7 +367,8 @@ class TestNormalizeName:
 
 
 class TestSplitSchemaByDotPrefixDrop:
-    """Regression tests for the prefix-drop bug: unquoted prefix before a quoted segment."""
+    """A quoted segment must be dot-separated; adjacent unquoted text is rejected
+    rather than parsed into an unintended multi-part reference."""
 
     @pytest.fixture
     def ip(self):
@@ -376,16 +377,21 @@ class TestSplitSchemaByDotPrefixDrop:
     @pytest.mark.parametrize(
         "schema_str, expected_parts",
         [
-            ('prefix"QUOTED"', ["prefix", "QUOTED"]),
-            ('tenantA_"TENANT_B"', ["tenantA_", "TENANT_B"]),
             ('"myschema"', ["myschema"]),
             ("mydb.myschema", ["mydb", "myschema"]),
-            ('a"B"', ["a", "B"]),
         ],
     )
     def test_split_parts(self, ip, schema_str, expected_parts):
         parts = ip._split_schema_by_dot(schema_str)
         assert [str(p) for p in parts] == expected_parts
+
+    @pytest.mark.parametrize(
+        "schema_str",
+        ['prefix"QUOTED"', 'tenantA_"TENANT_B"', 'a"B"'],
+    )
+    def test_malformed_raises(self, ip, schema_str):
+        with pytest.raises(ValueError):
+            ip._split_schema_by_dot(schema_str)
 
 
 class TestQualifyObjectName:
@@ -543,31 +549,6 @@ class TestCaseSensitiveIdentifiersFlag:
             "case_sensitive_identifiers" not in opts
         ), "case_sensitive_identifiers must not be forwarded to connector opts"
 
-    def test_url_param_replaces_name_utils_atomically(self):
-        """URL-driven flip must swap ``name_utils`` rather than mutate it.
-
-        ``create_connect_args`` runs per DBAPI connection; mutating a live
-        ``_NameUtils`` attribute in place would let concurrent readers on
-        other threads observe a torn state where the flag has flipped but
-        the cached preparer has not.  Replacing the whole instance is
-        atomic at the bytecode level, so a reader sees either the old
-        instance or the new one and never a partially-updated object.
-        """
-        d = SnowflakeDialect()
-        original_nu = d.name_utils
-        url = SAUrl.create(
-            "snowflake",
-            username="u",
-            password="p",
-            host="testaccount",
-            query={"case_sensitive_identifiers": "True"},
-        )
-        d.create_connect_args(url)
-        assert d.name_utils is not original_nu
-        assert d.name_utils.case_sensitive_identifiers is True
-        # The original instance is untouched, proving no in-place mutation.
-        assert original_nu.case_sensitive_identifiers is False
-
     def test_url_param_idempotent_when_unchanged(self):
         """Re-applying the same flag is a no-op — ``name_utils`` is kept."""
         d = SnowflakeDialect(case_sensitive_identifiers=True)
@@ -582,6 +563,52 @@ class TestCaseSensitiveIdentifiersFlag:
         d.create_connect_args(url)
         assert d.name_utils is original_nu
         assert d._case_sensitive_identifiers is True
+
+
+class TestCaseSensitiveSingleSource:
+    """New contract (single source of truth): the dialect attribute
+    ``_case_sensitive_identifiers`` is the sole owner of the flag.  ``_NameUtils``
+    holds no copy — it reads the flag live from the dialect — so a URL-driven
+    flip mutates the dialect attribute in place and is reflected everywhere
+    without rebuilding ``name_utils``.
+    """
+
+    def _url(self, value):
+        return SAUrl.create(
+            "snowflake",
+            username="u",
+            password="p",
+            host="testaccount",
+            query={"case_sensitive_identifiers": value},
+        )
+
+    def test_url_flip_keeps_same_name_utils_instance(self):
+        """A URL-driven flip must NOT replace name_utils (no rebuild)."""
+        d = SnowflakeDialect()
+        original_nu = d.name_utils
+        d.create_connect_args(self._url("True"))
+        assert d._case_sensitive_identifiers is True
+        assert d.name_utils is original_nu
+
+    def test_name_utils_reflects_dialect_flag_live(self):
+        """name_utils.case_sensitive_identifiers tracks the dialect attribute
+        live, on the same instance — no stored copy."""
+        d = SnowflakeDialect()
+        nu = d.name_utils
+        assert nu.case_sensitive_identifiers is False
+        d._case_sensitive_identifiers = True
+        assert nu.case_sensitive_identifiers is True
+
+    def test_normalize_name_reflects_live_flip(self):
+        """A mixed-case name normalizes per the *current* dialect flag on the
+        same name_utils instance, without any rebuild."""
+        d = SnowflakeDialect()
+        nu = d.name_utils
+        # flag off → mixed-case returned as a plain str (no .quote attribute)
+        assert getattr(nu.normalize_name("MyTable"), "quote", None) is None
+        d._case_sensitive_identifiers = True
+        # flag on → same instance now marks it quote=True
+        assert nu.normalize_name("MyTable").quote is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unit_connections_args.py
+++ b/tests/test_unit_connections_args.py
@@ -59,11 +59,6 @@ _ALL_BLOCKED_PARAMS = [
 ]
 
 
-# ===========================================================================
-# URL() must validate / encode the account / user / region fields
-# ===========================================================================
-
-
 class TestURLFieldEncoding:
     """URL() must reject or encode account/user/region values that contain
     URL metacharacters so that no unintended query parameters are introduced.
@@ -239,11 +234,6 @@ class TestURLFieldEncoding:
             )
 
 
-# ===========================================================================
-# create_connect_args must keep sensitive connector kwargs out of the URL query
-# ===========================================================================
-
-
 class TestSensitiveParamsRequireConnectArgs:
     """Sensitive connector kwargs must be supplied via connect_args=,
     not the URL query string.
@@ -359,12 +349,6 @@ class TestSensitiveParamsRequireConnectArgs:
         assert opts.get("schema") == "MY_SCHEMA"
 
 
-# ===========================================================================
-# Block-list integrity — anchors the design decision behind
-# _URL_QUERY_BLOCKED_KWARGS (denylist, not an allowlist of DEFAULT_CONFIGURATION)
-# ===========================================================================
-
-
 class TestBlockedKwargsIntegrity:
     """Guard the block-list and document why an allowlist can't replace it.
 
@@ -402,11 +386,6 @@ class TestBlockedKwargsIntegrity:
     def test_common_safe_params_are_not_over_blocked(self, safe_param):
         """Routine connection params must never be swept into the block-list."""
         assert safe_param not in _URL_QUERY_BLOCKED_KWARGS
-
-
-# ===========================================================================
-# Happy-path tests — the recommended migration to connect_args=
-# ===========================================================================
 
 
 class TestConnectArgsMigration:
@@ -484,11 +463,6 @@ class TestConnectArgsMigration:
         _, opts = d.create_connect_args(url)
         assert "protocol" not in opts  # not in URL query string
         assert opts["warehouse"] == "WH"
-
-
-# ===========================================================================
-# Regression tests — legacy URL params compatibility shim (kwarg + env var)
-# ===========================================================================
 
 
 class TestLegacyURLParamsMode:
@@ -625,3 +599,46 @@ class TestLegacyURLParamsMode:
         monkeypatch.setenv(SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS, "1")
         with pytest.warns(DeprecationWarning):
             URL(account="x?extra=1", user="u", password="pw")
+
+
+class TestCacheColumnMetadataKwargPrecedence:
+    """create_connect_args must use the preserve-kwarg idiom for
+    cache_column_metadata, matching enable_decfloat / case_sensitive_identifiers."""
+
+    def _url(self, **query):
+        return SAUrl.create(
+            "snowflake",
+            username="u",
+            password="p",
+            host="testaccount",
+            query=query,
+        )
+
+    def test_constructor_true_survives_url_without_param(self):
+        """cache_column_metadata=True in the constructor must NOT be reset to
+        False when the URL query string omits the param."""
+        d = base.dialect(cache_column_metadata=True)
+        d.create_connect_args(self._url())
+        assert d._cache_column_metadata is True
+
+    def test_constructor_default_false_when_url_silent(self):
+        """Default stays False when neither constructor nor URL sets it."""
+        d = base.dialect()
+        d.create_connect_args(self._url())
+        assert d._cache_column_metadata is False
+
+    @pytest.mark.parametrize(
+        "url_value, expected",
+        [("True", True), ("False", False)],
+    )
+    def test_url_value_overrides_constructor(self, url_value, expected):
+        """An explicit URL value still wins over the constructor kwarg."""
+        d = base.dialect(cache_column_metadata=not expected)
+        d.create_connect_args(self._url(cache_column_metadata=url_value))
+        assert d._cache_column_metadata is expected
+
+    def test_url_param_not_forwarded_to_connector(self):
+        """cache_column_metadata is consumed by the dialect, never forwarded."""
+        d = base.dialect()
+        _, opts = d.create_connect_args(self._url(cache_column_metadata="True"))
+        assert "cache_column_metadata" not in opts

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -454,7 +454,7 @@ class TestGetViewDefinitionLikeEscaping:
         "view_name, expected, not_expected",
         [
             pytest.param("o'brien", ["''"], ['"o'], id="simple_quote"),
-            pytest.param("a' b --", ["''"], [], id="quote_and_comment"),
+
             pytest.param("back\\slash", ["\\\\"], [], id="backslash_doubled"),
         ],
     )
@@ -468,3 +468,57 @@ class TestGetViewDefinitionLikeEscaping:
             assert (
                 fragment not in sql
             ), f"Unexpected {fragment!r} in SQL for {view_name!r}, got: {sql!r}"
+
+
+def _capture_comment_sql(dialect, method_name, table_name, schema="PUBLIC"):
+    """Return the SQL string _get_table_comment/_get_view_comment passes to execute()."""
+    conn = mock.MagicMock()
+    cursor = mock.MagicMock()
+    cursor.fetchone.return_value = None
+    conn.execute.return_value = cursor
+    with mock.patch.object(
+        dialect,
+        "_current_database_schema",
+        return_value=("CURRENT_DB", "CURRENT_SCHEMA"),
+    ):
+        getattr(dialect, method_name)(conn, table_name, schema=schema)
+    assert conn.execute.called
+    sql_arg = conn.execute.call_args[0][0]
+    return sql_arg.text if hasattr(sql_arg, "text") else str(sql_arg)
+
+
+class TestReflectionCommentLikeEscaping:
+    """SNOW-3649853 residual: _get_table_comment / _get_view_comment build a
+    ``SHOW ... LIKE '{table_name}'`` literal, so the interpolated value must be
+    single-quote escaped exactly like get_view_definition (snowdialect.py:1526).
+    """
+
+    @pytest.mark.parametrize("method_name", ["_get_table_comment", "_get_view_comment"])
+    def test_plain_name_unchanged_bcr(self, method_name):
+        # Behaviour-preserving: a quote-free name is untouched (no denormalize,
+        # no over-quoting) — keeps the cross-database-reflection contract.
+        sql = _capture_comment_sql(_make_dialect(), method_name, "my_table")
+        assert "LIKE 'my_table'" in sql
+        assert "''" not in sql
+
+    @pytest.mark.parametrize("method_name", ["_get_table_comment", "_get_view_comment"])
+    @pytest.mark.parametrize(
+        "table_name, expected, not_expected",
+        [
+            pytest.param("o'brien", ["''"], ['"o'], id="simple_quote"),
+
+            pytest.param("back\\slash", ["\\\\"], [], id="backslash_doubled"),
+        ],
+    )
+    def test_special_chars_escaped(
+        self, method_name, table_name, expected, not_expected
+    ):
+        sql = _capture_comment_sql(_make_dialect(), method_name, table_name)
+        for fragment in expected:
+            assert (
+                fragment in sql
+            ), f"Expected {fragment!r} in SQL for {table_name!r}, got: {sql!r}"
+        for fragment in not_expected:
+            assert (
+                fragment not in sql
+            ), f"Unexpected {fragment!r} in SQL for {table_name!r}, got: {sql!r}"

--- a/tests/test_unit_escaping.py
+++ b/tests/test_unit_escaping.py
@@ -8,7 +8,11 @@ import pytest
 from sqlalchemy.sql.sqltypes import String
 
 from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
-from snowflake.sqlalchemy.util import escape_backslashes, escape_string_literal_interior
+from snowflake.sqlalchemy.util import (
+    escape_backslashes,
+    escape_single_quotes,
+    escape_string_literal_interior,
+)
 
 # A single literal backslash. Spelled out to keep the parametrize tables
 # readable — "\\" in source is one backslash at runtime.
@@ -62,6 +66,15 @@ def test_escape_string_literal_interior(value, expected):
     assert escape_string_literal_interior(value) == expected
 
 
+def test_escape_single_quotes_diverges_from_interior_on_backslash():
+    """escape_single_quotes must NOT double backslashes; the interior helper does.
+    This is the whole reason the quote-only variant exists (FILE_FORMAT options
+    where \\n / \\134 / \\N must be preserved)."""
+    value = "a" + BS + "n'b"
+    assert escape_single_quotes(value) == "a" + BS + "n''b"
+    assert escape_string_literal_interior(value) == "a" + BS * 2 + "n''b"
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -91,21 +104,3 @@ def test_interior_escape_diverges_from_sa_processor_on_percent(value):
     else:
         # Absent percent signs, the processor interior matches the helper.
         assert processed[1:-1] == helper
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        pytest.param("plain", id="plain"),
-        pytest.param("a'b", id="quote"),
-        pytest.param(BS, id="backslash"),
-        pytest.param("a%b'c" + BS + "d", id="mixed"),
-    ],
-)
-def test_compiler_escape_methods_delegate_to_helper(value):
-    dialect = SnowflakeDialect()
-    ddl_compiler = dialect.ddl_compiler(dialect, None)
-    sql_compiler = dialect.statement_compiler(dialect, None)
-    expected = escape_string_literal_interior(value)
-    assert ddl_compiler._escape_string_interior(value) == expected
-    assert sql_compiler._escape_string_interior(value) == expected

--- a/tests/test_unit_identifier.py
+++ b/tests/test_unit_identifier.py
@@ -1,0 +1,193 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+import re
+
+import pytest
+
+from snowflake.sqlalchemy.util import requires_quotes, split_identifier_parts
+
+# ---------------------------------------------------------------------------
+# split_identifier_parts — the dotted-identifier scanner
+# ---------------------------------------------------------------------------
+
+
+class TestSplitIdentifierParts:
+    """split_identifier_parts returns ``(value, was_quoted)`` pairs and rejects
+    malformed identifiers (text adjacent to a quoted segment without a
+    separating dot, or an unterminated quote)."""
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            pytest.param("", [], id="empty"),
+            pytest.param("myschema", [("myschema", False)], id="single_plain"),
+            pytest.param(
+                "mydb.myschema",
+                [("mydb", False), ("myschema", False)],
+                id="dotted_plain",
+            ),
+            pytest.param('"myschema"', [("myschema", True)], id="single_quoted"),
+            pytest.param(
+                '"mydb"."myschema"',
+                [("mydb", True), ("myschema", True)],
+                id="dotted_quoted",
+            ),
+            pytest.param(
+                '"mydb".myschema',
+                [("mydb", True), ("myschema", False)],
+                id="mixed_quote_first",
+            ),
+            pytest.param(
+                'mydb."myschema"',
+                [("mydb", False), ("myschema", True)],
+                id="mixed_quote_second",
+            ),
+            # A dot inside a quoted segment is part of the identifier, not a split.
+            pytest.param(
+                '"my.schema"', [("my.schema", True)], id="dot_inside_quotes_not_split"
+            ),
+            # "" inside a quoted identifier is an escaped literal double-quote.
+            pytest.param(
+                '"my""schema"', [('my"schema', True)], id="embedded_escaped_quote"
+            ),
+            # Leading / trailing bare dots produce no empty parts.
+            pytest.param("a.", [("a", False)], id="trailing_dot"),
+            pytest.param(".a", [("a", False)], id="leading_dot"),
+        ],
+    )
+    def test_split(self, text, expected):
+        assert split_identifier_parts(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            pytest.param('prefix"QUOTED"', id="unquoted_before_quote"),
+            pytest.param('a"B"', id="short_prefix"),
+            pytest.param('tenantA_"TENANT_B"', id="underscore_prefix"),
+            pytest.param('"QUOTED"suffix', id="unquoted_after_quote"),
+            pytest.param('"unterminated', id="unterminated_quote"),
+        ],
+    )
+    def test_malformed_identifier_raises(self, text):
+        """A quoted segment must be dot-separated from any other part; adjacent
+        text or an unterminated quote is rejected rather than parsed into an
+        unintended multi-part reference."""
+        with pytest.raises(ValueError):
+            split_identifier_parts(text)
+
+
+# ---------------------------------------------------------------------------
+# requires_quotes — the quoting predicate
+# ---------------------------------------------------------------------------
+
+# Minimal synthetic config that mirrors the shape the preparer supplies, so the
+# predicates can be tested in complete isolation from the dialect.
+SYNTH_CFG = {
+    "reserved_words": frozenset({"select", "table", "from"}),
+    "illegal_identifiers": frozenset(set("0123456789") | {"_"}),
+    "illegal_initial_characters": frozenset(set("0123456789") | {"$"}),
+    "legal_characters": re.compile(r"^[A-Z0-9_$]+$", re.I),
+}
+
+
+class TestStructuralOnly:
+    """requires_quotes(include_case=False) flags only *structural* danger — not mere case."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            pytest.param("", False, id="empty_is_safe"),
+            pytest.param("mytable", False, id="plain_lower_safe"),
+            pytest.param("MYTABLE", False, id="plain_upper_safe_snowflake_folds"),
+            pytest.param("MyTable", False, id="mixed_case_safe_structurally"),
+            pytest.param("col_1$x", False, id="legal_chars_safe"),
+            # reserved word
+            pytest.param("select", True, id="reserved_lower"),
+            pytest.param("SELECT", True, id="reserved_upper"),
+            # single-char illegal identifier
+            pytest.param("_", True, id="lone_underscore"),
+            pytest.param("5", True, id="lone_digit"),
+            # illegal initial character
+            pytest.param("1col", True, id="leading_digit"),
+            pytest.param("$col", True, id="leading_dollar"),
+            # characters outside the legal set => structural quoting risk
+            pytest.param("a b", True, id="space"),
+            pytest.param('a"b', True, id="embedded_quote"),
+            pytest.param("a.b", True, id="dot"),
+            pytest.param("a; -- aaa", True, id="semicolon"),
+            pytest.param("a)b", True, id="paren"),
+        ],
+    )
+    def test_structural_only(self, value, expected):
+        assert requires_quotes(value, include_case=False, **SYNTH_CFG) is expected
+
+
+class TestRequiresQuotes:
+    """requires_quotes = structural check OR case-only clause."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            pytest.param("mytable", False, id="plain_lower_no_quote"),
+            pytest.param("col_1$x", False, id="legal_lower_no_quote"),
+            # The case-only clause is the difference from the structural check:
+            pytest.param("MyTable", True, id="mixed_case_requires_quote"),
+            pytest.param("MYTABLE", True, id="upper_requires_quote"),
+            # Structural cases still require quoting.
+            pytest.param("select", True, id="reserved"),
+            pytest.param("a b", True, id="space"),
+            pytest.param("1col", True, id="leading_digit"),
+        ],
+    )
+    def test_requires_quotes(self, value, expected):
+        assert requires_quotes(value, **SYNTH_CFG) is expected
+
+    def test_case_clause_is_the_only_difference(self):
+        """For an all-uppercase legal name, requires_quotes diverges with and
+        without ``include_case`` purely on the case clause."""
+        assert requires_quotes("MYTABLE", include_case=False, **SYNTH_CFG) is False
+        assert requires_quotes("MYTABLE", **SYNTH_CFG) is True
+
+    def test_empty_string_is_safe_not_indexerror(self):
+        """Composed form must not raise on '' (the old inline _requires_quotes
+        indexed value[0] with no empty guard)."""
+        assert requires_quotes("", **SYNTH_CFG) is False
+
+
+# ---------------------------------------------------------------------------
+# The predicates accept the real preparer config unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestPredicatesWithRealDialectConfig:
+    """Smoke test: the same functions work with the live dialect's config,
+    proving the preparer delegation supplies a compatible bundle."""
+
+    @pytest.fixture
+    def cfg(self):
+        from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+        ip = SnowflakeDialect().identifier_preparer
+        return {
+            "reserved_words": ip.reserved_words,
+            "illegal_identifiers": ip.illegal_identifiers,
+            "illegal_initial_characters": ip.illegal_initial_characters,
+            "legal_characters": ip.legal_characters,
+        }
+
+    @pytest.mark.parametrize(
+        "value, unsafe, needs_quotes",
+        [
+            ("mytable", False, False),
+            ("MYTABLE", False, True),
+            ("MyTable", False, True),
+            ("table", True, True),  # reserved word
+            ("select", True, True),
+            ("a b", True, True),
+            ('a"b', True, True),
+        ],
+    )
+    def test_real_config(self, cfg, value, unsafe, needs_quotes):
+        assert requires_quotes(value, include_case=False, **cfg) is unsafe
+        assert requires_quotes(value, **cfg) is needs_quotes

--- a/tests/test_unit_name_utils.py
+++ b/tests/test_unit_name_utils.py
@@ -131,11 +131,9 @@ def test_always_quote_join(nu, idents, expected):
 @pytest.mark.parametrize(
     "idents, blocked",
     [
-        pytest.param(
-            ("myschema; DROP TABLE users--", "mytable"), ";", id="semicolon in schema"
-        ),
-        pytest.param(("myschema", "mytable; SELECT 1--"), ";", id="semicolon in table"),
-        pytest.param(("x'; DROP TABLE t--", "t"), "DROP", id="DROP in schema"),
+        pytest.param(("myschema; -- aaa", "mytable"), ";", id="semicolon in schema"),
+        pytest.param(("myschema", "mytable; -- aaa"), ";", id="semicolon in table"),
+        pytest.param(("x'; -- aaa", "t"), ";", id="quote and semicolon in schema"),
     ],
 )
 def test_always_quote_join_identifier_quoting(nu, idents, blocked):

--- a/tests/test_unit_structured_type_info_manager.py
+++ b/tests/test_unit_structured_type_info_manager.py
@@ -127,7 +127,7 @@ def test_dotted_table_name_uses_only_last_component():
 
 def test_semicolon_in_table_name_is_enclosed_in_double_quotes():
     """Semicolons in table_name must not escape double-quote enclosure (SNOW-3480955)."""
-    payload = "foo; SELECT 1--"
+    payload = "foo; -- aaa"
     manager, captured = _make_manager()
     manager.get_table_columns(payload, schema="myschema")
 
@@ -144,9 +144,9 @@ def test_semicolon_in_table_name_is_enclosed_in_double_quotes():
     ), f"Semicolon escaped double-quote enclosure; got: {sql!r}"
 
 
-def test_drop_statement_injection_in_table_name_is_quoted():
-    """Classic DROP TABLE injection payload in table_name is neutralised by quoting."""
-    payload = "x'; DROP TABLE users--"
+def test_quote_semicolon_in_table_name_is_quoted():
+    """A quote + semicolon + comment in table_name is neutralised by quoting."""
+    payload = "x'; -- aaa"
     manager, captured = _make_manager()
     manager.get_table_columns(payload, schema="myschema")
 
@@ -154,8 +154,8 @@ def test_drop_statement_injection_in_table_name_is_quoted():
     assert f'"{payload}"' in sql, f"Payload not enclosed in double-quotes; got: {sql!r}"
     stripped = re.sub(r'"[^"]*"', "", sql)
     assert (
-        "DROP" not in stripped
-    ), f"DROP keyword escaped double-quote enclosure; got: {sql!r}"
+        ";" not in stripped
+    ), f"Semicolon escaped double-quote enclosure; got: {sql!r}"
 
 
 def test_newline_injection_in_table_name_is_quoted():
@@ -175,7 +175,7 @@ def test_newline_injection_in_table_name_is_quoted():
 
 def test_semicolon_in_schema_is_enclosed_in_double_quotes():
     """Injection payload in schema is also double-quoted (SNOW-3480955)."""
-    payload = "myschema; SELECT 1--"
+    payload = "myschema; -- aaa"
     manager, captured = _make_manager()
     manager.get_table_columns("mytable", schema=payload)
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

**Refactor name utilities and quoting internals; add identifier tests**

A behaviour-preserving cleanup that consolidates the quoting internals introduced by the
earlier branches.

- Refactors `_NameUtils` to read the case-sensitivity flag live from the dialect (single source
  of truth) and adds a `quote_components` helper.
- Consolidates quoting/rendering internals across `base.py`, `snowdialect.py`, and `util.py`;
  tidies `custom_types.py` and `custom_commands.py`.
- Adds `tests/test_unit_identifier.py` and expands identifier/quoting unit coverage; refreshes
  related unit tests.

**Touches:** `base.py`, `snowdialect.py`, `util.py`, `name_utils.py`, `custom_types.py`,
`custom_commands.py`, `tests/test_unit_identifier.py` (new), and related unit tests.