### PR TITLE
SNOW-589946: Add full Snowflake JSON option set to JSONFormatter

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at:
 - Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
 - Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).
 - Fix `URL` failing to encode `[`, `]`, `?` and `#` in passwords, which produced connect strings that could not be parsed (SNOW-828206 / GH #415).
+- Enhance `JSONFormatter` with the full Snowflake `TYPE=JSON` option set (`date_format`, `time_format`, `timestamp_format`, `binary_format`, `trim_space`, `null_if`, `enable_octal`, `allow_duplicate`, `strip_outer_array`, `strip_null_values`, `replace_invalid_characters`, `ignore_utf8_errors`, `skip_byte_order_mark`) (SNOW-589946).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/src/snowflake/sqlalchemy/custom_commands.py
+++ b/src/snowflake/sqlalchemy/custom_commands.py
@@ -472,6 +472,100 @@ class JSONFormatter(CopyFormatter):
         self.options["FILE_EXTENSION"] = ext
         return self
 
+    def date_format(self, dt_frmt: str) -> JSONFormatter:
+        """String that defines the format of date values in the data files."""
+        if not isinstance(dt_frmt, str):
+            raise TypeError("Date format should be a string")
+        self.options["DATE_FORMAT"] = dt_frmt
+        return self
+
+    def time_format(self, tm_frmt: str) -> JSONFormatter:
+        """String that defines the format of time values in the data files."""
+        if not isinstance(tm_frmt, str):
+            raise TypeError("Time format should be a string")
+        self.options["TIME_FORMAT"] = tm_frmt
+        return self
+
+    def timestamp_format(self, tmstmp_frmt: str) -> JSONFormatter:
+        """String that defines the format of timestamp values in the data files."""
+        if not isinstance(tmstmp_frmt, str):
+            raise TypeError("Timestamp format should be a string")
+        self.options["TIMESTAMP_FORMAT"] = tmstmp_frmt
+        return self
+
+    def binary_format(self, bin_fmt: str) -> JSONFormatter:
+        """Encoding format for binary input or output: one of hex, base64 or utf8."""
+        if isinstance(bin_fmt, str):
+            bin_fmt = bin_fmt.lower()
+        _available_options = ["hex", "base64", "utf8"]
+        if bin_fmt not in _available_options:
+            raise TypeError(f"Binary format should be one of : {_available_options}")
+        self.options["BINARY_FORMAT"] = bin_fmt
+        return self
+
+    def trim_space(self, trim_space: bool) -> JSONFormatter:
+        """Remove leading and trailing white space from strings."""
+        if not isinstance(trim_space, bool):
+            raise TypeError("trim_space should be a bool")
+        self.options["TRIM_SPACE"] = trim_space
+        return self
+
+    def null_if(self, null_value: Sequence) -> JSONFormatter:
+        """Strings to convert to and from SQL NULL."""
+        if not isinstance(null_value, Sequence):
+            raise TypeError("Parameter null_value should be an iterable")
+        self.options["NULL_IF"] = tuple(null_value)
+        return self
+
+    def enable_octal(self, value: bool) -> JSONFormatter:
+        """Enable parsing of octal numbers."""
+        if not isinstance(value, bool):
+            raise TypeError("enable_octal should be a bool")
+        self.options["ENABLE_OCTAL"] = value
+        return self
+
+    def allow_duplicate(self, value: bool) -> JSONFormatter:
+        """Allow duplicate object field names (only the last one is preserved)."""
+        if not isinstance(value, bool):
+            raise TypeError("allow_duplicate should be a bool")
+        self.options["ALLOW_DUPLICATE"] = value
+        return self
+
+    def strip_outer_array(self, value: bool) -> JSONFormatter:
+        """Remove the outer array brackets and load each element as its own row."""
+        if not isinstance(value, bool):
+            raise TypeError("strip_outer_array should be a bool")
+        self.options["STRIP_OUTER_ARRAY"] = value
+        return self
+
+    def strip_null_values(self, value: bool) -> JSONFormatter:
+        """Remove object fields or array elements containing SQL NULL."""
+        if not isinstance(value, bool):
+            raise TypeError("strip_null_values should be a bool")
+        self.options["STRIP_NULL_VALUES"] = value
+        return self
+
+    def replace_invalid_characters(self, value: bool) -> JSONFormatter:
+        """Replace invalid UTF-8 characters with the Unicode replacement character."""
+        if not isinstance(value, bool):
+            raise TypeError("replace_invalid_characters should be a bool")
+        self.options["REPLACE_INVALID_CHARACTERS"] = value
+        return self
+
+    def ignore_utf8_errors(self, value: bool) -> JSONFormatter:
+        """Replace UTF-8 encoding errors with the Unicode replacement character."""
+        if not isinstance(value, bool):
+            raise TypeError("ignore_utf8_errors should be a bool")
+        self.options["IGNORE_UTF8_ERRORS"] = value
+        return self
+
+    def skip_byte_order_mark(self, value: bool) -> JSONFormatter:
+        """Skip any byte order mark (BOM) present in an input file."""
+        if not isinstance(value, bool):
+            raise TypeError("skip_byte_order_mark should be a bool")
+        self.options["SKIP_BYTE_ORDER_MARK"] = value
+        return self
+
 
 class PARQUETFormatter(CopyFormatter):
     """Format specific functions"""

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -520,3 +520,53 @@ def test_copy_into_storage_parquet_pattern(sql_compiler):
         "(file_format => parquet_file_format))   FORCE = true PATTERN = '.*csv'"
     )
     assert result == expected
+
+
+def test_json_formatter_options(sql_compiler):
+    """JSONFormatter exposes the full Snowflake TYPE=JSON option set (SNOW-589946)."""
+    formatter = (
+        JSONFormatter()
+        .date_format("YYYY-MM-DD")
+        .time_format("HH24:MI:SS")
+        .timestamp_format("YYYY-MM-DD HH24:MI:SS")
+        .binary_format("hex")
+        .trim_space(True)
+        .null_if(["null", "Null"])
+        .enable_octal(True)
+        .allow_duplicate(False)
+        .strip_outer_array(True)
+        .strip_null_values(False)
+        .replace_invalid_characters(True)
+        .ignore_utf8_errors(False)
+        .skip_byte_order_mark(True)
+    )
+    assert sql_compiler(formatter) == (
+        "FILE_FORMAT=(TYPE=json "
+        "ALLOW_DUPLICATE=False "
+        "BINARY_FORMAT='hex' "
+        "DATE_FORMAT='YYYY-MM-DD' "
+        "ENABLE_OCTAL=True "
+        "IGNORE_UTF8_ERRORS=False "
+        "NULL_IF=('null', 'Null') "
+        "REPLACE_INVALID_CHARACTERS=True "
+        "SKIP_BYTE_ORDER_MARK=True "
+        "STRIP_NULL_VALUES=False "
+        "STRIP_OUTER_ARRAY=True "
+        "TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS' "
+        "TIME_FORMAT='HH24:MI:SS' "
+        "TRIM_SPACE=True)"
+    )
+
+
+def test_json_formatter_validation():
+    """Invalid option values raise TypeError (SNOW-589946)."""
+    with pytest.raises(TypeError):
+        JSONFormatter().date_format(123)
+    with pytest.raises(TypeError):
+        JSONFormatter().binary_format("bogus")
+    with pytest.raises(TypeError):
+        JSONFormatter().trim_space("yes")
+    with pytest.raises(TypeError):
+        JSONFormatter().strip_outer_array("no")
+    with pytest.raises(TypeError):
+        JSONFormatter().null_if(123)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-589946 (Jira-tracked; no corresponding public GitHub issue).

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `JSONFormatter` previously exposed only `compression` and `file_extension`, so most Snowflake `TYPE = JSON` file-format options could not be set through the builder. This adds the remaining options as chainable, validated methods mirroring `CSVFormatter`: `date_format`, `time_format`, `timestamp_format`, `binary_format` (hex/base64/utf8), `trim_space`, `null_if`, `enable_octal`, `allow_duplicate`, `strip_outer_array`, `strip_null_values`, `replace_invalid_characters`, `ignore_utf8_errors`, and `skip_byte_order_mark`. Each validates its input type and populates `self.options`, so rendering flows through the existing `visit_copy_formatter` with no compiler changes. The change is purely additive — existing `JSONFormatter` usage is unchanged. Added compile-order and validation unit tests in `tests/test_copy.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API on COPY/JSON formatting only; existing `JSONFormatter` usage is unchanged and no compiler or security-sensitive paths are modified.
> 
> **Overview**
> **`JSONFormatter`** now supports the rest of Snowflake’s `TYPE=JSON` file-format knobs via chainable builder methods (aligned with **`CSVFormatter`**): date/time/timestamp formats, `binary_format`, `trim_space`, `null_if`, and JSON-specific flags such as `enable_octal`, `allow_duplicate`, `strip_outer_array`, `strip_null_values`, UTF-8 handling, and `skip_byte_order_mark`. Each method validates inputs and writes into `self.options`, so compiled `FILE_FORMAT=(TYPE=json …)` still goes through the existing `visit_copy_formatter` path with no compiler changes.
> 
> Release notes in **`DESCRIPTION.md`** document the enhancement. **`tests/test_copy.py`** adds a compile-order assertion for the full option set and **`TypeError`** checks for invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ddaa1d96fc42dc25288bdba96f719958d39274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->