### PR TITLE
Fix `SnowflakeCompiler`: `LIMIT NULL` when `OFFSET` is set

### DIFF
--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -948,6 +948,17 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         )
         return f"@{prefix}{external_stage.path} (file_format => {file_format})"
 
+    def limit_clause(self, select, **kw):
+        # Replica of base SQLCompiler, but with `LIMIT NULL` instead of `LIMIT -1`
+        text = ""
+        if select._limit_clause is not None:
+            text += "\n LIMIT " + self.process(select._limit_clause, **kw)
+        if select._offset_clause is not None:
+            if select._limit_clause is None:
+                text += "\n LIMIT NULL"
+            text += " OFFSET " + self.process(select._offset_clause, **kw)
+        return text
+
     def delete_extra_from_clause(
         self,
         delete_stmt: Any,

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -32,7 +32,7 @@ from sqlalchemy.sql.elements import BinaryExpression, BindParameter, Label, quot
 from sqlalchemy.sql.expression import Executable
 from sqlalchemy.sql.operators import OperatorType
 from sqlalchemy.sql.schema import Column, Identity, IdentityOptions
-from sqlalchemy.sql.selectable import Join, Lateral, SelectState
+from sqlalchemy.sql.selectable import Join, Lateral, Select, SelectState
 from sqlalchemy.sql.type_api import TypeEngine
 
 from ._constants import DIALECT_NAME, NOT_NULL

--- a/src/snowflake/sqlalchemy/base.py
+++ b/src/snowflake/sqlalchemy/base.py
@@ -948,7 +948,7 @@ class SnowflakeCompiler(compiler.SQLCompiler):
         )
         return f"@{prefix}{external_stage.path} (file_format => {file_format})"
 
-    def limit_clause(self, select, **kw):
+    def limit_clause(self, select: Select, **kw: Any) -> str:
         # Replica of base SQLCompiler, but with `LIMIT NULL` instead of `LIMIT -1`
         text = ""
         if select._limit_clause is not None:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -168,6 +168,13 @@ class TestSnowflakeCompiler(AssertsCompiledSQL):
             "ALTER TABLE test.table2 ALTER COLUMN id UNSET COMMENT",
         )
 
+    def test_offset_without_limit(self):
+        self.assert_compile(
+            select(table1.c.id).offset(10),
+            "SELECT table1.id FROM table1 LIMIT NULL OFFSET %(param_1)s",
+            dialect="snowflake",
+        )
+
 
 def test_quoted_name_label(engine_testaccount):
     test_cases = [


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #745

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Snowflake expects `LIMIT NULL` when there is an `OFFSET`. Default SQLAlchemy behavior is `LIMIT -1`, which is invalid syntax. This overrides the `SnowflakeCompiler` to reimplement `limit_clause()` to the desired behavior. I just copy+pasted what is in `sqlalchemy` and replaced the `LIMIT -1` with `LIMIT NULL`, then wrote a unit-test asserting the behavior. See: https://github.com/sqlalchemy/sqlalchemy/blob/d9b44cb731bd27e6e82c99a3c0fb598214e8e7ff/lib/sqlalchemy/sql/compiler.py#L5510-L5518 Code is not AI generated, it's "human written" insofar that it's mostly a copy+paste job. 😆 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to SELECT limit/offset SQL generation with a unit test; no auth, data, or runtime behavior outside offset-only queries.
> 
> **Overview**
> Fixes invalid SQL when a `SELECT` uses **OFFSET** without an explicit **LIMIT**. SQLAlchemy’s default compiler inserts `LIMIT -1` in that case; Snowflake requires **`LIMIT NULL`** instead.
> 
> **`SnowflakeCompiler.limit_clause`** is overridden to mirror the base implementation but emit `LIMIT NULL` when `_offset_clause` is set and `_limit_clause` is absent. A compiler test asserts `select(...).offset(10)` compiles to `LIMIT NULL OFFSET ...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c52cbe03ffce77b87e008cf36ef7ccfdc2f8af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->