### PR TITLE
SNOW-801402 / GH #411: Document writing dicts/lists to VARIANT/OBJECT…/ARRAY

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at:
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).
+- Document writing dicts/lists to VARIANT/OBJECT/ARRAY via `INSERT ... SELECT` with `PARSE_JSON` (SNOW-801402 / GH #411).
 
 # Release Notes
 

--- a/README.md
+++ b/README.md
@@ -756,6 +756,37 @@ data_object  = json.loads(row[1])
 data_array   = json.loads(row[2])
 ```
 
+#### Writing Python dicts/lists to VARIANT, OBJECT and ARRAY
+
+Snowflake does **not** accept a bound Python `dict`/`list` for a semi-structured column, and it
+rejects a function expression such as `PARSE_JSON(?)` inside an `INSERT ... VALUES` clause. Binding
+a raw `dict` raises `255001: Binding data in type (dict) is not supported`, and binding a JSON
+string fails with an `expecting VARIANT but got VARCHAR` type mismatch.
+
+The supported pattern is `INSERT ... SELECT` (or `UPDATE`) with `PARSE_JSON` applied to a
+JSON string:
+
+```python
+import json
+from sqlalchemy import select, literal, func
+
+# INSERT ... SELECT PARSE_JSON(?)
+connection.execute(
+    t.insert().from_select(
+        ["id", "va"],
+        select(literal(1), func.parse_json(json.dumps({"a": 1, "b": [2, 3]}))),
+    )
+)
+
+# UPDATE ... SET va = PARSE_JSON(?)
+connection.execute(
+    t.update().where(t.c.id == 1).values(va=func.parse_json(json.dumps({"a": 2})))
+)
+```
+
+Use `func.parse_json(json.dumps(value))` anywhere you would otherwise bind a dict/list to a
+`VARIANT`, `OBJECT`, or `ARRAY` column.
+
 ### Structured Data Types Support
 
 This module defines custom SQLAlchemy types for Snowflake structured data, specifically for **Iceberg tables**.


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #411 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Snowflake rejects bound dicts and `PARSE_JSON` inside `INSERT ... VALUES`. Add a `README` subsection showing the supported `INSERT ... SELECT / UPDATE` pattern using `func.parse_json(json.dumps(...))`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> Documents how to **write** Python `dict`/`list` values to `VARIANT`, `OBJECT`, and `ARRAY` columns (fixes GH #411 / SNOW-801402), complementing the existing read path with `json.loads`.
> 
> The new **README** subsection under VARIANT/ARRAY/OBJECT explains Snowflake limitations: bound dicts are unsupported, `PARSE_JSON(?)` in `INSERT ... VALUES` fails, and a bound JSON string can hit a VARIANT vs VARCHAR mismatch. It shows the supported **`INSERT ... SELECT`** pattern with `t.insert().from_select(...)` and **`UPDATE`** with `func.parse_json(json.dumps(value))`.
> 
> **`DESCRIPTION.md`** adds a matching unreleased bullet for the next release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdff6a02cff34b6320772b178b1f6755dadc297b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->