### PR TITLE
SNOW-889678 / GH #435: Document MERGE INTO with a VALUES source

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at:
 
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
+- Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -962,6 +962,28 @@ merge.when_not_matched_then_insert().values(val=t2.c.newval, status=t2.c.newstat
 connection.execute(merge)
 ```
 
+#### Using a `VALUES` source (no staging table required)
+
+`MergeInto`'s `source` accepts any SQLAlchemy `Selectable`, so you can merge from an inline
+`VALUES` list (wrapped in a subquery) instead of an existing table:
+
+```python
+from sqlalchemy import values, column, Integer, String, select
+
+src = select(
+    values(
+        column("id", Integer),
+        column("status", String),
+        name="src",
+    ).data([(1, "active"), (2, "inactive")])
+).subquery()
+
+merge = MergeInto(target=t1, source=src, on=t1.c.id == src.c.id)
+merge.when_matched_then_update().values(status=src.c.status)
+merge.when_not_matched_then_insert().values(id=src.c.id, status=src.c.status)
+connection.execute(merge)
+```
+
 ### Bulk Insert Optimization for ORM Models
 
 When using `Session.bulk_save_objects()` with models that have nullable optional


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #435 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 MergeInto already accepts any Selectable as its source. Add a README subsection showing how to merge from an inline SQLAlchemy VALUES list (wrapped in a subquery) without a staging table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only README and DESCRIPTION.md are updated; behavior is unchanged and no tests or library code are touched.
> 
> **Overview**
> **Documentation-only** change for **SNOW-889678** / **#435** — no runtime or API changes.
> 
> The **README** gains a subsection under **Merge Command Support** explaining that `MergeInto.source` can be any SQLAlchemy `Selectable`, with a full example that builds an inline `values(...).data([...])` subquery and runs matched update / not-matched insert without a staging table.
> 
> **DESCRIPTION.md** adds a matching bullet under **Unreleased Notes** so the release notes call out the new guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d10dd53f9730f603050e6a0ba5c4b4a55d0c8f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->