### PR TITLE
GH #680: Document boolean IS TRUE/IS FALSE alternative

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,7 @@ Source code is also available at:
 - Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168 / [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
 - Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838 / [#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313)).
 - Document AUTOINCREMENT and IDENTITY column usage, including Sequence vs Identity trade-offs for Hybrid tables (SNOW-1232362).
+- Document that Snowflake lacks `IS TRUE`/`IS FALSE`; use `col == true()`/`col == false()` (GH #680).
 
 # Release Notes
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,7 +16,7 @@ Source code is also available at:
 - Document the raw-connector workaround for `PUT` with an in-memory `file_stream` (`BytesIO`) (SNOW-645168 / [#337](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/337)).
 - Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838 / [#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313)).
 - Document AUTOINCREMENT and IDENTITY column usage, including Sequence vs Identity trade-offs for Hybrid tables (SNOW-1232362).
-- Document that Snowflake lacks `IS TRUE`/`IS FALSE`; use `col == true()`/`col == false()` (GH #680).
+- Document that Snowflake lacks `IS TRUE`/`IS FALSE`; use `col == true()`/`col == false()` ([#680](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/680)).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,16 @@ for identity-provider setup instructions.
 
 SQLAlchemy's idiomatic `col.is_(True)` / `col.is_(False)` compile to `IS TRUE` / `IS FALSE`,
 which **Snowflake does not support** (Snowflake only allows `IS [NOT] NULL`). Using them raises a
-syntax error.
+syntax error (see [#680](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/680)):
+
+```python
+from sqlalchemy import select
+
+# ❌ Fails — Snowflake has no IS TRUE / IS FALSE:
+select(t).where(t.c.flag.is_(True))
+# snowflake.connector.errors.ProgrammingError: 001003 (42000):
+#   SQL compilation error: syntax error ... unexpected 'IS'.
+```
 
 Use equality against SQLAlchemy's `true()` / `false()` helpers instead:
 

--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ strict `IS TRUE` behavior, add an explicit null check:
 ```python
 from sqlalchemy import and_, true
 select(t).where(and_(t.c.flag.isnot(None), t.c.flag == true()))
+# WHERE flag IS NOT NULL AND flag = TRUE
 ```
 
 ### Merge Command Support

--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,30 @@ engine = create_engine(
 See Snowflake's [federated authentication and SSO documentation](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-overview)
 for identity-provider setup instructions.
 
+### Boolean Column Comparisons (`IS TRUE` / `IS FALSE`)
+
+SQLAlchemy's idiomatic `col.is_(True)` / `col.is_(False)` compile to `IS TRUE` / `IS FALSE`,
+which **Snowflake does not support** (Snowflake only allows `IS [NOT] NULL`). Using them raises a
+syntax error.
+
+Use equality against SQLAlchemy's `true()` / `false()` helpers instead:
+
+```python
+from sqlalchemy import true, false, select
+
+select(t).where(t.c.flag == true())     # WHERE flag = TRUE
+select(t).where(t.c.flag == false())    # WHERE flag = FALSE
+```
+
+Note the NULL semantics differ from `IS TRUE`/`IS FALSE`: `flag = TRUE` yields `NULL` for a
+`NULL` row (which filters it out), whereas `flag IS TRUE` would yield `FALSE`. If you need the
+strict `IS TRUE` behavior, add an explicit null check:
+
+```python
+from sqlalchemy import and_, true
+select(t).where(and_(t.c.flag.isnot(None), t.c.flag == true()))
+```
+
 ### Merge Command Support
 
 Snowflake SQLAlchemy supports upserting with its `MergeInto` custom expression.


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #680 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Snowflake does not support IS TRUE / IS FALSE. Add a README section recommending `col == true()` / `col == false()` (with the NULL-semantics caveat and an explicit null-check example).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, SQL compilation, or dependency changes.
> 
> **Overview**
> **Documentation-only** change for [#680](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/680): Snowflake does not support `IS TRUE` / `IS FALSE`, so idiomatic `col.is_(True)` / `col.is_(False)` fail at compile/execute time.
> 
> The **README** gains a new **Boolean Column Comparisons** section (after SSO auth) that shows the failing pattern, recommends `col == true()` and `col == false()`, and explains that `= TRUE`/`FALSE` differs from `IS TRUE`/`IS FALSE` for `NULL` rows, with an `and_(col.isnot(None), col == true())` example when strict semantics are needed.
> 
> **DESCRIPTION.md** adds a matching unreleased note pointing readers to the README guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6551d379c5f6fade8403e7e7e6df00a278bb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->