### PR TITLE
SNOW-589962: Add IF NOT EXISTS and COMMENT support to CreateFileFormat

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at:
 - Enhance `JSONFormatter` with the full Snowflake `TYPE=JSON` option set (`date_format`, `time_format`, `timestamp_format`, `binary_format`, `trim_space`, `null_if`, `enable_octal`, `allow_duplicate`, `strip_outer_array`, `strip_null_values`, `replace_invalid_characters`, `ignore_utf8_errors`, `skip_byte_order_mark`) (SNOW-589946).
 - Support `json_serializer` and `json_deserializer` parameters in `create_engine`, matching the built-in SQLAlchemy dialects (SNOW-889293 / GH #433).
 - Detect expired-session/token and closed-connection errors as disconnects so `connection_invalidated` is set and pooled connections are recycled (SNOW-669163 / GH #348).
+- Add `if_not_exists` and `comment` options to `CreateFileFormat` for closer parity with Snowflake's `CREATE FILE FORMAT` (SNOW-589962 / GH #291).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,26 @@ sink. That logger is independent of the Snowflake connector's secret masking.
   directly. Note that object `repr()` (`AWSBucket`, `AzureContainer`,
   `CopyIntoStorage`, ...) already masks these secrets.
 
+### Creating a named file format
+
+Use `CreateFileFormat` together with a formatter to emit a `CREATE FILE FORMAT` statement.
+It supports `OR REPLACE` (`replace_if_exists=True`), `IF NOT EXISTS` (`if_not_exists=True`,
+which is mutually exclusive with `OR REPLACE`) and an optional `comment`:
+
+```python
+from snowflake.sqlalchemy import CreateFileFormat, CSVFormatter
+
+create_format = CreateFileFormat(
+    format_name="my_db.my_schema.my_csv_format",
+    formatter=CSVFormatter().field_delimiter(","),
+    if_not_exists=True,
+    comment="CSV format for ingestion",
+)
+connection.execute(create_format)
+# CREATE FILE FORMAT IF NOT EXISTS my_db.my_schema.my_csv_format
+#     TYPE='csv' FIELD_DELIMITER = ',' COMMENT = 'CSV format for ingestion'
+```
+
 ### Iceberg Table with Snowflake Catalog support
 
 Snowflake SQLAlchemy supports Iceberg Tables with the Snowflake Catalog, along with various related parameters. For detailed information about Iceberg Tables, refer to the Snowflake [CREATE ICEBERG](https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-snowflake) documentation.

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -1394,19 +1394,26 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
         This visitor will create the SQL representation for a CREATE FILE FORMAT
         command.
         """
-        return "CREATE {}FILE FORMAT {} TYPE='{}' {}".format(
+        options = " ".join(
+            [
+                f"{name} = {file_format.formatter.value_repr(name, value)}"
+                for name, value in file_format.formatter.options.items()
+            ]
+        )
+        text = "CREATE {}FILE FORMAT {}{} TYPE='{}' {}".format(
             "OR REPLACE " if file_format.replace_if_exists else "",
+            "IF NOT EXISTS " if file_format.if_not_exists else "",
             # format_name is a (possibly schema-qualified) identifier; quote any
             # unsafe part to prevent unintended DDL (SNOW-3649881).
             self.preparer.quote_identifier_if_unsafe(file_format.format_name),
             file_format.formatter.file_format,
-            " ".join(
-                [
-                    f"{name} = {file_format.formatter.value_repr(name, value)}"
-                    for name, value in file_format.formatter.options.items()
-                ]
-            ),
+            options,
         )
+        if file_format.comment is not None:
+            text += " COMMENT = '{}'".format(
+                escape_string_literal_interior(file_format.comment)
+            )
+        return text
 
     def visit_drop_table_comment(self, drop: DropTableComment, **kw: Any) -> str:
         """Snowflake does not support setting table comments as NULL.

--- a/src/snowflake/sqlalchemy/custom_commands.py
+++ b/src/snowflake/sqlalchemy/custom_commands.py
@@ -657,11 +657,20 @@ class CreateFileFormat(DDLElement):
         format_name: str,
         formatter: CopyFormatter,
         replace_if_exists: bool = False,
+        if_not_exists: bool = False,
+        comment: str | None = None,
     ) -> None:
         super().__init__()
+        if replace_if_exists and if_not_exists:
+            raise ValueError(
+                "replace_if_exists and if_not_exists are mutually exclusive; "
+                "Snowflake does not allow OR REPLACE together with IF NOT EXISTS."
+            )
         self.format_name = format_name
         self.formatter = formatter
         self.replace_if_exists = replace_if_exists
+        self.if_not_exists = if_not_exists
+        self.comment = comment
 
 
 class CreateStage(DDLElement):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -130,3 +130,77 @@ def test_create_parquet_format(sql_compiler):
         "TYPE='parquet' COMPRESSION = 'AUTO'"
     )
     assert actual == expected
+
+
+def test_create_format_if_not_exists(sql_compiler):
+    """CREATE FILE FORMAT should support the IF NOT EXISTS option."""
+    create_format = CreateFileFormat(
+        format_name="ML_POC.PUBLIC.CSV_FILE_FORMAT",
+        formatter=CSVFormatter().field_delimiter(","),
+        if_not_exists=True,
+    )
+    actual = sql_compiler(create_format)
+    expected = (
+        "CREATE FILE FORMAT IF NOT EXISTS ML_POC.PUBLIC.CSV_FILE_FORMAT "
+        "TYPE='csv' FIELD_DELIMITER = ','"
+    )
+    assert actual == expected
+
+
+def test_create_format_with_comment(sql_compiler):
+    """CREATE FILE FORMAT should support a trailing COMMENT clause."""
+    create_format = CreateFileFormat(
+        format_name="ML_POC.PUBLIC.CSV_FILE_FORMAT",
+        formatter=CSVFormatter().field_delimiter(","),
+        comment="my csv format",
+    )
+    actual = sql_compiler(create_format)
+    expected = (
+        "CREATE FILE FORMAT ML_POC.PUBLIC.CSV_FILE_FORMAT "
+        "TYPE='csv' FIELD_DELIMITER = ',' COMMENT = 'my csv format'"
+    )
+    assert actual == expected
+
+
+def test_create_format_comment_escapes_single_quotes(sql_compiler):
+    """Single quotes and backslashes in a comment must be escaped for Snowflake."""
+    create_format = CreateFileFormat(
+        format_name="ML_POC.PUBLIC.CSV_FILE_FORMAT",
+        formatter=CSVFormatter().field_delimiter(","),
+        comment="it's a\\b",
+    )
+    actual = sql_compiler(create_format)
+    expected = (
+        "CREATE FILE FORMAT ML_POC.PUBLIC.CSV_FILE_FORMAT "
+        "TYPE='csv' FIELD_DELIMITER = ',' COMMENT = 'it''s a\\\\b'"
+    )
+    assert actual == expected
+
+
+def test_create_format_if_not_exists_with_comment(sql_compiler):
+    """IF NOT EXISTS and COMMENT can be combined."""
+    create_format = CreateFileFormat(
+        format_name="ML_POC.PUBLIC.CSV_FILE_FORMAT",
+        formatter=CSVFormatter().field_delimiter(","),
+        if_not_exists=True,
+        comment="hello",
+    )
+    actual = sql_compiler(create_format)
+    expected = (
+        "CREATE FILE FORMAT IF NOT EXISTS ML_POC.PUBLIC.CSV_FILE_FORMAT "
+        "TYPE='csv' FIELD_DELIMITER = ',' COMMENT = 'hello'"
+    )
+    assert actual == expected
+
+
+def test_create_format_replace_and_if_not_exists_are_mutually_exclusive():
+    """OR REPLACE and IF NOT EXISTS cannot be requested together."""
+    import pytest
+
+    with pytest.raises(ValueError):
+        CreateFileFormat(
+            format_name="ML_POC.PUBLIC.CSV_FILE_FORMAT",
+            formatter=CSVFormatter().field_delimiter(","),
+            replace_if_exists=True,
+            if_not_exists=True,
+        )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #291

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `CreateFileFormat` only supported `OR REPLACE`. It now accepts `if_not_exists` and `comment` arguments, and the DDL compiler renders `IF NOT EXISTS` and a trailing `COMMENT = '...'` clause (single quotes in the comment are escaped). Because Snowflake forbids `OR REPLACE` together with `IF NOT EXISTS`, the constructor raises `ValueError` when both are requested. Added unit tests for each option, quote-escaping, the combined case, and the mutual-exclusion guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive DDL API and SQL compilation only; existing CreateFileFormat calls behave the same unless new kwargs are used.
> 
> **Overview**
> Extends **`CreateFileFormat`** so compiled `CREATE FILE FORMAT` DDL can match more of Snowflake’s syntax: optional **`if_not_exists=True`** (`IF NOT EXISTS`), optional **`comment`**, and a trailing **`COMMENT = '...'`** clause with standard literal escaping for quotes and backslashes.
> 
> The constructor **rejects** using **`replace_if_exists`** and **`if_not_exists`** together with **`ValueError`**, since Snowflake disallows `OR REPLACE` with `IF NOT EXISTS`. README and release notes document usage; unit tests cover each option, escaping, combined cases, and mutual exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8305160e7cdc0244a4cf1d73f1c758b861e6de62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->