### PR TITLE
SNOW-710474: Document bulk array binding for large executemany inserts

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at:
 # Unreleased Notes
 
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
+- Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,53 @@ session.commit()
   the base class is required to unify the column-key sets before `SnowflakeSession`
   can batch them together.
 
+### Bulk Array Binding for Large `executemany` Inserts
+
+For large batch inserts (e.g. `Connection.execute(insert(t), [row1, row2, ...])`,
+`session.bulk_insert_mappings()`, or any `cursor.executemany`-backed path), the Snowflake
+Connector for Python can upload the bind values to a temporary internal stage as CSV and run a
+single insert that reads them from the stage, instead of embedding a large inline `VALUES`
+payload. This "bulk array binding" is faster and far more scalable for high row counts.
+
+This optimization is only used when the paramstyle is `qmark` (or `numeric`). The dialect defaults
+to `pyformat` (to match the connector default), so you must switch **both** the SQLAlchemy engine
+and the underlying connector connection to `qmark` — they must agree, or binding will fail:
+
+```python
+from sqlalchemy import create_engine
+
+engine = create_engine(
+    "snowflake://<account>/<db>/<schema>",
+    paramstyle="qmark",                 # SQLAlchemy renders positional "?" placeholders
+    connect_args={
+        "paramstyle": "qmark",          # connector uses qmark -> enables stage array binding
+    },
+)
+```
+
+Optionally tune when the stage upload kicks in with the connector session parameter
+`CLIENT_STAGE_ARRAY_BINDING_THRESHOLD` (total bind size in bytes; `0` disables the optimization):
+
+```python
+engine = create_engine(
+    "snowflake://<account>/<db>/<schema>",
+    paramstyle="qmark",
+    connect_args={
+        "paramstyle": "qmark",
+        "CLIENT_STAGE_ARRAY_BINDING_THRESHOLD": 65536,
+    },
+)
+```
+
+Notes:
+
+* Both `paramstyle` settings must match. Setting only one side causes a placeholder/binding
+  mismatch — the engine `paramstyle` controls how SQLAlchemy renders the SQL, while the
+  `connect_args["paramstyle"]` controls how the connector processes the parameters.
+* `qmark` applies engine-wide: every statement compiled by that engine uses positional binds.
+* Below the threshold (or for smaller batches) the connector sends the binds inline as usual;
+  the staged path is transparent to your code either way.
+
 ### CopyIntoStorage Support
 
 Snowflake SQLAlchemy supports saving tables/query results into different stages, as well as into Azure Containers and


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-710474

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add a README section explaining how to enable the connector's staged bulk array-binding optimization by setting qmark paramstyle on both the SQLAlchemy engine and the connector connect_args, plus the CLIENT_STAGE_ARRAY_BINDING_THRESHOLD tuning knob and the both-must-match caveat.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code, tests, or connection behavior changes.
> 
> **Overview**
> **Documentation-only** change for SNOW-710474: no runtime or dialect code changes.
> 
> Adds an **Unreleased** bullet in `DESCRIPTION.md` and a new README section **Bulk Array Binding for Large `executemany` Inserts**, placed after the existing ORM bulk-insert guidance. The section explains the connector’s staged CSV upload path for large `executemany` / bulk-insert workloads, why **`qmark`** (or `numeric`) is required while the dialect defaults to **`pyformat`**, and that **`paramstyle` must match** on `create_engine(..., paramstyle="qmark")` and `connect_args["paramstyle"]`. It includes example `create_engine` snippets and optional tuning via **`CLIENT_STAGE_ARRAY_BINDING_THRESHOLD`**, plus notes on engine-wide `qmark` behavior and transparent fallback below the threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b715790a4e7d497eb1061e2f1fb77a7007adf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->