### PR TITLE
SNOW-1023317: Support RELY on PRIMARY KEY / FOREIGN KEY / UNIQUE constraints

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
 - Document SSO/Okta authentication via the `authenticator` connect_args parameter (SNOW-715550).
 - Document how to enable connector bulk array binding for large `executemany` inserts via `qmark` paramstyle (SNOW-710474).
 - Document using a SQLAlchemy `VALUES` source with `MergeInto` (no staging table needed) (SNOW-889678 / GH #435).

--- a/README.md
+++ b/README.md
@@ -946,6 +946,37 @@ stmt = select(my_table).where(
 )
 ```
 
+### RELY Constraint Property
+
+Snowflake does not enforce `PRIMARY KEY`, `UNIQUE`, or `FOREIGN KEY` constraints — they are metadata only. The `RELY` property tells the query optimizer it may **trust** such a constraint for rewrites like join elimination, even though it isn't enforced. Set the opt-in `snowflake_rely=True` dialect keyword on a constraint to emit it:
+
+```python
+from sqlalchemy import (
+    Column, ForeignKeyConstraint, Integer, MetaData,
+    PrimaryKeyConstraint, String, Table, UniqueConstraint,
+)
+
+metadata = MetaData()
+
+dim = Table(
+    "dim", metadata,
+    Column("id", Integer),
+    Column("email", String),
+    PrimaryKeyConstraint("id", snowflake_rely=True),
+    UniqueConstraint("email", snowflake_rely=True),
+)
+# ... PRIMARY KEY (id) RELY ... UNIQUE (email) RELY
+
+fact = Table(
+    "fact", metadata,
+    Column("dim_id", Integer),
+    ForeignKeyConstraint(["dim_id"], ["dim.id"], snowflake_rely=True),
+)
+# ... FOREIGN KEY(dim_id) REFERENCES dim (id) RELY
+```
+
+> **Warning:** `RELY` is an unverified promise. Snowflake trusts it without checking the data. If the data actually violates the constraint (duplicate keys, orphan foreign keys), the optimizer may rewrite queries based on a false assumption and return **incorrect results**. Only set `snowflake_rely=True` when you are certain the data satisfies the constraint. It defaults to off, so existing DDL is unaffected.
+
 ### Alembic Support
 
 [Alembic](http://alembic.zzzcomputing.com) is a database migration tool on top of `SQLAlchemy`. Snowflake SQLAlchemy works by adding the following code to `alembic/env.py` so that Alembic can recognize Snowflake SQLAlchemy.

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -18,7 +18,13 @@ from sqlalchemy.engine import default
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.orm import context
 from sqlalchemy.orm.context import _MapperEntity
-from sqlalchemy.schema import Sequence, Table
+from sqlalchemy.schema import (
+    ForeignKeyConstraint,
+    PrimaryKeyConstraint,
+    Sequence,
+    Table,
+    UniqueConstraint,
+)
 from sqlalchemy.sql import compiler, expression, functions, sqltypes
 from sqlalchemy.sql.base import CompileState
 from sqlalchemy.sql.ddl import DropColumnComment, DropTableComment
@@ -1300,6 +1306,35 @@ class SnowflakeDDLCompiler(compiler.DDLCompiler):
             raise CustomOptionsAreOnlySupportedOnSnowflakeTables()
 
         return text
+
+    def _append_rely(self, constraint: Any, text: str) -> str:
+        """Append the Snowflake ``RELY`` constraint property when opted in.
+
+        Snowflake does not enforce PRIMARY KEY / UNIQUE / FOREIGN KEY
+        constraints; ``RELY`` tells the optimizer it may trust them for query
+        rewrites such as join elimination. It is opt-in per constraint via the
+        ``snowflake_rely=True`` dialect keyword (SNOW-1023317) and defaults off
+        so existing DDL is unchanged.
+        """
+        if text and constraint.dialect_options[DIALECT_NAME].get("rely"):
+            text += " RELY"
+        return text
+
+    def visit_primary_key_constraint(
+        self, constraint: PrimaryKeyConstraint, **kw: Any
+    ) -> str:
+        text = super().visit_primary_key_constraint(constraint, **kw)
+        return self._append_rely(constraint, text)
+
+    def visit_foreign_key_constraint(
+        self, constraint: ForeignKeyConstraint, **kw: Any
+    ) -> str:
+        text = super().visit_foreign_key_constraint(constraint, **kw)
+        return self._append_rely(constraint, text)
+
+    def visit_unique_constraint(self, constraint: UniqueConstraint, **kw: Any) -> str:
+        text = super().visit_unique_constraint(constraint, **kw)
+        return self._append_rely(constraint, text)
 
     def _format_stage_prefix(self, stage) -> str:
         """Identifier-quote a stage's ``<namespace>.<name>`` prefix.

--- a/tests/test_rely.py
+++ b/tests/test_rely.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from sqlalchemy import (
+    Column,
+    ForeignKeyConstraint,
+    Integer,
+    MetaData,
+    PrimaryKeyConstraint,
+    String,
+    Table,
+    UniqueConstraint,
+)
+from sqlalchemy.schema import CreateTable
+
+
+def test_primary_key_rely(sql_compiler):
+    """snowflake_rely=True renders RELY on a PRIMARY KEY constraint (SNOW-1023317)."""
+    metadata = MetaData()
+    table = Table(
+        "t_pk",
+        metadata,
+        Column("id", Integer),
+        PrimaryKeyConstraint("id", snowflake_rely=True),
+    )
+    ddl = sql_compiler(CreateTable(table))
+    assert "PRIMARY KEY (id) RELY" in ddl
+
+
+def test_foreign_key_rely(sql_compiler):
+    """snowflake_rely=True renders RELY on a FOREIGN KEY constraint (SNOW-1023317)."""
+    metadata = MetaData()
+    Table("parent", metadata, Column("id", Integer, primary_key=True))
+    child = Table(
+        "child",
+        metadata,
+        Column("pid", Integer),
+        ForeignKeyConstraint(["pid"], ["parent.id"], snowflake_rely=True),
+    )
+    ddl = sql_compiler(CreateTable(child))
+    assert "REFERENCES parent (id) RELY" in ddl
+
+
+def test_unique_constraint_rely(sql_compiler):
+    """snowflake_rely=True renders RELY on a UNIQUE constraint (SNOW-1023317)."""
+    metadata = MetaData()
+    table = Table(
+        "t_uq",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("email", String),
+        UniqueConstraint("email", snowflake_rely=True),
+    )
+    ddl = sql_compiler(CreateTable(table))
+    assert "UNIQUE (email) RELY" in ddl
+
+
+def test_no_rely_by_default(sql_compiler):
+    """Constraints without snowflake_rely are unchanged (no RELY emitted)."""
+    metadata = MetaData()
+    table = Table(
+        "t_default",
+        metadata,
+        Column("id", Integer),
+        PrimaryKeyConstraint("id"),
+    )
+    ddl = sql_compiler(CreateTable(table))
+    assert "RELY" not in ddl
+    assert "PRIMARY KEY (id)" in ddl
+
+
+def test_rely_false_does_not_render(sql_compiler):
+    """snowflake_rely=False behaves like the default (no RELY)."""
+    metadata = MetaData()
+    table = Table(
+        "t_false",
+        metadata,
+        Column("id", Integer),
+        PrimaryKeyConstraint("id", snowflake_rely=False),
+    )
+    ddl = sql_compiler(CreateTable(table))
+    assert "RELY" not in ddl


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #463

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Snowflake does not enforce PRIMARY KEY / UNIQUE / FOREIGN KEY constraints; the `RELY` property lets the optimizer trust them for query rewrites (e.g. join elimination). This adds an opt-in `snowflake_rely=True` dialect keyword on those constraints. `SnowflakeDDLCompiler` overrides `visit_primary_key_constraint`, `visit_foreign_key_constraint`, and `visit_unique_constraint` to call `super()` and append ` RELY` when `constraint.dialect_options["snowflake"].get("rely")` is truthy (mirroring the existing `snowflake_clusterby` pattern). It defaults off, so generated DDL and query results are unchanged unless the user explicitly opts in — important because `RELY` is an unverified promise and, if the data violates the constraint, the optimizer could return incorrect results. Added unit tests in `tests/test_rely.py` (PK/FK/UNIQUE positive, default-off, and `rely=False`) and README documentation with a correctness warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in DDL only, but enabling RELY on constraints that data does not actually satisfy can cause the Snowflake optimizer to return incorrect results; the change is limited to constraint compilation, not runtime queries.
> 
> **Overview**
> Adds **opt-in `snowflake_rely=True`** on `PrimaryKeyConstraint`, `ForeignKeyConstraint`, and `UniqueConstraint` so compiled DDL appends Snowflake **`RELY`** (e.g. `PRIMARY KEY (id) RELY`), enabling the optimizer to trust metadata-only constraints for rewrites such as join elimination.
> 
> `SnowflakeDDLCompiler` delegates to the base constraint visitors and appends ` RELY` when the Snowflake dialect option `rely` is set; it stays **off by default**, so existing DDL is unchanged unless callers opt in.
> 
> README and release notes document usage and warn that **`RELY` is unverified**—bad data can yield **wrong query results** if the optimizer relies on a false assumption.
> 
> Adds **`tests/test_rely.py`** covering PK/FK/UNIQUE with `snowflake_rely=True`, default-off behavior, and `snowflake_rely=False` (fixes #463 / SNOW-1023317).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b3d81748daab19d4519b3ae2ab69bbbc200174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->