### PR TITLE
Fix index related bugs

### DIFF
--- a/src/snowflake/sqlalchemy/parser/custom_type_parser.py
+++ b/src/snowflake/sqlalchemy/parser/custom_type_parser.py
@@ -133,7 +133,10 @@ def parse_index_columns(columns: str) -> list[str]:
     :example:
         For input `"[A, B, C]"`, the output is `['A', 'B', 'C']`.
     """
-    return [column.strip() for column in columns.strip("[]").split(",")]
+    inner = columns.strip("[]")
+    if not inner:
+        return []
+    return [column.strip() for column in inner.split(",")]
 
 
 def parse_type(type_text: str) -> TypeEngine:

--- a/src/snowflake/sqlalchemy/snowdialect.py
+++ b/src/snowflake/sqlalchemy/snowdialect.py
@@ -1932,17 +1932,18 @@ class SnowflakeDialect(default.DefaultDialect):
         """
         Gets the indexes definition
         """
-        schema = schema or self.default_schema_name
+        resolved_schema = schema or self.default_schema_name
         hybrid_table_names = self.get_table_names_with_prefix(
             connection,
-            schema=schema,
+            schema=resolved_schema,
             prefix=CustomTablePrefix.HYBRID.name,
             info_cache=kw.get("info_cache", None),
         )
+
         if len(hybrid_table_names) == 0:
             return []
 
-        full_schema_name = self._get_full_schema_name(connection, schema, **kw)
+        full_schema_name = self._get_full_schema_name(connection, resolved_schema, **kw)
         result = connection.execute(
             text(
                 f"SHOW /* sqlalchemy:get_multi_indexes */ INDEXES IN SCHEMA {full_schema_name}"
@@ -1984,7 +1985,7 @@ class SnowflakeDialect(default.DefaultDialect):
             table_name = self.normalize_name(str(row[name_to_index_map["table"]]))
             indexes[table_name].append(
                 {
-                    "name": row[name_to_index_map["name"]],
+                    "name": self.normalize_name(row[name_to_index_map["name"]]),
                     "unique": row[name_to_index_map["is_unique"]] == "Y",
                     "column_names": [
                         self.normalize_name(column)

--- a/tests/custom_tables/test_reflect_hybrid_table.py
+++ b/tests/custom_tables/test_reflect_hybrid_table.py
@@ -5,6 +5,8 @@ import pytest
 from sqlalchemy import MetaData, Table
 from sqlalchemy.sql.ddl import CreateTable
 
+from tests.util import random_string
+
 
 @pytest.mark.aws
 def test_simple_reflection_hybrid_table_as_table(
@@ -40,14 +42,23 @@ def test_simple_reflection_hybrid_table_as_table(
 
 
 @pytest.mark.aws
+@pytest.mark.parametrize(
+    "name_case", [str.upper, str.lower], ids=["uppercase", "lowercase"]
+)
+@pytest.mark.parametrize(
+    "explicit_schema", [True, False], ids=["explicit_schema", "default_schema"]
+)
 def test_reflect_hybrid_table_with_index(
-    engine_testaccount, db_parameters, sql_compiler
+    engine_testaccount, db_parameters, sql_compiler, name_case, explicit_schema
 ):
     metadata = MetaData()
-    schema = db_parameters["schema"]
+    # Reflecting through the connection's default schema (schema=None) keys
+    # the multi-reflection results differently from an explicit schema — the
+    # index must survive both paths.
+    schema = db_parameters["schema"] if explicit_schema else None
 
-    table_name = "test_hybrid_table_2"
-    index_name = "INDEX_NAME_2"
+    table_name = "test_hybrid_table_2_" + random_string(6)
+    index_name = name_case("index_name_2")
 
     create_table_sql = f"""
        CREATE HYBRID TABLE {table_name} (id INT primary key, name VARCHAR, INDEX {index_name} (name));
@@ -59,7 +70,11 @@ def test_reflect_hybrid_table_with_index(
     table = Table(table_name, metadata, schema=schema, autoload_with=engine_testaccount)
 
     try:
-        assert len(table.indexes) == 1 and table.indexes.pop().name == index_name
+        assert len(table.indexes) == 1
+        # Unquoted identifiers are case-insensitive whichever case they were
+        # written in, so reflection returns SQLAlchemy's normalized
+        # (lowercase) form.
+        assert table.indexes.pop().name == index_name.lower()
 
     finally:
         metadata.drop_all(engine_testaccount)

--- a/tests/test_index_reflection.py
+++ b/tests/test_index_reflection.py
@@ -10,18 +10,28 @@ from tests.util import random_string
 
 
 @pytest.mark.aws
-def test_indexes_reflection(engine_testaccount, db_parameters, sql_compiler):
+@pytest.mark.parametrize(
+    "name_case", [str.upper, str.lower], ids=["uppercase", "lowercase"]
+)
+@pytest.mark.parametrize(
+    "include_columns", [[], ["name3"]], ids=["no_include", "include"]
+)
+def test_indexes_reflection(
+    engine_testaccount, db_parameters, sql_compiler, name_case, include_columns
+):
     table_name = "test_hybrid_table_" + random_string(6)
-    index_name = "INDEX_NAME_" + random_string(6).upper()
+    index_name = name_case("index_name_" + random_string(6))
     schema = db_parameters["schema"]
     index_columns = ["name", "name2"]
+    include_sql = f" INCLUDE ({', '.join(include_columns)})" if include_columns else ""
 
     create_table_sql = f"""
    CREATE HYBRID TABLE {schema}.{table_name} (
         id INT primary key,
         name VARCHAR,
         name2 VARCHAR,
-        INDEX {index_name} ({", ".join(index_columns)})
+        name3 VARCHAR,
+        INDEX {index_name} ({", ".join(index_columns)}){include_sql}
     );
     """
 
@@ -39,8 +49,9 @@ def test_indexes_reflection(engine_testaccount, db_parameters, sql_compiler):
         )
 
         assert len(indexes) == 1
-        assert indexes[0].get("name") == index_name
+        assert indexes[0].get("name") == index_name.lower()
         assert indexes[0].get("column_names") == index_columns
+        assert indexes[0].get("include_columns") == include_columns
 
     finally:
         with engine_testaccount.connect() as connection:

--- a/tests/test_unit_index_reflection.py
+++ b/tests/test_unit_index_reflection.py
@@ -1,0 +1,122 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake.sqlalchemy.parser.custom_type_parser import parse_index_columns
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+
+def _show_indexes_result(rows):
+    """A stub of the CursorResult that SHOW INDEXES produces, exposing just
+    what _map_name_to_idx / _parse_index_rows consume: cursor.description
+    (column name first per entry) and cursor.fetchall().
+    """
+    result = MagicMock()
+    result.cursor.description = [
+        (name,)
+        for name in ("name", "table", "is_unique", "columns", "included_columns")
+    ]
+    result.cursor.fetchall.return_value = rows
+    return result
+
+
+_PK_SENTINEL_ROW = ("SYS_INDEX_MY_TABLE_PRIMARY", "MY_TABLE", "Y", "[ID]", "[]")
+_PLAIN_INDEX_ROW = ("IX_MY_TABLE_VAL", "MY_TABLE", "N", "[VAL]", "[]")
+_UNIQUE_INDEX_ROW = ("UQ_MY_TABLE_VAL", "MY_TABLE", "Y", "[VAL]", "[OTHER]")
+
+
+@pytest.fixture
+def dialect():
+    """SnowflakeDialect without a live connection."""
+    return SnowflakeDialect()
+
+
+class TestParseIndexColumns:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("[]", []),
+            ("[VAL]", ["VAL"]),
+            ("[A, B]", ["A", "B"]),
+        ],
+    )
+    def test_parse(self, raw, expected):
+        assert parse_index_columns(raw) == expected
+
+
+class TestParseIndexRows:
+    def test_index_name_is_normalized(self, dialect):
+        parsed = dialect._parse_index_rows(_show_indexes_result([_PLAIN_INDEX_ROW]))
+        (index,) = parsed["my_table"]
+        assert index["name"] == "ix_my_table_val"
+
+    def test_case_sensitive_index_name_is_preserved(self, dialect):
+        row = ("MyIndex", "MY_TABLE", "N", "[VAL]", "[]")
+        parsed = dialect._parse_index_rows(_show_indexes_result([row]))
+        (index,) = parsed["my_table"]
+        assert index["name"] == "MyIndex"
+
+    def test_empty_include_columns(self, dialect):
+        parsed = dialect._parse_index_rows(_show_indexes_result([_PLAIN_INDEX_ROW]))
+        (index,) = parsed["my_table"]
+        assert index["include_columns"] == []
+
+    def test_columns_unique_flag_and_include_columns_normalized(self, dialect):
+        parsed = dialect._parse_index_rows(_show_indexes_result([_UNIQUE_INDEX_ROW]))
+        (index,) = parsed["my_table"]
+        assert index["unique"] is True
+        assert index["column_names"] == ["val"]
+        assert index["include_columns"] == ["other"]
+
+    def test_pk_sentinel_is_filtered(self, dialect):
+        parsed = dialect._parse_index_rows(
+            _show_indexes_result([_PK_SENTINEL_ROW, _PLAIN_INDEX_ROW])
+        )
+        assert len(parsed["my_table"]) == 1
+        assert parsed["my_table"][0]["name"] != "sys_index_my_table_primary"
+
+
+class TestGetMultiIndexesKeying:
+    def _call(self, dialect, schema):
+        connection = MagicMock()
+        connection.execute.return_value = _show_indexes_result([_PLAIN_INDEX_ROW])
+        with (
+            patch.object(
+                dialect, "get_table_names_with_prefix", return_value=["my_table"]
+            ) as get_hybrid_names,
+            patch.object(
+                dialect, "_get_full_schema_name", return_value='"MYDB"."MYSCHEMA"'
+            ) as get_full_name,
+        ):
+            result = dialect.get_multi_indexes(
+                connection, schema=schema, filter_names=["my_table"]
+            )
+        return result, get_hybrid_names, get_full_name
+
+    def test_default_schema_keys_are_none(self, dialect):
+        dialect.default_schema_name = "myschema"
+        result, get_hybrid_names, get_full_name = self._call(dialect, schema=None)
+
+        # Must key on what was actually passed
+        assert [key for key, _ in result] == [(None, "my_table")]
+
+        # Internally, call to the default schema
+        assert get_hybrid_names.call_args.kwargs["schema"] == "myschema"
+        assert get_full_name.call_args.args[1] == "myschema"
+
+    def test_explicit_schema_in_keys(self, dialect):
+        result, _, _ = self._call(dialect, schema="myschema")
+        assert [key for key, _ in result] == [("myschema", "my_table")]
+
+    def test_no_hybrid_tables_short_circuits(self, dialect):
+        dialect.default_schema_name = "myschema"
+        connection = MagicMock()
+        with patch.object(dialect, "get_table_names_with_prefix", return_value=[]):
+            assert (
+                dialect.get_multi_indexes(connection, schema=None, filter_names=["t"])
+                == []
+            )
+        connection.execute.assert_not_called()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #754

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fixes all 3 related issues via normalizing names, handling `"[]"` correctly, and handling `schema=None` correctly in the return value to `get_multi_indexes()`.

   Note: library code was hand-written, but unit-tests were largely AI generated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reflection metadata shape and naming for hybrid indexes, which can affect autoload and migration diffs, but scope is limited to index parsing and bulk reflection keying.
> 
> **Overview**
> Fixes **hybrid table index reflection** so `MetaData.reflect()` and `Inspector.get_indexes()` return consistent, usable metadata (closes #754).
> 
> **`parse_index_columns`** now returns an empty list for `"[]"` instead of a spurious empty string entry, which affected **include columns** when Snowflake reports no included columns.
> 
> **`_parse_index_rows`** applies **`normalize_name`** to reflected index names so unquoted identifiers match SQLAlchemy’s lowercase convention; quoted/case-sensitive names stay as returned.
> 
> **`get_multi_indexes`** resolves the default schema internally via `resolved_schema` but keeps the **original `schema` argument** (including `None`) in result keys, aligning with other bulk reflection hooks so indexes attach when reflecting without an explicit schema.
> 
> Integration tests cover uppercase/lowercase index names, default vs explicit schema, and INCLUDE columns; new unit tests cover parsing, normalization, PK sentinel filtering, and multi-index keying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a4c8b8e9f1846643db3415094db0dfb9701bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->