### PR TITLE
SNOW-828206: Encode square brackets in RFC 1738 password quoting

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at:
 
 - Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
 - Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).
+- Fix `URL` failing to encode `[`, `]`, `?` and `#` in passwords, which produced connect strings that could not be parsed (SNOW-828206 / GH #415).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/src/snowflake/sqlalchemy/util.py
+++ b/src/snowflake/sqlalchemy/util.py
@@ -34,7 +34,11 @@ from ._constants import (
 
 
 def _rfc_1738_quote(text: str) -> str:
-    return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
+    # Encode the characters that would otherwise terminate or corrupt the URL
+    # authority component when the value is placed in ``user:password@host``:
+    # ``: @ /`` (RFC 1738 userinfo delimiters), ``[ ]`` (IPv6 host literal
+    # brackets) and ``? #`` (query/fragment delimiters). See SNOW-828206.
+    return re.sub(r"[\[\]?#:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
 
 
 # --- connection-input handling --------------------------------------------

--- a/tests/test_unit_url.py
+++ b/tests/test_unit_url.py
@@ -3,6 +3,8 @@
 #
 import urllib.parse
 
+from sqlalchemy.engine.url import make_url
+
 from snowflake.sqlalchemy import URL
 
 
@@ -132,3 +134,51 @@ def test_url():
         "snowflake://testuser:test@testaccount"
         "/?authenticator=https%3A%2F%2Ftestokta.okta.com"
     )
+
+
+def test_url_password_with_square_brackets():
+    """Square brackets in a password must be percent-encoded (SNOW-828206).
+
+    Otherwise urllib's URL parser treats ``[``/``]`` as an IPv6 host literal and
+    raises, breaking otherwise valid RFC 1738 passwords.
+    """
+    assert (
+        URL(account="testaccount", user="admin", password="mypass]")
+        == "snowflake://admin:mypass%5D@testaccount/"
+    )
+    assert (
+        URL(account="testaccount", user="admin", password="[mypass")
+        == "snowflake://admin:%5Bmypass@testaccount/"
+    )
+    assert (
+        URL(account="testaccount", user="admin", password="a[b]c:@/")
+        == "snowflake://admin:a%5Bb%5Dc%3A%40%2F@testaccount/"
+    )
+
+
+def test_url_password_with_query_and_fragment_delimiters():
+    """``?`` and ``#`` in a password must be encoded (SNOW-828206).
+
+    They are URL query/fragment delimiters; if left raw they terminate the
+    authority component and push the host into the query/fragment.
+    """
+    assert (
+        URL(account="testaccount", user="admin", password="pa?ss")
+        == "snowflake://admin:pa%3Fss@testaccount/"
+    )
+    assert (
+        URL(account="testaccount", user="admin", password="pa#ss")
+        == "snowflake://admin:pa%23ss@testaccount/"
+    )
+
+
+def test_url_password_with_brackets_roundtrips():
+    """The generated URL parses and decodes back to the original password."""
+    password = "p[a]s:s@w/o[rd]?x#y"
+    generated = URL(account="testaccount", user="admin", password=password)
+
+    # Should not raise (previously ``[``/``]``/``?``/``#`` broke the parser).
+    urllib.parse.urlsplit(generated)
+
+    parsed = make_url(generated)
+    assert parsed.password == password


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #415

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `_rfc_1738_quote` did not encode `[` and `]`, so a password containing either produced a connect string that `urllib` rejected (it treats the brackets as an IPv6 host literal). The character class now includes `[` and `]`, so they are percent-encoded as `%5B` / `%5D` like the other reserved characters and the generated URL parses and round-trips back to the original password. Added unit tests for the encoding and for the parse/round-trip.

   Supersedes the source-only community PR #416 (same one-line fix) by adding test coverage and a changelog entry; co-authored with the original contributor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to URL string construction for passwords; only affects users whose passwords contain the newly encoded characters and should restore correct parsing rather than alter behavior for typical passwords.
> 
> **Overview**
> Fixes **SNOW-828206 / GH #415**: `URL()` could emit connect strings that **urllib** and SQLAlchemy could not parse when the password contained `[`, `]`, `?`, or `#`.
> 
> **`_rfc_1738_quote`** in `util.py` now percent-encodes those characters (in addition to the existing `:`, `@`, `/` handling) so they are not mistaken for IPv6 host literals or query/fragment delimiters in the authority segment. Unit tests cover the encoded forms and a **round-trip** through `urllib.parse.urlsplit` and `make_url`. The unreleased notes document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f883a05a27ebb6291637b95d4a13849e3979180a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->