### PR TITLE
SNOW-715550: Document SSO/Okta authentication

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,8 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
+
 # Release Notes
 
 - v2.0.0a0 (July 16, 2026)

--- a/README.md
+++ b/README.md
@@ -898,6 +898,41 @@ Where `PRIVATE_KEY_PASSPHRASE` is a passphrase to decrypt the private key file, 
 
 Currently a private key parameter is not accepted by the `snowflake.sqlalchemy.URL` method.
 
+### SSO Authentication (Okta, Azure AD, etc.)
+
+Snowflake SQLAlchemy supports federated/SSO authentication by forwarding the `authenticator`
+parameter to the Snowflake Connector for Python. No dialect-specific configuration is required.
+
+For native Okta, pass your Okta endpoint URL as the `authenticator`:
+
+```python
+from sqlalchemy import create_engine
+from snowflake.sqlalchemy import URL
+
+engine = create_engine(
+    URL(
+        account="abc123",
+        user="testuser1",
+        database="testdb",
+        schema="public",
+    ),
+    connect_args={"authenticator": "https://your-okta-domain.okta.com"},
+)
+```
+
+For browser-based SSO (any configured identity provider, including Azure AD), use
+`externalbrowser`, which opens your default browser to complete the login:
+
+```python
+engine = create_engine(
+    URL(account="abc123", user="testuser1"),
+    connect_args={"authenticator": "externalbrowser"},
+)
+```
+
+See Snowflake's [federated authentication and SSO documentation](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-overview)
+for identity-provider setup instructions.
+
 ### Merge Command Support
 
 Snowflake SQLAlchemy supports upserting with its `MergeInto` custom expression.


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-715550

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add an "SSO Authentication" section showing how to authenticate via Okta and externalbrowser by forwarding the authenticator parameter through connect_args.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or connection behavior changes.
> 
> **Overview**
> Adds user-facing documentation for **federated/SSO login** with Snowflake SQLAlchemy by passing the connector’s `authenticator` through `create_engine(..., connect_args=...)`, with no new dialect APIs.
> 
> **README** gains an **SSO Authentication (Okta, Azure AD, etc.)** section after key-pair auth: native Okta via an Okta URL, browser SSO via `externalbrowser`, plus a link to Snowflake’s federated auth docs.
> 
> **DESCRIPTION.md** records the same under **Unreleased Notes** (SNOW-715550).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae4ddd37890403eda2e756675c1cd0e7914e329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->