### PR TITLE
SNOW-3882904: Treat error code 390195 as a disconnect in is_disconnect

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at:
 
 # Unreleased Notes
 
+- Treat error code `390195` (authentication token expired, variant) as a session disconnect in `is_disconnect`, so `pool_pre_ping` / `connection_invalidated` recover from it like the other token/session-loss codes (SNOW-3882904 / GH #702).
 - Fix reflection failing on schemas/databases with more than 10,000 objects by paginating the underlying object-listing `SHOW` commands (`get_table_names`, `get_view_names`, `get_temp_table_names`, `get_schema_names`, `get_sequence_names`) with `LIMIT ... FROM ...` (SNOW-796954 / GH #406).
 - Add opt-in `snowflake_rely=True` to render `RELY` on `PRIMARY KEY` / `FOREIGN KEY` / `UNIQUE` constraints so the optimizer can trust them for query rewrites such as join elimination (SNOW-1023317 / GH #463).
 - Add a `python_type` property to Snowflake custom types (`VARIANT`, `OBJECT`, `MAP`, `ARRAY`, `VECTOR`, `TIMESTAMP_*`, `GEOGRAPHY`, `GEOMETRY`, `DECFLOAT`) for SQLAlchemy compatibility (SNOW-1866493 / GH #562).

--- a/README.md
+++ b/README.md
@@ -373,11 +373,11 @@ finally:
 
 #### Automatic reconnection on expired sessions
 
-The dialect flags Snowflake session/token-loss errors (for example *"Authentication token has
-expired"* or *"Session no longer exists"*) as disconnects. This lets SQLAlchemy's connection
-pool transparently discard the dead connection and open a fresh one, so long-lived engines
-recover instead of raising. Combine it with `pool_pre_ping=True` to validate connections before
-use:
+The dialect implements `is_disconnect`, flagging Snowflake session/token-loss errors (for example
+*"Authentication token has expired"* or *"Session no longer exists"*) as disconnects based on the
+connector's structured error codes. This lets SQLAlchemy's connection pool transparently discard
+the dead connection and open a fresh one, so long-lived engines recover instead of raising. Combine
+it with `pool_pre_ping=True` to validate connections before use:
 
 ```python
 from sqlalchemy import create_engine
@@ -388,6 +388,11 @@ engine = create_engine(
     pool_pre_ping=True,  # invalidate + reconnect stale/expired connections automatically
 )
 ```
+
+> **Note:** only *recoverable* session/token-loss errors are treated as disconnects. Permanent
+> authentication failures (for example revoked credentials) are **not** flagged as disconnects,
+> because reconnecting cannot recover them — they surface as errors so the underlying problem stays
+> visible.
 
 ### Auto-increment Behavior
 

--- a/src/snowflake/sqlalchemy/_constants.py
+++ b/src/snowflake/sqlalchemy/_constants.py
@@ -28,6 +28,7 @@ DISCONNECT_ERROR_CODES = frozenset(
         390112,  # session expired
         390113,  # master token not found
         390114,  # authentication/master token expired
+        390195,  # authentication token expired (variant)
         390115,  # master token invalid
         390318,  # OAuth access token expired
         ER_CONNECTION_IS_CLOSED,  # 250002, connection is closed (client side)

--- a/tests/test_dialect_connect.py
+++ b/tests/test_dialect_connect.py
@@ -336,3 +336,26 @@ def test_is_disconnect_false_for_non_snowflake_error():
     error.errno = 390111
 
     assert dialect.is_disconnect(error, None, None) is False
+
+
+def test_is_disconnect_true_for_token_expired_variant():
+    """390195 (authentication token expired, variant) is recoverable by
+    reconnect and must be reported as a disconnect (GH #702)."""
+    from snowflake.connector.errors import ProgrammingError
+
+    dialect = SnowflakeDialect()
+    error = ProgrammingError(msg="token expired", errno=390195)
+
+    assert dialect.is_disconnect(error, None, None) is True
+
+
+def test_is_disconnect_false_for_revoked_token():
+    """390302 (authentication failed, token revoked) is a permanent auth
+    failure — reconnecting cannot succeed, so it is intentionally NOT treated
+    as a disconnect (GH #702)."""
+    from snowflake.connector.errors import ProgrammingError
+
+    dialect = SnowflakeDialect()
+    error = ProgrammingError(msg="authentication failed", errno=390302)
+
+    assert dialect.is_disconnect(error, None, None) is False


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #702

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Follow-up to #348 (SNOW-669163), which added `is_disconnect`. #702 additionally
   listed error codes the dialect did not yet cover. This PR adds `390195`
   (authentication token expired, variant) to `DISCONNECT_ERROR_CODES` next to `390114`,
   so `pool_pre_ping` / `connection_invalidated` recover from it like the other
   session/token-loss codes.

   `390302` (authentication failed, token revoked) is intentionally **not** added: it is a
   permanent authentication failure that reconnecting cannot recover, so treating it as a
   disconnect would only cause futile reconnect loops. The README "Automatic reconnection
   on expired sessions" section documents that permanent auth failures are deliberately not
   flagged as disconnects.

   Unit tests in `tests/test_dialect_connect.py` cover both cases (390195 → disconnect,
   390302 → not).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to disconnect errno classification plus documentation and tests; behavior only improves recovery for one additional recoverable token-expiry code.
> 
> **Overview**
> **Connection pool recovery:** Snowflake error code `390195` (authentication token expired, variant) is now included in `DISCONNECT_ERROR_CODES`, so `is_disconnect` treats it like other session/token-loss codes and `pool_pre_ping` / `connection_invalidated` can drop and replace stale pooled connections (GH #702).
> 
> **Docs:** The README “Automatic reconnection on expired sessions” section now describes `is_disconnect` and connector error codes explicitly, and notes that **permanent** auth failures (e.g. revoked credentials) are **not** flagged as disconnects so apps do not spin on futile reconnects.
> 
> **Tests:** Unit tests assert `390195` → disconnect and `390302` (token revoked) → not a disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d598a727e0f51d751273ec07b2adc4126ccc1cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->