### PR TITLE
SNOW-669163: Detect expired session/token errors as disconnects

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -14,6 +14,7 @@ Source code is also available at:
 - Fix `URL` failing to encode `[`, `]`, `?` and `#` in passwords, which produced connect strings that could not be parsed (SNOW-828206 / GH #415).
 - Enhance `JSONFormatter` with the full Snowflake `TYPE=JSON` option set (`date_format`, `time_format`, `timestamp_format`, `binary_format`, `trim_space`, `null_if`, `enable_octal`, `allow_duplicate`, `strip_outer_array`, `strip_null_values`, `replace_invalid_characters`, `ignore_utf8_errors`, `skip_byte_order_mark`) (SNOW-589946).
 - Support `json_serializer` and `json_deserializer` parameters in `create_engine`, matching the built-in SQLAlchemy dialects (SNOW-889293 / GH #433).
+- Detect expired-session/token and closed-connection errors as disconnects so `connection_invalidated` is set and pooled connections are recycled (SNOW-669163 / GH #348).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/README.md
+++ b/README.md
@@ -370,6 +370,24 @@ finally:
     engine.dispose()
 ```
 
+#### Automatic reconnection on expired sessions
+
+The dialect flags Snowflake session/token-loss errors (for example *"Authentication token has
+expired"* or *"Session no longer exists"*) as disconnects. This lets SQLAlchemy's connection
+pool transparently discard the dead connection and open a fresh one, so long-lived engines
+recover instead of raising. Combine it with `pool_pre_ping=True` to validate connections before
+use:
+
+```python
+from sqlalchemy import create_engine
+from snowflake.sqlalchemy import URL
+
+engine = create_engine(
+    URL(account="myaccount", user="me", password="secret"),
+    pool_pre_ping=True,  # invalidate + reconnect stale/expired connections automatically
+)
+```
+
 ### Auto-increment Behavior
 
 Auto-incrementing a value requires the `Sequence` object. Include the `Sequence` object in the primary key column to automatically increment the value as each new record is inserted. For example:

--- a/src/snowflake/sqlalchemy/_constants.py
+++ b/src/snowflake/sqlalchemy/_constants.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
+from snowflake.connector.errorcode import ER_CONNECTION_IS_CLOSED
+
 from .version import VERSION
 
 # parameters needed for usage tracking
@@ -12,6 +14,25 @@ APPLICATION_NAME = "SnowflakeSQLAlchemy"
 SNOWFLAKE_SQLALCHEMY_VERSION = VERSION
 DIALECT_NAME = "snowflake"
 NOT_NULL = "NOT NULL"
+
+# Error codes that mean the session/token is gone (or the socket is already
+# closed) and the connection must be treated as disconnected so the pool can
+# recycle it (SNOW-669163). The 390xxx values are Snowflake server (GS) codes;
+# the connector only exposes them as strings via ``snowflake.connector.network``
+# while DBAPI errors report ``errno`` as an int, so they are listed here as
+# ints. This set is the single source of truth and is imported by the tests.
+DISCONNECT_ERROR_CODES = frozenset(
+    {
+        390110,  # ID token expired
+        390111,  # session no longer exists
+        390112,  # session expired
+        390113,  # master token not found
+        390114,  # authentication/master token expired
+        390115,  # master token invalid
+        390318,  # OAuth access token expired
+        ER_CONNECTION_IS_CLOSED,  # 250002, connection is closed (client side)
+    }
+)
 
 # Set this environment variable to opt into the legacy behaviour where
 # certain connection parameters are accepted as URL query-string

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import CursorResult, Row
     from sqlalchemy.engine.interfaces import (
         DBAPIConnection,
+        DBAPIModule,
         ReflectedCheckConstraint,
         ReflectedColumn,
         ReflectedForeignKeyConstraint,
@@ -47,7 +48,11 @@ from sqlalchemy.sql import text
 from sqlalchemy.sql.sqltypes import NullType
 from sqlalchemy.types import FLOAT, Date, DateTime, Float, Time
 
-from ._constants import DIALECT_NAME, SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS
+from ._constants import (
+    DIALECT_NAME,
+    DISCONNECT_ERROR_CODES,
+    SNOWFLAKE_SQLALCHEMY_LEGACY_URL_PARAMS,
+)
 from .base import (
     SnowflakeCompiler,
     SnowflakeDDLCompiler,
@@ -274,6 +279,22 @@ class SnowflakeDialect(default.DefaultDialect):
         self.div_is_floordiv = self.force_div_is_floordiv
         if self._redact_log_secrets:
             _ensure_engine_log_redaction()
+
+    def is_disconnect(
+        self,
+        e: DBAPIModule.Error,
+        connection: Any,
+        cursor: Any,
+    ) -> bool:
+        """Detect connection/session loss so SQLAlchemy can invalidate the pool.
+
+        Returning True marks the DBAPI error's ``connection_invalidated`` flag,
+        which lets generic reconnect logic recover from expired sessions/tokens
+        (e.g. "Authentication token has expired", "Session no longer exists").
+        """
+        if isinstance(e, sf_errors.Error) and e.errno in DISCONNECT_ERROR_CODES:
+            return True
+        return super().is_disconnect(e, connection, cursor)
 
     @classmethod
     def dbapi(cls) -> Any:  # type: ignore[override]

--- a/tests/test_dialect_connect.py
+++ b/tests/test_dialect_connect.py
@@ -13,6 +13,7 @@ from sqlalchemy.engine import default as sqla_default
 from sqlalchemy.engine.url import URL as SAUrl
 
 from snowflake.sqlalchemy import URL
+from snowflake.sqlalchemy._constants import DISCONNECT_ERROR_CODES
 from snowflake.sqlalchemy.snowdialect import (
     SnowflakeDialect,
     TelemetryEvents,
@@ -300,3 +301,38 @@ def test_create_engine_routes_json_serializer_and_deserializer():
 
     assert engine.dialect._json_serializer is serializer
     assert engine.dialect._json_deserializer is deserializer
+
+
+# ---------------------------------------------------------------------------
+# is_disconnect / connection_invalidated detection (SNOW-669163)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("errno", sorted(DISCONNECT_ERROR_CODES))
+def test_is_disconnect_true_for_session_and_token_errors(errno):
+    """Session/token loss must be reported as a disconnect."""
+    from snowflake.connector.errors import ProgrammingError
+
+    dialect = SnowflakeDialect()
+    error = ProgrammingError(msg="boom", errno=errno)
+
+    assert dialect.is_disconnect(error, None, None) is True
+
+
+def test_is_disconnect_false_for_regular_sql_error():
+    """A plain SQL error (e.g. compilation) is not a disconnect."""
+    from snowflake.connector.errors import ProgrammingError
+
+    dialect = SnowflakeDialect()
+    error = ProgrammingError(msg="SQL compilation error", errno=1003)
+
+    assert dialect.is_disconnect(error, None, None) is False
+
+
+def test_is_disconnect_false_for_non_snowflake_error():
+    """Non-connector exceptions with a matching errno are ignored."""
+    dialect = SnowflakeDialect()
+    error = OSError("broken pipe")
+    error.errno = 390111
+
+    assert dialect.is_disconnect(error, None, None) is False


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #348

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The dialect inherited the default `is_disconnect`, which always returns `False`, so expired sessions/tokens were never flagged and `DBAPIError.connection_invalidated` stayed `False`, breaking generic reconnect logic. `SnowflakeDialect` now overrides `is_disconnect` to return `True` when the error is a `snowflake.connector.errors.Error` whose `errno` is a known session/token-loss or connection-closed code (390110-390115, 390318, 250002). This lets SQLAlchemy invalidate and recycle pooled connections after "Authentication token has expired" / "Session no longer exists". Added parametrized unit tests for the disconnect codes plus negative cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection-pool invalidation behavior for a defined set of errors; impact is limited to recovery paths and should improve long-lived engines, with false positives unlikely given errno + connector type checks.
> 
> **Overview**
> **SnowflakeDialect** now overrides **`is_disconnect`** so Snowflake connector errors whose **`errno`** is in a shared **`DISCONNECT_ERROR_CODES`** set (session/token expiry, invalid master token, OAuth token expiry, and client **connection closed**) are treated as disconnects. That lets SQLAlchemy set **`connection_invalidated`** and recycle pooled connections instead of failing on messages like *Authentication token has expired* or *Session no longer exists*.
> 
> The errno list lives in **`_constants.py`** as the single source of truth (tests import the same set). Other errors still defer to the base dialect; only **`snowflake.connector.errors.Error`** instances with matching codes count.
> 
> **README** documents pairing this behavior with **`pool_pre_ping=True`** for long-lived engines; **DESCRIPTION.md** adds an unreleased note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bba0058571b4ad9dada560ed55f2770f3f05d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->