### PR TITLE
Add unreleased note for LIMIT NULL OFFSET fix (#746)

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -25,6 +25,7 @@ Source code is also available at:
 - Document `CLUSTER BY` usage in ORM/declarative models via `SnowflakeTable` (SNOW-638838 / [#313](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/313)).
 - Document AUTOINCREMENT and IDENTITY column usage, including Sequence vs Identity trade-offs for Hybrid tables (SNOW-1232362).
 - Document that Snowflake lacks `IS TRUE`/`IS FALSE`; use `col == true()`/`col == false()` ([#680](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/680)).
+- Fix invalid `LIMIT -1` SQL generated for a `SELECT` with `OFFSET` but no `LIMIT`; the `SnowflakeCompiler` now emits `LIMIT NULL OFFSET ...` as Snowflake requires (NO-SNOW / GH #745).
 
 # Release Notes
 


### PR DESCRIPTION
## Summary
- Adds a missing `# Unreleased Notes` entry in `DESCRIPTION.md` for the `LIMIT NULL OFFSET` fix merged in #746 (fixes #745).

## Details
PR #746 was merged without a changelog entry. This backfills the note:

> Fix invalid `LIMIT -1` SQL generated for a `SELECT` with `OFFSET` but no `LIMIT`; the `SnowflakeCompiler` now emits `LIMIT NULL OFFSET ...` as Snowflake requires (NO-SNOW / GH #745).

## Test plan
- [ ] Docs-only change; no code affected. Pre-commit hooks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update; no code or behavior changes in this PR.
> 
> **Overview**
> Adds a missing **Unreleased Notes** bullet in `DESCRIPTION.md` for the `SnowflakeCompiler` change that fixes **OFFSET-without-LIMIT** queries (GH #745), which previously produced invalid `LIMIT -1` SQL.
> 
> The new entry documents that the compiler now emits **`LIMIT NULL OFFSET ...`**, matching Snowflake’s syntax. No runtime or test code is modified in this PR—it only backfills the changelog after #746.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0244119408d8728686a7a40c2784f8b4cdc612e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->