### PR TITLE
SNOW-728151: Add asdecimal support to _CUSTOM_DECIMAL for opt-in float results

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Support `asdecimal` parameter on `_CUSTOM_DECIMAL` type to allow opt-in conversion of numeric results to float instead of Decimal; default remains Decimal for backward compatibility (SNOW-728151 / GH #373).
 - Fix reflection failing on schemas/databases with more than 10,000 objects by paginating the underlying object-listing `SHOW` commands (`get_table_names`, `get_view_names`, `get_temp_table_names`, `get_schema_names`, `get_sequence_names`) with `LIMIT ... FROM ...` (SNOW-796954 / GH #406).
 - Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
 - Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).

--- a/README.md
+++ b/README.md
@@ -569,6 +569,27 @@ engine = create_engine(URL(
 
 **Why is `enable_decfloat` not enabled by default?** Enabling it sets `decimal.getcontext().prec = 38`, which modifies Python's thread-local decimal context and affects all `Decimal` operations in that thread, not just database queries. To avoid unexpected side effects on application code, the dialect emits a warning when `DECFLOAT` values are retrieved without full precision enabled, guiding users to opt-in explicitly.
 
+### Returning `float` Instead of `Decimal`
+
+By default, Snowflake `NUMBER` / `DECIMAL` columns are returned as Python
+`decimal.Decimal` values. If you prefer plain `float` results for a column, set
+`asdecimal=False` on its numeric type:
+
+```python
+from sqlalchemy import Column, Integer, MetaData, Table
+from snowflake.sqlalchemy import NUMBER
+
+metadata = MetaData()
+prices = Table(
+    "prices",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("amount", NUMBER(10, 2, asdecimal=False)),  # rows return float, not Decimal
+)
+```
+
+The default remains `asdecimal=True` (Decimal), so existing behavior is unchanged.
+
 ### VECTOR Data Type Support
 
 Snowflake SQLAlchemy supports the `VECTOR` data type with varying element type and dimension.

--- a/src/snowflake/sqlalchemy/custom_types.py
+++ b/src/snowflake/sqlalchemy/custom_types.py
@@ -353,6 +353,17 @@ class _CUSTOM_Float(SnowflakeType, sqltypes.Float):
 
 
 class _CUSTOM_DECIMAL(SnowflakeType, sqltypes.DECIMAL):
+    def __init__(
+        self,
+        precision: int | None = None,
+        scale: int | None = None,
+        asdecimal: bool = True,
+        **kw: Any,
+    ) -> None:
+        super().__init__(  # type: ignore[call-overload]
+            precision=precision, scale=scale, asdecimal=asdecimal, **kw
+        )
+
     @util.memoized_property
     def _type_affinity(self) -> type:
         return sqltypes.INTEGER if self.scale == 0 else sqltypes.DECIMAL

--- a/tests/test_custom_decimal.py
+++ b/tests/test_custom_decimal.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+from decimal import Decimal
+
+import pytest
+
+from snowflake.sqlalchemy.custom_types import _CUSTOM_DECIMAL
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+
+@pytest.fixture(scope="function")
+def process():
+    """Yield a helper that applies a type's result processor, accounting for
+    SQLAlchemy returning ``None`` (pass-through) when ``asdecimal=True`` and the
+    driver already yields ``Decimal`` values."""
+
+    def _process(decimal_type, value):
+        processor = decimal_type.result_processor(SnowflakeDialect(), None)
+        return processor(value) if processor is not None else value
+
+    yield _process
+
+
+def test_asdecimal_defaults_to_true():
+    assert _CUSTOM_DECIMAL().asdecimal is True
+
+
+def test_asdecimal_false_is_honored():
+    assert _CUSTOM_DECIMAL(asdecimal=False).asdecimal is False
+
+
+def test_precision_and_scale_preserved():
+    decimal_type = _CUSTOM_DECIMAL(precision=10, scale=2, asdecimal=False)
+    assert decimal_type.precision == 10
+    assert decimal_type.scale == 2
+    assert decimal_type.asdecimal is False
+
+
+def test_result_is_float_when_asdecimal_false(process):
+    result = process(_CUSTOM_DECIMAL(asdecimal=False), Decimal("123.45"))
+    assert isinstance(result, float)
+    assert result == 123.45
+
+
+def test_result_is_decimal_by_default(process):
+    result = process(_CUSTOM_DECIMAL(), Decimal("42.00"))
+    assert isinstance(result, Decimal)
+    assert result == Decimal("42.00")
+
+
+def test_none_is_passed_through_when_asdecimal_false(process):
+    assert process(_CUSTOM_DECIMAL(asdecimal=False), None) is None


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #373

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

`_CUSTOM_DECIMAL` previously had no `__init__` and ignored SQLAlchemy's standard `asdecimal` flag, so there was no way to have Snowflake `NUMBER`/`DECIMAL` columns returned as `float` instead of `decimal.Decimal`. This PR adds an `__init__` that accepts `asdecimal` (default `True`) and forwards it to `sqltypes.DECIMAL`. 
With `asdecimal=False` the result processor now converts values to `float`, while the default preserves the existing `Decimal` behavior. New unit tests in `tests/test_custom_decimal.py` cover the default, the float conversion, and `None` handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible type constructor change with default `asdecimal=True`; only callers who set `asdecimal=False` see different Python types on fetch.
> 
> **Overview**
> Adds **`asdecimal`** support on the Snowflake **`_CUSTOM_DECIMAL`** type (used for `NUMBER` / `DECIMAL` columns) so applications can opt into **`float`** row values instead of **`decimal.Decimal`**, matching SQLAlchemy’s usual numeric type behavior (fixes GH #373).
> 
> **`_CUSTOM_DECIMAL`** now defines an **`__init__`** that accepts **`precision`**, **`scale`**, and **`asdecimal`** (default **`True`**) and forwards them to **`sqltypes.DECIMAL`**, enabling the built-in result processor to convert to **`float`** when **`asdecimal=False`**.
> 
> **README** documents the pattern (e.g. **`NUMBER(10, 2, asdecimal=False)`**), and **DESCRIPTION** records the unreleased note. New unit tests in **`tests/test_custom_decimal.py`** cover defaults, **`precision`/`scale`**, float vs Decimal results, and **`None`** handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b844cde5831271b8dab9b2f950f6ebb6d8e493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->