### PR TITLE
SNOW-1866493: Add python_type property to Snowflake custom types

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at:
 # Unreleased Notes
 
 - Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
+- Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/src/snowflake/sqlalchemy/custom_types.py
+++ b/src/snowflake/sqlalchemy/custom_types.py
@@ -51,6 +51,10 @@ class SnowflakeType(sqltypes.TypeEngine):
 class VARIANT(SnowflakeType):
     __visit_name__ = "VARIANT"
 
+    @property
+    def python_type(self) -> type:
+        return dict
+
 
 class VECTOR(SnowflakeType):
     """
@@ -119,6 +123,10 @@ class VECTOR(SnowflakeType):
     def __repr__(self) -> str:
         return f"VECTOR({self.element_type}, {self.dimension})"
 
+    @property
+    def python_type(self) -> type:
+        return list
+
 
 class StructuredType(SnowflakeType):
     def __init__(self, is_semi_structured: bool = False) -> None:
@@ -140,6 +148,10 @@ class MAP(StructuredType):
         self.not_null = not_null
         super().__init__()
 
+    @property
+    def python_type(self) -> type:
+        return dict
+
 
 class OBJECT(StructuredType):
     __visit_name__ = "OBJECT"
@@ -152,6 +164,10 @@ class OBJECT(StructuredType):
         self.items_types: dict[str, tuple[TypeEngine, bool]] = normalized
         self.is_semi_structured = len(normalized) == 0
         super().__init__()
+
+    @property
+    def python_type(self) -> type:
+        return dict
 
     def __repr__(self) -> str:
         dq = '"'
@@ -181,25 +197,49 @@ class ARRAY(StructuredType):
         self.not_null = not_null
         super().__init__(is_semi_structured=value_type is None)
 
+    @property
+    def python_type(self) -> type:
+        return list
+
 
 class TIMESTAMP_TZ(SnowflakeType):
     __visit_name__ = "TIMESTAMP_TZ"
+
+    @property
+    def python_type(self) -> type:
+        return datetime
 
 
 class TIMESTAMP_LTZ(SnowflakeType):
     __visit_name__ = "TIMESTAMP_LTZ"
 
+    @property
+    def python_type(self) -> type:
+        return datetime
+
 
 class TIMESTAMP_NTZ(SnowflakeType):
     __visit_name__ = "TIMESTAMP_NTZ"
+
+    @property
+    def python_type(self) -> type:
+        return datetime
 
 
 class GEOGRAPHY(SnowflakeType):
     __visit_name__ = "GEOGRAPHY"
 
+    @property
+    def python_type(self) -> type:
+        return str
+
 
 class GEOMETRY(SnowflakeType):
     __visit_name__ = "GEOMETRY"
+
+    @property
+    def python_type(self) -> type:
+        return str
 
 
 class DECFLOAT(SnowflakeType):
@@ -228,6 +268,10 @@ class DECFLOAT(SnowflakeType):
 
     __visit_name__ = "DECFLOAT"
     _warned_precision: ClassVar[bool] = False
+
+    @property
+    def python_type(self) -> type:
+        return decimal.Decimal
 
     def result_processor(
         self, dialect: Dialect, coltype: object

--- a/tests/test_unit_types.py
+++ b/tests/test_unit_types.py
@@ -2,7 +2,26 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import datetime
+import decimal
+
+import pytest
+from sqlalchemy.types import INTEGER, VARCHAR
+
 import snowflake.sqlalchemy
+from snowflake.sqlalchemy import (
+    ARRAY,
+    DECFLOAT,
+    GEOGRAPHY,
+    GEOMETRY,
+    MAP,
+    OBJECT,
+    TIMESTAMP_LTZ,
+    TIMESTAMP_NTZ,
+    TIMESTAMP_TZ,
+    VARIANT,
+    VECTOR,
+)
 from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 
 from .util import ischema_names_baseline
@@ -21,3 +40,24 @@ def test_type_baseline():
     )
     for k, v in SnowflakeDialect.ischema_names.items():
         assert issubclass(v, ischema_names_baseline[k])
+
+
+@pytest.mark.parametrize(
+    "type_instance, expected_python_type",
+    [
+        (VARIANT(), dict),
+        (OBJECT(), dict),
+        (MAP(VARCHAR(), INTEGER()), dict),
+        (ARRAY(), list),
+        (VECTOR("FLOAT", 3), list),
+        (TIMESTAMP_TZ(), datetime.datetime),
+        (TIMESTAMP_LTZ(), datetime.datetime),
+        (TIMESTAMP_NTZ(), datetime.datetime),
+        (GEOGRAPHY(), str),
+        (GEOMETRY(), str),
+        (DECFLOAT(), decimal.Decimal),
+    ],
+)
+def test_python_type(type_instance, expected_python_type):
+    """Snowflake custom types expose a ``python_type`` (SNOW-1866493)."""
+    assert type_instance.python_type is expected_python_type


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #562

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   SQLAlchemy's `TypeEngine.python_type` raises `NotImplementedError` unless a type overrides it, so the Snowflake-specific types did not report a Python type — breaking downstream tools (pandas, ORM helpers) that introspect `column.type.python_type`. This adds the property to each Snowflake custom type: `VARIANT`/`OBJECT`/`MAP` -> `dict`, `ARRAY`/`VECTOR` -> `list`, `TIMESTAMP_TZ`/`TIMESTAMP_LTZ`/`TIMESTAMP_NTZ` -> `datetime.datetime`, `GEOGRAPHY`/`GEOMETRY` -> `str`, `DECFLOAT` -> `decimal.Decimal`. The change is purely additive (a read-only property) and does not alter any existing behavior. Types that already inherit a standard SQLAlchemy type (Date/DateTime/Time/Float/DECIMAL) keep their inherited `python_type`. Added parametrized unit tests in `tests/test_unit_types.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only metadata on type classes; no SQL compilation, binding, or reflection behavior changes.
> 
> **Overview**
> Adds a **`python_type`** property on Snowflake-specific `TypeEngine` subclasses so introspection via `column.type.python_type` works instead of raising `NotImplementedError` (fixes GH #562).
> 
> Mappings are **dict** for `VARIANT`, `OBJECT`, and `MAP`; **list** for `ARRAY` and `VECTOR`; **`datetime.datetime`** for `TIMESTAMP_TZ` / `TIMESTAMP_LTZ` / `TIMESTAMP_NTZ`; **str** for `GEOGRAPHY` and `GEOMETRY`; **`decimal.Decimal`** for `DECFLOAT`. Types that already inherit standard SQLAlchemy types keep their inherited `python_type`.
> 
> Parametrized coverage lives in `tests/test_unit_types.py`; unreleased notes in `DESCRIPTION.md` document the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44855ad1d169c7e7da19ce641401ebe6fc408d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->