### PR TITLE
SNOW-645168: Document PUT with file_stream (BytesIO) workaround

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,7 +13,7 @@ Source code is also available at:
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).
 - Document writing dicts/lists to VARIANT/OBJECT/ARRAY via `INSERT ... SELECT` with `PARSE_JSON` (SNOW-801402 / GH #411).
-- Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168).
+- Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168 / [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
 
 # Release Notes
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at:
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).
 - Document writing dicts/lists to VARIANT/OBJECT/ARRAY via `INSERT ... SELECT` with `PARSE_JSON` (SNOW-801402 / GH #411).
+- Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1425,10 +1425,24 @@ with Session(engine) as session:
 
 The Snowflake connector's `PUT` command accepts an in-memory `file_stream` keyword, but
 SQLAlchemy's execution API treats every keyword passed to `Connection.execute()` as a bound
-SQL parameter. Passing `file_stream` through SQLAlchemy therefore fails with:
+SQL parameter. Passing `file_stream` through SQLAlchemy therefore fails
+(see [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)):
 
 ```
 snowflake.connector.errors.ProgrammingError: 255001: Binding data in type (bytesio) is not supported.
+```
+
+For example, the intuitive call below does **not** work:
+
+```python
+from io import BytesIO
+from sqlalchemy import text
+
+buf = BytesIO()
+# ❌ Fails — SQLAlchemy binds file_stream as a SQL parameter:
+connection.execute(text("PUT file://example.txt @my_stage"), {"file_stream": buf})
+# snowflake.connector.errors.ProgrammingError: 255001:
+#   Binding data in type (bytesio) is not supported.
 ```
 
 **Workaround — use the raw connector cursor** for `PUT`/`GET` file-stream operations. You can

--- a/README.md
+++ b/README.md
@@ -1421,6 +1421,42 @@ with Session(engine) as session:
 
 ---
 
+### `PUT` with a file stream (`BytesIO`)
+
+The Snowflake connector's `PUT` command accepts an in-memory `file_stream` keyword, but
+SQLAlchemy's execution API treats every keyword passed to `Connection.execute()` as a bound
+SQL parameter. Passing `file_stream` through SQLAlchemy therefore fails with:
+
+```
+snowflake.connector.errors.ProgrammingError: 255001: Binding data in type (bytesio) is not supported.
+```
+
+**Workaround — use the raw connector cursor** for `PUT`/`GET` file-stream operations. You can
+obtain one from the SQLAlchemy engine without opening a second connection:
+
+```python
+from io import BytesIO
+
+buf = BytesIO()
+df.to_json(buf, orient="records", date_format="iso")
+buf.seek(0)
+
+raw = engine.raw_connection()
+try:
+    cur = raw.cursor()
+    cur.execute(
+        f"PUT file://example.txt @{stage} auto_compress=true",
+        file_stream=buf,
+    )
+finally:
+    raw.close()
+```
+
+Regular SQL (including `COPY INTO`) continues to work through SQLAlchemy as usual; only the
+file-stream keyword of `PUT`/`GET` requires the raw cursor.
+
+---
+
 ### Case-sensitive identifiers
 
 Snowflake stores unquoted identifiers in UPPERCASE and treats them case-insensitively.  SQLAlchemy uses lowercase for case-insensitive identifiers.  The dialect bridges this gap via `normalize_name` / `denormalize_name`, but a few edge cases require explicit opt-in.


### PR DESCRIPTION


Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-645168

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add a Known Limitations entry explaining why passing file_stream through Connection.execute() fails and showing the raw-connection cursor workaround for PUT/GET file-stream operations. This closes the bug as a documentation issue; a dialect-level passthrough would be a separate additive feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code, tests, or behavioral changes.
> 
> **Overview**
> Documents a **Known Limitations** entry for uploading in-memory data with Snowflake `PUT` when using SQLAlchemy.
> 
> **Why it fails:** `Connection.execute()` treats extra kwargs (including `file_stream`) as SQL bind parameters, which triggers `255001: Binding data in type (bytesio) is not supported` ([#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
> 
> **Workaround:** Use `engine.raw_connection()` and pass `file_stream` on the connector cursor’s `execute()` for `PUT`/`GET` stream uploads; normal SQL (e.g. `COPY INTO`) stays on the SQLAlchemy connection.
> 
> `DESCRIPTION.md` **Unreleased Notes** lists this documentation change (SNOW-645168). No runtime or dialect code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1fb731af93319e97d30f3cb86bde1628400565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->