### PR TITLE
SNOW-1232362: Document AUTOINCREMENT and IDENTITY usage

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at:
 - Document writing dicts/lists to VARIANT/OBJECT/ARRAY via `INSERT ... SELECT` with `PARSE_JSON` (SNOW-801402 / GH #411).
 - Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168 / [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
 - Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838 / [#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313)).
+- Document AUTOINCREMENT and IDENTITY column usage, including Sequence vs Identity trade-offs for Hybrid tables (SNOW-1232362).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -397,14 +397,29 @@ t = Table('mytable', metadata,
 ```
 
 **Sequences and Hybrid tables.** For Hybrid tables (which require a defined primary key), both
-`Sequence`-backed and `AUTOINCREMENT` columns work for DDL. Note that when a `Sequence` is used,
-SQLAlchemy's ORM fetches the next value with a separate `SELECT <seq>.nextval` before the
-`INSERT`. To emit a single statement, use a Core insert instead of ORM `session.add()`:
+`Sequence`-backed and `AUTOINCREMENT` columns work. Note the difference in how the key is
+produced (`MyModel` below is an ORM-mapped class over such a table):
 
-```python
-from sqlalchemy import insert
-connection.execute(insert(t).values(name="abc"))
-```
+- With a `Sequence`, SQLAlchemy fetches the next value with a separate `SELECT <seq>.nextval`
+  before the `INSERT` — on both the ORM and Core paths:
+
+  ```python
+  from sqlalchemy import insert
+
+  # ORM — issues SELECT id_seq.nextval, then INSERT
+  session.add(MyModel(name="abc"))
+  session.commit()
+
+  # Core — same two-step behavior
+  connection.execute(insert(MyModel).values(name="abc"))
+  ```
+
+- With `AUTOINCREMENT` (no `Sequence`), Snowflake assigns the value server-side, so a plain
+  insert is a single statement:
+
+  ```python
+  connection.execute(insert(MyModel).values(name="abc"))  # single INSERT; id assigned by Snowflake
+  ```
 
 ### Object Name Case Handling
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,31 @@ t = Table('mytable', metadata,
 )
 ```
 
+`Sequence` is the recommended approach for ORM primary keys because the generated value is
+available to the ORM after insert. See [Identity columns as primary keys](#identity-columns-as-primary-keys)
+in Known Limitations for why `Identity()` does not work as an ORM primary key.
+
+**`AUTOINCREMENT` columns.** The dialect renders a column as `AUTOINCREMENT` when it is the
+table's autoincrement column and has no other server default. This is driven by SQLAlchemy's
+standard `autoincrement=True`:
+
+```python
+t = Table('mytable', metadata,
+    Column('id', Integer, primary_key=True, autoincrement=True),  # rendered as AUTOINCREMENT
+    Column('name', String),
+)
+```
+
+**Sequences and Hybrid tables.** For Hybrid tables (which require a defined primary key), both
+`Sequence`-backed and `AUTOINCREMENT` columns work for DDL. Note that when a `Sequence` is used,
+SQLAlchemy's ORM fetches the next value with a separate `SELECT <seq>.nextval` before the
+`INSERT`. To emit a single statement, use a Core insert instead of ORM `session.add()`:
+
+```python
+from sqlalchemy import insert
+connection.execute(insert(t).values(name="abc"))
+```
+
 ### Object Name Case Handling
 
 Snowflake stores all case-insensitive object names in uppercase text. In contrast, SQLAlchemy considers all lowercase object names to be case-insensitive. Snowflake SQLAlchemy converts the object name case during schema-level communication, i.e. during table and index reflection. If you use uppercase object names, SQLAlchemy assumes they are case-sensitive and encloses the names with quotes. This behavior will cause mismatches against data dictionary data received from Snowflake, so unless identifier names have been truly created as case sensitive using quotes, e.g., `"TestDb"`, all lowercase names should be used on the SQLAlchemy side.


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1232362

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Expand the "Auto-increment Behavior" section to cover AUTOINCREMENT columns via autoincrement=True, Sequence vs Identity trade-offs for Hybrid tables (with a cross-link to the Identity primary-key limitation), and how to avoid the two-statement sequence fetch by using Core inserts. Existing behavior already supports these patterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation; no behavioral or API changes.
> 
> **Overview**
> **Documentation-only** update for SNOW-1232362: expands **Auto-increment Behavior** in `README.md` and adds an unreleased note in `DESCRIPTION.md`. No runtime or dialect code changes.
> 
> The README now states that **`Sequence` is the recommended ORM primary key** (generated id available after insert) and **links to Known Limitations** for why **`Identity()`** is unsuitable as an ORM PK on Snowflake.
> 
> New guidance covers **`AUTOINCREMENT` DDL** when a column is the table autoincrement column with `autoincrement=True` and no other server default, plus **Hybrid table** patterns: **`Sequence`** implies a **`SELECT … nextval` then `INSERT`** on ORM and Core, while **`AUTOINCREMENT`** (no sequence) is a **single server-assigned `INSERT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c0b3cd1ca135620d3d21ed92d34d945e5ef95d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->