### PR TITLE
SNOW-638838: Document CLUSTER BY usage in ORM/declarative models

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -14,7 +14,7 @@ Source code is also available at:
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).
 - Document writing dicts/lists to VARIANT/OBJECT/ARRAY via `INSERT ... SELECT` with `PARSE_JSON` (SNOW-801402 / GH #411).
 - Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168 / [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
-- Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838).
+- Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838 / [#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313)).
 
 # Release Notes
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -14,6 +14,7 @@ Source code is also available at:
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).
 - Document writing dicts/lists to VARIANT/OBJECT/ARRAY via `INSERT ... SELECT` with `PARSE_JSON` (SNOW-801402 / GH #411).
 - Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168 / [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
+- Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -874,6 +874,37 @@ t = Table('myuser', metadata,
 metadata.create_all(engine)
 ```
 
+#### ORM / Declarative usage
+
+For declarative models, use the `SnowflakeTable` construct, which accepts a `cluster_by`
+argument (plain column names and/or `text()` expressions):
+
+```python
+from sqlalchemy import Column, Integer, String, text
+from snowflake.sqlalchemy.sql.custom_schema import SnowflakeTable
+
+my_table = SnowflakeTable(
+    "my_table",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", String),
+    cluster_by=["id", text("date_trunc('hour', ts)")],
+)
+```
+
+`CLUSTER BY` is a storage optimization applied at DDL time and does not change query semantics —
+you query a clustered table exactly as any other table. To filter on a clustering expression,
+build it in the `WHERE` clause as usual:
+
+```python
+from datetime import datetime, timedelta
+from sqlalchemy import func, select
+
+stmt = select(my_table).where(
+    func.date_trunc("hour", my_table.c.ts) > datetime.utcnow() - timedelta(hours=1)
+)
+```
+
 ### Alembic Support
 
 [Alembic](http://alembic.zzzcomputing.com) is a database migration tool on top of `SQLAlchemy`. Snowflake SQLAlchemy works by adding the following code to `alembic/env.py` so that Alembic can recognize Snowflake SQLAlchemy.

--- a/README.md
+++ b/README.md
@@ -877,7 +877,8 @@ metadata.create_all(engine)
 #### ORM / Declarative usage
 
 For declarative models, use the `SnowflakeTable` construct, which accepts a `cluster_by`
-argument (plain column names and/or `text()` expressions):
+argument (plain column names and/or `text()` expressions) — see
+[#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313):
 
 ```python
 from sqlalchemy import Column, Integer, String, text


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-638838

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add an "ORM / Declarative usage" subsection to CLUSTER BY Support showing the SnowflakeTable cluster_by argument and clarifying that CLUSTER BY is a DDL-time storage optimization that does not affect query semantics (with a filter example).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no runtime, API, or test changes.
> 
> **Overview**
> **Documentation-only** change for SNOW-638838 / [#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313).
> 
> Under **CLUSTER BY Support** in `README.md`, a new **ORM / Declarative usage** subsection documents defining clustering with `SnowflakeTable` and the `cluster_by` argument (column names and `text()` expressions), with an import from `snowflake.sqlalchemy.sql.custom_schema`. It clarifies that **CLUSTER BY** is applied at DDL as a storage optimization and does not change how you query, and adds a short `select()` / `WHERE` example for filtering on a clustering expression such as `date_trunc('hour', ts)`.
> 
> `DESCRIPTION.md` adds a matching bullet to **Unreleased Notes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5104c610c72c2e090abe1753f2a9552465e96c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->