### PR TITLE
SNOW-796954: Paginate object-listing SHOW commands for schemas with >10,000 objects

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Fix reflection failing on schemas/databases with more than 10,000 objects by paginating the underlying object-listing `SHOW` commands (`get_table_names`, `get_view_names`, `get_temp_table_names`, `get_schema_names`, `get_sequence_names`) with `LIMIT ... FROM ...` (SNOW-796954 / GH #406).
 - Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
 - Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).
 - Fix `URL` failing to encode `[`, `]`, `?` and `#` in passwords, which produced connect strings that could not be parsed (SNOW-828206 / GH #415).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Table of contents:
     * [UUID Data Type Support](#uuid-data-type-support)
     * [Cache Column Metadata](#cache-column-metadata)
     * [Cross-Database Reflection](#cross-database-reflection)
+    * [Reflecting Large Schemas (10,000+ objects)](#reflecting-large-schemas-10000-objects)
     * [VARIANT, ARRAY and OBJECT Support](#variant-array-and-object-support)
     * [Structured Data Types Support](#structured-data-types-support)
       * [MAP](#map)
@@ -785,6 +786,56 @@ table = Table('mytable', metadata, schema='database_b."my.schema"', autoload_wit
 ```
 
 The SQL compilation layer already treats unquoted dots as separators. This cross-database reflection feature makes the reflection layer consistent with that existing behavior.
+
+### Reflecting Large Schemas (10,000+ objects)
+
+Snowflake `SHOW` commands return at most **10,000 rows** per call. Reflection helpers that list objects in a schema issue `SHOW ... IN SCHEMA`, so before this was addressed a schema (or database) with more than 10,000 objects would fail with an error like:
+
+```
+090201 (22000): SHOW ... returned more than the maximum of 10000 results.
+Use LIMIT to reduce the number of results.
+```
+
+Snowflake SQLAlchemy now transparently pages through these object-listing `SHOW` commands using `LIMIT <n> FROM '<last_name>'`, so reflection works regardless of object count. No code change is required on your side:
+
+```python
+from sqlalchemy import create_engine, inspect
+
+engine = create_engine("snowflake://<user>:<password>@<account>/<db>/<schema>")
+inspector = inspect(engine)
+
+# All of these page automatically and no longer fail past 10,000 objects:
+inspector.get_table_names(schema="my_schema")     # SHOW TABLES IN SCHEMA
+inspector.get_view_names(schema="my_schema")      # SHOW VIEWS IN
+inspector.get_sequence_names(schema="my_schema")  # SHOW SEQUENCES IN SCHEMA
+inspector.get_schema_names()                       # SHOW SCHEMAS
+inspector.get_temp_table_names(schema="my_schema")  # SHOW TABLES IN SCHEMA (temp)
+```
+
+`MetaData.reflect()` / `Table(..., autoload_with=engine)` benefit as well, since they call these helpers internally.
+
+#### How paging works
+
+Each command is fetched in pages ordered lexicographically by object name; each page after the first seeks past the previous page's last name:
+
+```sql
+SHOW TABLES IN SCHEMA "MY_DB"."MY_SCHEMA" LIMIT 10000
+SHOW TABLES IN SCHEMA "MY_DB"."MY_SCHEMA" LIMIT 10000 FROM '<last name of previous page>'
+-- ...repeated until a page returns fewer than 10000 rows
+```
+
+The page size defaults to Snowflake's 10,000 maximum. It is exposed as `SnowflakeDialect._SHOW_TABLES_PAGE_SIZE` (clamped to 1–10,000) primarily so tests can exercise the paging loop with a small value; you normally do not need to change it.
+
+#### Known limitations
+
+Only the **object-listing** `SHOW ... IN [SCHEMA]` commands are paged (tables, views, temp tables, schemas, sequences). The **schema-wide constraint/index** commands are *not* yet paged and can still hit the 10,000-row cap on very large schemas when using the bulk `MetaData.reflect()` path:
+
+- `SHOW PRIMARY KEYS IN SCHEMA`
+- `SHOW UNIQUE KEYS IN SCHEMA`
+- `SHOW IMPORTED KEYS IN SCHEMA`
+- `SHOW INDEXES IN SCHEMA`
+
+These lack a `name` column to page by and generally do not support `LIMIT ... FROM`, so they require a different approach (per-table fallback) tracked separately. Reflecting a **single** table's primary key, unique/foreign keys, or indexes is unaffected — those use the bounded `SHOW ... IN TABLE` form. Single-object lookups such as `get_view_definition()` (`SHOW VIEWS LIKE ...`) are likewise unaffected.
 
 ### VARIANT, ARRAY and OBJECT Support
 

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -161,6 +161,11 @@ class SnowflakeDialect(default.DefaultDialect):
     max_identifier_length = 255
     cte_follows_insert = True
 
+    # Snowflake SHOW commands cap output at 10,000 rows; _get_schema_tables_info
+    # pages through SHOW TABLES using this size (SNOW-796954). Overridable so the
+    # pagination loop can be unit-tested without creating 10,000+ tables.
+    _SHOW_TABLES_PAGE_SIZE = 10000
+
     # TODO: support SQL caching, for more info see: https://docs.sqlalchemy.org/en/14/core/connections.html#caching-for-third-party-dialects
     supports_statement_cache = False
 
@@ -1650,28 +1655,76 @@ class SnowflakeDialect(default.DefaultDialect):
                 return None
             raise
 
+    def _show_in_schema_rows(
+        self, connection: Connection, show_sql_prefix: str
+    ) -> tuple[dict[str, int], list[Any]]:
+        """Run an object-listing ``SHOW`` command with pagination and return
+        ``(name_to_index_map, all_rows)``.
+
+        Snowflake ``SHOW`` commands cap their output at 10,000 rows, so larger
+        object sets are paged past the previous page's last ``name`` using
+        ``LIMIT ... FROM ...`` (SNOW-796954). Only valid for ``SHOW`` commands
+        that expose a ``name`` column and support ``LIMIT ... FROM`` (e.g.
+        TABLES, VIEWS, SCHEMAS, SEQUENCES). ``show_sql_prefix`` is the full
+        command up to but excluding ``LIMIT``.
+        """
+        # Snowflake caps SHOW output at 10,000 rows and rejects a larger LIMIT,
+        # so clamp any override into the valid 1..10,000 range.
+        page_size = max(1, min(10000, int(self._SHOW_TABLES_PAGE_SIZE)))
+        from_name: str | None = None
+        prev_from_name: str | None = None
+        all_rows: list[Any] = []
+        name_to_index_map: dict[str, int] = {}
+
+        while True:
+            paging = "" if from_name is None else f" FROM '{from_name}'"
+            result = connection.execute(
+                text(f"{show_sql_prefix} LIMIT {page_size}{paging}")
+            )
+            name_to_index_map = self._map_name_to_idx(result)
+            rows = result.cursor.fetchall()
+            all_rows.extend(rows)
+
+            # A short page means we've reached the end.
+            if len(rows) < page_size:
+                break
+            # The FROM cursor is a case-sensitive string literal, so page past the
+            # raw SHOW output name (escaped) of the last row.
+            from_name = escape_string_literal_interior(
+                str(rows[-1][name_to_index_map["name"]])
+            )
+            # Defensive guard: SHOW ... FROM returns names strictly greater than
+            # the cursor, so it must advance every full page. If it does not
+            # (unexpected server behavior), stop instead of looping forever.
+            if from_name == prev_from_name:
+                break
+            prev_from_name = from_name
+
+        return name_to_index_map, all_rows
+
     @reflection.cache
     def _get_schema_tables_info(
         self, connection: Connection, schema: str | None = None, **kw: Any
     ) -> Any:
         """
         Retrieves information about all tables in the specified schema.
+
+        ``SHOW TABLES`` is retained (rather than ``INFORMATION_SCHEMA``) so the
+        row shape consumed by ``get_prefixes_from_data`` — and the ``SHOW``
+        privilege semantics — stay unchanged; the 10,000-row cap is handled by
+        ``_show_in_schema_rows`` (SNOW-796954).
         """
-
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
-        result = connection.execute(
-            text(
-                f"SHOW /* sqlalchemy:get_schema_tables_info */ TABLES IN SCHEMA {full_schema_name}"
-            )
+        name_to_index_map, rows = self._show_in_schema_rows(
+            connection,
+            "SHOW /* sqlalchemy:get_schema_tables_info */ "
+            f"TABLES IN SCHEMA {full_schema_name}",
         )
-
-        name_to_index_map = self._map_name_to_idx(result)
         tables = {}
-        for row in result.cursor.fetchall():
+        for row in rows:
             table_name = self.normalize_name(str(row[name_to_index_map["name"]]))
             table_prefixes = self.get_prefixes_from_data(name_to_index_map, row)
             tables[table_name] = {"prefixes": table_prefixes}
-
         return tables
 
     def get_table_names(
@@ -1693,11 +1746,11 @@ class SnowflakeDialect(default.DefaultDialect):
         Gets all view names
         """
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
-        cursor = connection.execute(
-            text(f"SHOW /* sqlalchemy:get_view_names */ VIEWS IN {full_schema_name}")
+        _, rows = self._show_in_schema_rows(
+            connection,
+            f"SHOW /* sqlalchemy:get_view_names */ VIEWS IN {full_schema_name}",
         )
-
-        return [self.normalize_name(row[1]) for row in cursor]  # type: ignore[misc]
+        return [self.normalize_name(row[1]) for row in rows]  # type: ignore[misc]
 
     @reflection.cache
     def get_view_definition(
@@ -1744,15 +1797,14 @@ class SnowflakeDialect(default.DefaultDialect):
         self, connection: Connection, schema: str | None = None, **kw: Any
     ) -> list[str]:
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
-        cursor = connection.execute(
-            text(
-                f"SHOW /* sqlalchemy:get_temp_table_names */ TABLES IN SCHEMA {full_schema_name}"
-            )
+        name_to_index_map, rows = self._show_in_schema_rows(
+            connection,
+            "SHOW /* sqlalchemy:get_temp_table_names */ "
+            f"TABLES IN SCHEMA {full_schema_name}",
         )
 
         ret = []
-        name_to_index_map = self.__class__._map_name_to_idx(cursor)
-        for row in cursor:
+        for row in rows:
             if row[name_to_index_map["kind"]] == "TEMPORARY":
                 ret.append(self.normalize_name(row[name_to_index_map["name"]]))
 
@@ -1762,21 +1814,21 @@ class SnowflakeDialect(default.DefaultDialect):
         """
         Gets all schema names.
         """
-        cursor = connection.execute(
-            text("SHOW /* sqlalchemy:get_schema_names */ SCHEMAS")
+        _, rows = self._show_in_schema_rows(
+            connection, "SHOW /* sqlalchemy:get_schema_names */ SCHEMAS"
         )
-
-        return [self.normalize_name(row[1]) for row in cursor]  # type: ignore[misc]
+        return [self.normalize_name(row[1]) for row in rows]  # type: ignore[misc]
 
     @reflection.cache
     def get_sequence_names(
         self, connection: Connection, schema: str | None = None, **kw: Any
     ) -> list[str]:
         full_schema_name = self._get_full_schema_name(connection, schema, **kw)
-        sql_command = f"SHOW SEQUENCES IN SCHEMA {full_schema_name}"
         try:
-            cursor = connection.execute(text(sql_command))
-            return [self.normalize_name(row[0]) for row in cursor]  # type: ignore[misc]
+            _, rows = self._show_in_schema_rows(
+                connection, f"SHOW SEQUENCES IN SCHEMA {full_schema_name}"
+            )
+            return [self.normalize_name(row[0]) for row in rows]  # type: ignore[misc]
         except sa_exc.ProgrammingError as pe:
             if getattr(pe.orig, "errno", None) == 2003:
                 # Schema does not exist

--- a/tests/test_unit_large_schema_tables.py
+++ b/tests/test_unit_large_schema_tables.py
@@ -1,0 +1,383 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+"""Unit tests for paginated table reflection (SNOW-796954 / GH #406).
+
+Snowflake ``SHOW`` commands cap output at 10,000 rows, so ``_get_schema_tables_info``
+pages through ``SHOW TABLES`` with ``LIMIT ... FROM ...``. The 10k cap is server-side,
+so these tests never create real tables: they mock ``connection.execute`` with tiny
+synthetic result sets and shrink ``_SHOW_TABLES_PAGE_SIZE`` so multi-page behavior is
+exercised with a handful of rows.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+# Column layout of ``SHOW TABLES`` output that _map_name_to_idx / get_prefixes_from_data
+# rely on: index 1 is ``name`` and the ``is_*`` flags drive prefix detection.
+SHOW_DESCRIPTION = [
+    ("created_on",),
+    ("name",),
+    ("database_name",),
+    ("schema_name",),
+    ("kind",),
+    ("comment",),
+    ("cluster_by",),
+    ("rows",),
+    ("bytes",),
+    ("owner",),
+    ("retention_time",),
+    ("is_external",),
+    ("is_event",),
+    ("is_hybrid",),
+    ("is_iceberg",),
+    ("is_dynamic",),
+]
+_IDX = {col[0]: i for i, col in enumerate(SHOW_DESCRIPTION)}
+
+
+def _row(name, *, hybrid=False, iceberg=False, dynamic=False, kind="TABLE"):
+    row = [None] * len(SHOW_DESCRIPTION)
+    row[_IDX["name"]] = name
+    row[_IDX["kind"]] = kind
+    row[_IDX["is_external"]] = "N"
+    row[_IDX["is_event"]] = "N"
+    row[_IDX["is_hybrid"]] = "Y" if hybrid else "N"
+    row[_IDX["is_iceberg"]] = "Y" if iceberg else "N"
+    row[_IDX["is_dynamic"]] = "Y" if dynamic else "N"
+    return row
+
+
+def _result_with(rows, description):
+    """Mock CursorResult with an arbitrary column description."""
+    result = MagicMock()
+    result.cursor.description = description
+    result.cursor.fetchall.return_value = rows
+    return result
+
+
+def _dialect_with_results(results, page_size=2):
+    """Dialect whose connection.execute yields each prebuilt result in turn."""
+    dialect = SnowflakeDialect()
+    dialect._SHOW_TABLES_PAGE_SIZE = page_size
+    dialect._get_full_schema_name = MagicMock(return_value='"MYDB"."MYSCHEMA"')
+    conn = MagicMock()
+    conn.execute.side_effect = list(results)
+    return dialect, conn
+
+
+def _result_for(rows):
+    result = MagicMock()
+    result.cursor.description = SHOW_DESCRIPTION
+    result.cursor.fetchall.return_value = rows
+    return result
+
+
+def _dialect_with_pages(pages, page_size=2):
+    """A dialect whose connection returns each page in turn from execute()."""
+    dialect = SnowflakeDialect()
+    dialect._SHOW_TABLES_PAGE_SIZE = page_size
+    dialect._get_full_schema_name = MagicMock(return_value='"MYDB"."MYSCHEMA"')
+
+    conn = MagicMock()
+    conn.execute.side_effect = [_result_for(p) for p in pages]
+    return dialect, conn
+
+
+def test_single_page_partial_stops_immediately():
+    """A page smaller than page_size ends pagination after one call."""
+    dialect, conn = _dialect_with_pages([[_row("ALPHA")]], page_size=2)
+    tables = dialect._get_schema_tables_info(conn, schema="myschema")
+    assert set(tables) == {"alpha"}
+    assert conn.execute.call_count == 1
+    assert "LIMIT 2" in str(conn.execute.call_args_list[0][0][0])
+    # First page must not carry a FROM cursor.
+    assert "FROM" not in str(conn.execute.call_args_list[0][0][0])
+
+
+def test_multi_page_collects_all_rows():
+    """Full pages are followed until a short page is returned (5 rows / 3 pages)."""
+    pages = [
+        [_row("ALPHA"), _row("BRAVO")],  # full
+        [_row("CHARLIE"), _row("DELTA")],  # full
+        [_row("ECHO")],  # partial -> stop
+    ]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    tables = dialect._get_schema_tables_info(conn, schema="myschema")
+    assert set(tables) == {"alpha", "bravo", "charlie", "delta", "echo"}
+    assert conn.execute.call_count == 3
+
+
+def test_exact_page_size_triggers_extra_empty_fetch():
+    """When the last data page is exactly full, one more (empty) fetch ends the loop."""
+    pages = [
+        [_row("TABLE_A"), _row("TABLE_B")],  # full
+        [_row("TABLE_C"), _row("TABLE_D")],  # full
+        [],  # empty -> stop
+    ]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    tables = dialect._get_schema_tables_info(conn, schema="myschema")
+    assert len(tables) == 4
+    assert conn.execute.call_count == 3
+
+
+def test_from_cursor_uses_last_raw_name():
+    """Page 2+ pages with FROM '<last raw name from previous page>'."""
+    pages = [[_row("Alpha"), _row("Bravo")], [_row("Charlie")]]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    dialect._get_schema_tables_info(conn, schema="myschema")
+
+    sql_page1 = str(conn.execute.call_args_list[0][0][0])
+    sql_page2 = str(conn.execute.call_args_list[1][0][0])
+    assert "FROM" not in sql_page1
+    # Raw (non-normalized) name is used for the case-sensitive FROM literal.
+    assert "FROM 'Bravo'" in sql_page2
+
+
+def test_empty_schema_returns_empty_dict():
+    dialect, conn = _dialect_with_pages([[]], page_size=2)
+    tables = dialect._get_schema_tables_info(conn, schema="myschema")
+    assert tables == {}
+    assert conn.execute.call_count == 1
+
+
+def test_prefixes_preserved_across_pages():
+    """HYBRID/ICEBERG/DYNAMIC detection survives pagination."""
+    pages = [
+        [_row("H", hybrid=True), _row("I", iceberg=True)],  # full
+        [_row("D", dynamic=True)],  # partial -> stop
+    ]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    tables = dialect._get_schema_tables_info(conn, schema="myschema")
+    assert tables["h"]["prefixes"] == ["HYBRID"]
+    assert tables["i"]["prefixes"] == ["ICEBERG"]
+    assert tables["d"]["prefixes"] == ["DYNAMIC"]
+
+
+def test_from_literal_is_escaped():
+    """A single quote in a table name is escaped inside the FROM literal."""
+    pages = [[_row("O'HARA"), _row("PLAIN")], [_row("ZED")]]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    dialect._get_schema_tables_info(conn, schema="myschema")
+    sql_page2 = str(conn.execute.call_args_list[1][0][0])
+    # escape_string_literal_interior doubles the quote so the literal stays valid.
+    assert "FROM 'PLAIN'" in sql_page2  # last row of page 1 drives the cursor
+
+    # And a quote in the cursor name is doubled, not left raw.
+    pages2 = [[_row("A"), _row("O'HARA")], [_row("B")]]
+    dialect2, conn2 = _dialect_with_pages(pages2, page_size=2)
+    dialect2._get_schema_tables_info(conn2, schema="myschema")
+    assert "FROM 'O''HARA'" in str(conn2.execute.call_args_list[1][0][0])
+
+
+def test_get_table_names_returns_keys():
+    pages = [[_row("ALPHA"), _row("BRAVO")], [_row("CHARLIE")]]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    names = dialect.get_table_names(conn, schema="myschema")
+    assert sorted(names) == ["alpha", "bravo", "charlie"]
+
+
+def test_get_table_names_with_prefix_filters():
+    pages = [[_row("PLAIN"), _row("HYB", hybrid=True)]]
+    dialect, conn = _dialect_with_pages(pages, page_size=5)
+    hybrids = dialect.get_table_names_with_prefix(
+        conn, schema="myschema", prefix="HYBRID"
+    )
+    assert hybrids == ["hyb"]
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_default_page_size_is_10000(n):
+    """The production default remains 10,000 (single fetch for small schemas)."""
+    dialect = SnowflakeDialect()
+    assert dialect._SHOW_TABLES_PAGE_SIZE == 10000
+    dialect._get_full_schema_name = MagicMock(return_value='"D"."S"')
+    conn = MagicMock()
+    conn.execute.side_effect = [_result_for([_row(f"T{i}") for i in range(n)])]
+    tables = dialect._get_schema_tables_info(conn, schema="s")
+    assert len(tables) == n
+    assert conn.execute.call_count == 1
+    assert "LIMIT 10000" in str(conn.execute.call_args_list[0][0][0])
+
+
+def test_page_size_zero_is_clamped_to_one():
+    """A misconfigured page size of 0 must not crash (clamped to >=1)."""
+    dialect, conn = _dialect_with_pages([[_row("A")], []], page_size=0)
+    tables = dialect._get_schema_tables_info(conn, schema="myschema")
+    assert set(tables) == {"a"}
+    assert "LIMIT 1" in str(conn.execute.call_args_list[0][0][0])
+
+
+def test_page_size_over_max_is_clamped_to_10000():
+    """Snowflake rejects LIMIT > 10000, so an oversized override is clamped."""
+    dialect, conn = _dialect_with_pages([[_row("A")]], page_size=25000)
+    dialect._get_schema_tables_info(conn, schema="myschema")
+    assert "LIMIT 10000" in str(conn.execute.call_args_list[0][0][0])
+
+
+def test_non_advancing_cursor_does_not_loop_forever():
+    """If SHOW keeps returning the same full page, the guard stops the loop."""
+    dialect = SnowflakeDialect()
+    dialect._SHOW_TABLES_PAGE_SIZE = 2
+    dialect._get_full_schema_name = MagicMock(return_value='"D"."S"')
+    conn = MagicMock()
+    # Infinite supply of an identical full page (last name never advances).
+    conn.execute.side_effect = lambda *a, **k: _result_for([_row("A"), _row("B")])
+    tables = dialect._get_schema_tables_info(conn, schema="s")
+    assert set(tables) == {"a", "b"}
+    # Page 1 sets cursor 'B'; page 2 yields 'B' again -> guard breaks. No hang.
+    assert conn.execute.call_count == 2
+
+
+def test_from_cursor_escapes_backslash():
+    """A backslash in the cursor name is doubled in the FROM literal."""
+    pages = [[_row("A"), _row("back\\slash")], [_row("Z")]]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    dialect._get_schema_tables_info(conn, schema="myschema")
+    sql_page2 = str(conn.execute.call_args_list[1][0][0])
+    assert "FROM 'back\\\\slash'" in sql_page2
+
+
+@pytest.mark.parametrize(
+    "evil_name",
+    [
+        "tab'; DROP TABLE x; --",  # quote-breakout + statement injection
+        "trailing_backslash\\",  # trailing \ must not escape the closing quote
+        "quote'inside",  # embedded single quote
+        "backslash_quote\\'",  # \ immediately before a quote
+        "both\\'; SELECT 1; --",  # combined backslash + quote payload
+    ],
+)
+def test_from_cursor_is_injection_safe(evil_name):
+    """The FROM cursor fully escapes both ' and \\ so no payload can break out.
+
+    Locks in the secure ``escape_string_literal_interior`` behavior: switching to
+    single-quote-only escaping (which would leave a trailing backslash able to
+    escape the closing quote) makes this test fail.
+    """
+    from snowflake.sqlalchemy.util import escape_string_literal_interior
+
+    # Put the hostile name last on page 1 so it becomes the FROM cursor.
+    pages = [[_row("aaa"), _row(evil_name)], [_row("zzz")]]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    dialect._get_schema_tables_info(conn, schema="myschema")
+
+    sql_page2 = str(conn.execute.call_args_list[1][0][0])
+    expected = f"FROM '{escape_string_literal_interior(evil_name)}'"
+    assert expected in sql_page2
+
+    # The literal body must have every quote and backslash doubled (even counts),
+    # so the single-quoted string cannot be terminated early.
+    body = sql_page2.split("FROM '", 1)[1].rsplit("'", 1)[0]
+    assert body.count("'") % 2 == 0
+    assert (len(body) - len(body.replace("\\", ""))) % 2 == 0
+
+
+def test_pagination_traverses_real_catalog_semantics():
+    """End-to-end pagination against a fake server that honors LIMIT/FROM.
+
+    This models Snowflake's documented contract (FROM returns names strictly
+    greater than the cursor, ordered lexicographically) rather than blindly
+    replaying canned pages, proving the cursor logic actually traverses.
+    """
+    import re
+
+    catalog = sorted(f"T{i:03d}" for i in range(23))  # 23 tables, page size 5
+
+    dialect = SnowflakeDialect()
+    dialect._SHOW_TABLES_PAGE_SIZE = 5
+    dialect._get_full_schema_name = MagicMock(return_value='"D"."S"')
+
+    def fake_execute(stmt, *a, **k):
+        sql = str(stmt)
+        m = re.search(r"LIMIT (\d+)", sql)
+        limit = int(m.group(1))
+        cursor = None
+        fm = re.search(r"FROM '([^']*)'", sql)
+        if fm:
+            cursor = fm.group(1)
+        after = [n for n in catalog if cursor is None or n > cursor]
+        return _result_for([_row(n) for n in after[:limit]])
+
+    conn = MagicMock()
+    conn.execute.side_effect = fake_execute
+    tables = dialect._get_schema_tables_info(conn, schema="s")
+
+    assert set(tables) == {n.lower() for n in catalog}
+    # 23 rows / 5 per page = 5 pages (last partial), so 5 execute calls.
+    assert conn.execute.call_count == 5
+
+
+# --- Other object-listing SHOW commands now share the pagination helper -------
+
+# SHOW VIEWS / SHOW SCHEMAS expose `name` at column index 1.
+_NAME_AT_1 = [("created_on",), ("name",)]
+# SHOW SEQUENCES: get_sequence_names reads column 0, which is also `name`.
+_NAME_AT_0 = [("name",), ("created_on",)]
+
+
+def test_get_view_names_paginates():
+    results = [
+        _result_with([["c", "AV"], ["c", "BV"]], _NAME_AT_1),  # full
+        _result_with([["c", "CV"]], _NAME_AT_1),  # partial -> stop
+    ]
+    dialect, conn = _dialect_with_results(results, page_size=2)
+    names = dialect.get_view_names(conn, schema="myschema")
+    assert names == ["av", "bv", "cv"]
+    assert conn.execute.call_count == 2
+    assert "VIEWS IN" in str(conn.execute.call_args_list[0][0][0])
+    assert "FROM 'BV'" in str(conn.execute.call_args_list[1][0][0])
+
+
+def test_get_schema_names_paginates():
+    results = [
+        _result_with([["c", "S1"], ["c", "S2"]], _NAME_AT_1),
+        _result_with([["c", "S3"]], _NAME_AT_1),
+    ]
+    dialect, conn = _dialect_with_results(results, page_size=2)
+    names = dialect.get_schema_names(conn)
+    assert names == ["s1", "s2", "s3"]
+    assert conn.execute.call_count == 2
+    assert "SCHEMAS" in str(conn.execute.call_args_list[0][0][0])
+
+
+def test_get_sequence_names_paginates():
+    results = [
+        _result_with([["SEQ_A", "c"], ["SEQ_B", "c"]], _NAME_AT_0),
+        _result_with([["SEQ_C", "c"]], _NAME_AT_0),
+    ]
+    dialect, conn = _dialect_with_results(results, page_size=2)
+    names = dialect.get_sequence_names(conn, schema="myschema")
+    assert names == ["seq_a", "seq_b", "seq_c"]
+    assert conn.execute.call_count == 2
+    assert "FROM 'SEQ_B'" in str(conn.execute.call_args_list[1][0][0])
+
+
+def test_get_sequence_names_missing_schema_returns_empty():
+    """The 2003 (schema does not exist) fallback is preserved through the helper."""
+    from sqlalchemy import exc as sa_exc
+
+    class _Orig(Exception):
+        errno = 2003
+
+    dialect = SnowflakeDialect()
+    dialect._get_full_schema_name = MagicMock(return_value='"D"."NOPE"')
+    conn = MagicMock()
+    conn.execute.side_effect = sa_exc.ProgrammingError("SHOW SEQUENCES", {}, _Orig())
+    assert dialect.get_sequence_names(conn, schema="nope") == []
+
+
+def test_get_temp_table_names_paginates_and_filters():
+    """Temp-table filtering by `kind` still works across paged SHOW TABLES."""
+    pages = [
+        [_row("REG1"), _row("TMP1", kind="TEMPORARY")],  # full
+        [_row("TMP2", kind="TEMPORARY")],  # partial -> stop
+    ]
+    dialect, conn = _dialect_with_pages(pages, page_size=2)
+    names = dialect.get_temp_table_names(conn, schema="myschema")
+    assert names == ["tmp1", "tmp2"]
+    assert conn.execute.call_count == 2


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #406

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Snowflake `SHOW` commands cap their output at 10,000 rows, so schema/database reflection that lists objects via `SHOW ... IN SCHEMA` failed on large schemas (originally reported for `get_table_names` with >10,000 tables). There was no fallback on this path — the `SHOW` simply errored.

   This adds a shared `_show_in_schema_rows` helper that transparently pages through an object-listing `SHOW` command using `LIMIT <n> FROM '<last_name>'`, and applies it to all five object-listing reflectors:
   - `_get_schema_tables_info` (backing `get_table_names` / `get_table_names_with_prefix`) — `SHOW TABLES IN SCHEMA`
   - `get_view_names` — `SHOW VIEWS IN`
   - `get_temp_table_names` — `SHOW TABLES IN SCHEMA`
   - `get_schema_names` — `SHOW SCHEMAS`
   - `get_sequence_names` — `SHOW SEQUENCES IN SCHEMA`

   Design notes:
   - `SHOW TABLES` is retained rather than switching to `INFORMATION_SCHEMA` so the row shape consumed by `get_prefixes_from_data` (HYBRID/ICEBERG/DYNAMIC detection) and the `SHOW` privilege semantics stay unchanged. Each caller keeps its exact original row parsing, so behavior is identical apart from fixing the >10k failure — the return shapes are unchanged (backwards-compatible).
   - The `FROM` cursor uses the previous page's raw (non-normalized) `name`, escaped with the existing `escape_string_literal_interior` (doubles both `'` and `\`, injection-safe), since `SHOW ... FROM` is a case-sensitive string literal.
   - Page size is a clamped (1..10,000), overridable class constant `_SHOW_TABLES_PAGE_SIZE` so the paging loop is unit-tested without creating 10k+ objects. A defensive guard stops the loop if the cursor ever fails to advance.

   Out of scope (follow-up): the schema-wide keyed commands (`SHOW PRIMARY/UNIQUE/IMPORTED KEYS`, `SHOW INDEXES IN SCHEMA`) also cap at 10,000 rows, but they have no `name` column to page by and generally do not support `LIMIT ... FROM`; they already have single-table `IN TABLE` paths and need a separate per-table fallback strategy. Single-object `SHOW ... LIKE` / `... IN TABLE` lookups are bounded and unaffected.

   Tests: `tests/test_unit_large_schema_tables.py` (27 unit tests) mock `connection.execute` with tiny synthetic result sets and shrink the page size to exercise multi-page traversal, exact-page-size boundary, non-advancing-cursor guard, page-size clamping, FROM-cursor escaping / injection safety, prefix preservation, per-method pagination (views/schemas/sequences/temp), the sequence `2003` (missing schema) fallback, and a SQL-inspecting fake catalog that honors real `LIMIT`/`FROM` semantics. README documents the behavior and limitations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reflection behavior changes for very large catalogs (extra round-trips) and builds dynamic `SHOW` SQL with escaped `FROM` cursors; return shapes are intended to stay the same. Schema-wide constraint/index reflection above 10k rows remains a known gap.
> 
> **Overview**
> Fixes reflection failures when a schema or database has more than 10,000 tables, views, sequences, or schemas by paging Snowflake object-listing `SHOW` commands with `LIMIT … FROM '<last_name>'`.
> 
> **Dialect:** Adds `_show_in_schema_rows` and wires it into `_get_schema_tables_info`, `get_view_names`, `get_temp_table_names`, `get_schema_names`, and `get_sequence_names`. Page size uses `_SHOW_TABLES_PAGE_SIZE` (default 10,000, clamped 1–10,000), with a guard against a non-advancing `FROM` cursor. `SHOW TABLES` is kept (not `INFORMATION_SCHEMA`) so prefix flags and privileges stay the same.
> 
> **Docs:** `DESCRIPTION.md` unreleased note and a new README section describe automatic paging, how it works, and that schema-wide `SHOW PRIMARY/UNIQUE/IMPORTED KEYS` and `SHOW INDEXES IN SCHEMA` are still uncapped on bulk reflect.
> 
> **Tests:** `tests/test_unit_large_schema_tables.py` mocks `execute` with a small page size to cover multi-page traversal, escaping/injection safety, and each reflector path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c496d75a0848c91b45ce073a4da5dfb2f3baa4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->