### PR TITLE
SNOW-889293: Support json_serializer and json_deserializer engine parameters

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at:
 - Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).
 - Fix `URL` failing to encode `[`, `]`, `?` and `#` in passwords, which produced connect strings that could not be parsed (SNOW-828206 / GH #415).
 - Enhance `JSONFormatter` with the full Snowflake `TYPE=JSON` option set (`date_format`, `time_format`, `timestamp_format`, `binary_format`, `trim_space`, `null_if`, `enable_octal`, `allow_duplicate`, `strip_outer_array`, `strip_null_values`, `replace_invalid_characters`, `ignore_utf8_errors`, `skip_byte_order_mark`) (SNOW-589946).
+- Support `json_serializer` and `json_deserializer` parameters in `create_engine`, matching the built-in SQLAlchemy dialects (SNOW-889293 / GH #433).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/README.md
+++ b/README.md
@@ -827,6 +827,26 @@ connection.execute(
 Use `func.parse_json(json.dumps(value))` anywhere you would otherwise bind a dict/list to a
 `VARIANT`, `OBJECT`, or `ARRAY` column.
 
+#### Customizing JSON serialization (`json_serializer` / `json_deserializer`)
+
+Snowflake SQLAlchemy accepts the standard SQLAlchemy engine-level `json_serializer` and
+`json_deserializer` callables, matching the built-in dialects. Use them to plug in a custom
+JSON encoder/decoder — for example to preserve `Decimal` precision instead of parsing floats:
+
+```python
+import json
+import decimal
+import simplejson
+from sqlalchemy import create_engine
+from snowflake.sqlalchemy import URL
+
+engine = create_engine(
+    URL(account="myaccount", user="me", password="secret"),
+    json_serializer=lambda obj: simplejson.dumps(obj, use_decimal=True),
+    json_deserializer=lambda value: json.loads(value, parse_float=decimal.Decimal),
+)
+```
+
 ### Structured Data Types Support
 
 This module defines custom SQLAlchemy types for Snowflake structured data, specifically for **Iceberg tables**.

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -243,6 +243,8 @@ class SnowflakeDialect(default.DefaultDialect):
         case_sensitive_identifiers: bool = False,
         legacy_url_params: bool | None = None,
         redact_log_secrets: bool = True,
+        json_serializer: Any = None,
+        json_deserializer: Any = None,
         **kwargs: Any,
     ):
         super().__init__(isolation_level=isolation_level, **kwargs)  # type: ignore[arg-type]
@@ -251,6 +253,11 @@ class SnowflakeDialect(default.DefaultDialect):
         self._case_sensitive_identifiers = case_sensitive_identifiers
         self.name_utils = _NameUtils(self.identifier_preparer)
         self._enable_decfloat = enable_decfloat
+        # Serializers used for JSON (de)serialization of semi-structured data.
+        # Accepting these keeps parity with the built-in SQLAlchemy dialects so
+        # ``create_engine(..., json_serializer=..., json_deserializer=...)`` works.
+        self._json_serializer = json_serializer
+        self._json_deserializer = json_deserializer
         # Opt-in compatibility shim for the legacy URL/query behaviour.
         # An explicit ``legacy_url_params`` kwarg wins; when it is left unset
         # (None) the env variable acts as a global fallback.  It is deliberately

--- a/tests/test_dialect_connect.py
+++ b/tests/test_dialect_connect.py
@@ -7,10 +7,12 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+import sqlalchemy
 from sqlalchemy import __version__ as SQLALCHEMY_VERSION
 from sqlalchemy.engine import default as sqla_default
 from sqlalchemy.engine.url import URL as SAUrl
 
+from snowflake.sqlalchemy import URL
 from snowflake.sqlalchemy.snowdialect import (
     SnowflakeDialect,
     TelemetryEvents,
@@ -249,3 +251,52 @@ def test_connect_telemetry_records_url_driven_flag(
     assert message[TelemetryField.KEY_VALUE.value] == str(
         {"SQLAlchemy": SQLALCHEMY_VERSION, **expected_flags}
     )
+
+
+# ---------------------------------------------------------------------------
+# json_serializer / json_deserializer engine parameters (SNOW-889293)
+# ---------------------------------------------------------------------------
+
+
+def test_dialect_accepts_json_serializer_and_deserializer_kwargs():
+    """Constructor accepts and stores json_serializer/json_deserializer."""
+
+    def serializer(obj):
+        return obj
+
+    def deserializer(value):
+        return value
+
+    dialect = SnowflakeDialect(
+        json_serializer=serializer, json_deserializer=deserializer
+    )
+
+    assert dialect._json_serializer is serializer
+    assert dialect._json_deserializer is deserializer
+
+
+def test_dialect_json_serializers_default_to_none():
+    """When not provided the json (de)serializers default to None."""
+    dialect = SnowflakeDialect()
+
+    assert dialect._json_serializer is None
+    assert dialect._json_deserializer is None
+
+
+def test_create_engine_routes_json_serializer_and_deserializer():
+    """create_engine no longer raises when json (de)serializers are passed."""
+
+    def serializer(obj):
+        return obj
+
+    def deserializer(value):
+        return value
+
+    engine = sqlalchemy.create_engine(
+        URL(account="testaccount", user="u", password="p"),
+        json_serializer=serializer,
+        json_deserializer=deserializer,
+    )
+
+    assert engine.dialect._json_serializer is serializer
+    assert engine.dialect._json_deserializer is deserializer


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #433

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `create_engine(..., json_serializer=..., json_deserializer=...)` previously raised `TypeError` because `SnowflakeDialect` did not accept these kwargs. The dialect `__init__` now accepts `json_serializer` and `json_deserializer` and stores them as `self._json_serializer` / `self._json_deserializer`, matching the built-in SQLAlchemy dialects (sqlite, postgresql). Added unit tests covering the constructor defaults, explicit values, and end-to-end routing through `create_engine`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible dialect constructor change; default behavior unchanged when the new kwargs are omitted.
> 
> **Overview**
> Fixes **#433** / SNOW-889293: `create_engine(..., json_serializer=..., json_deserializer=...)` used to fail with `TypeError` because `SnowflakeDialect.__init__` did not accept those kwargs.
> 
> **`SnowflakeDialect`** now takes optional `json_serializer` and `json_deserializer` and stores them on `self._json_serializer` / `self._json_deserializer`, matching built-in SQLAlchemy dialects so engine creation accepts the same options.
> 
> **Tests** cover constructor defaults (`None`), explicit callables, and end-to-end routing through `sqlalchemy.create_engine` with `snowflake.sqlalchemy.URL`.
> 
> **Docs**: unreleased note in `DESCRIPTION.md` and a README section under VARIANT/OBJECT/ARRAY with an example (e.g. `simplejson` + `Decimal` via `parse_float`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05181e2bc04d160de6b5c83138021dd654408592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->